### PR TITLE
Check if `.dat` file exists when running `genProofs` command

### DIFF
--- a/.github/workflows/circuit-build.yml
+++ b/.github/workflows/circuit-build.yml
@@ -45,10 +45,10 @@ jobs:
           npm run build
         working-directory: circuits
 
-      - name: Download circom Binary v2.0.3
+      - name: Download circom Binary v2.0.4
         run: |
           mkdir -p /home/runner/work/maci/.local/bin
-          wget -O /home/runner/work/maci/.local/bin/circom https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/circom-linux-amd64-v2.0.3
+          wget -O /home/runner/work/maci/.local/bin/circom https://maci-devops.s3.ap-northeast-2.amazonaws.com/circom-linux-amd64-v2.0.4
           chmod +x /home/runner/work/maci/.local/bin/circom
 
       - name: Run circom-helper

--- a/.github/workflows/e2e-nightly-test.yml
+++ b/.github/workflows/e2e-nightly-test.yml
@@ -62,11 +62,11 @@ jobs:
           wget -O ~/rapidsnark/build/prover https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/rapidsnark-linux-amd64-1c137
           chmod +x ~/rapidsnark/build/prover
 
-      - name: Download circom v2.0.3
+      - name: Download circom Binary v2.0.4
         run: |
           mkdir -p /home/runner/work/maci/.local/bin
-          wget -O /home/runner/work/maci/.local/bin/circom https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/circom-linux-amd64-v2.0.3
-          chmod +x  /home/runner/work/maci/.local/bin/circom
+          wget -O /home/runner/work/maci/.local/bin/circom https://maci-devops.s3.ap-northeast-2.amazonaws.com/circom-linux-amd64-v2.0.4
+          chmod +x /home/runner/work/maci/.local/bin/circom
 
       - name: Generate zkeys
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,8 +28,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes \
             build-essential \
-            g++ \
-            git \
             libgmp-dev \
             libsodium-dev \
             nasm \
@@ -65,11 +63,11 @@ jobs:
           wget -O ~/rapidsnark/build/prover https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/rapidsnark-linux-amd64-1c137
           chmod +x ~/rapidsnark/build/prover
 
-      - name: Download circom v2.0.3
+      - name: Download circom Binary v2.0.4
         run: |
           mkdir -p /home/runner/work/maci/.local/bin
-          wget -O /home/runner/work/maci/.local/bin/circom https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/circom-linux-amd64-v2.0.3
-          chmod +x  /home/runner/work/maci/.local/bin/circom
+          wget -O /home/runner/work/maci/.local/bin/circom https://maci-devops.s3.ap-northeast-2.amazonaws.com/circom-linux-amd64-v2.0.4
+          chmod +x /home/runner/work/maci/.local/bin/circom
 
       - name: Generate zkeys
         run: |

--- a/cli/ts/utils.ts
+++ b/cli/ts/utils.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs'
 import * as prompt from 'prompt-async'
 
 prompt.colors = false
@@ -132,6 +133,15 @@ const delay = (ms: number): Promise<void> => {
     return new Promise((resolve: Function) => setTimeout(resolve, ms))
 }
 
+const isPathExist = (paths: Array<string>): [boolean, string] => {
+    for (const path of paths) {
+        if (!fs.existsSync(path)) {
+            return [false, path]
+        }
+    }
+    return [true, null]
+}
+
 export {
     promptPwd,
     calcBinaryTreeDepthFromMaxLeaves,
@@ -145,4 +155,5 @@ export {
     currentBlockTimestamp,
     batchTransactionRequests,
     delay,
+    isPathExist,
 }


### PR DESCRIPTION
This PR add checks for `.dat` file (one of the artifact of compiled circuit and it is required to execute witness generation) and print error if it doesn't exist.

Currently, when user execute `genProofs` command without `.dat` file,  they will got ambiguous error doesn't address explicitly they missed `.dat` file.