### PR TITLE
Reflect GitHub Organization name change

### DIFF
--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -37,7 +37,7 @@ do
     file_name=$(basename "$file_path")
 
     # Skipping testKeyChange.sh temporally
-    # related issue: https://github.com/appliedzkp/maci/issues/400
+    # related issue: https://github.com/privacy-scaling-explorations/maci/issues/400
     if [ "$file_name" = "testKeyChange.sh" ]; then
         continue
     fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ post](https://ethresear.ch/t/minimal-anti-collusion-infrastructure/5413) for a
 high-level view.
 
 Documentation for developers and integrators can be found here:
-https://appliedzkp.github.io/maci/
+https://privacy-scaling-explorations.github.io/maci/
 
 We welcome contributions to this project. Please join our
 [Telegram group](https://t.me/joinchat/LUgOpE7J2gstRcZqdERyvw) to discuss.
@@ -29,7 +29,7 @@ If you are missing the correct version of glibc see `circuits/scripts/installGli
 Clone this repository, install NodeJS dependencies, and build the source code:
 
 ```bash
-git clone git@github.com:appliedzkp/maci.git && \
+git clone git@github.com:privacy-scaling-explorations/maci.git && \
 cd maci && \
 npm i && \
 npm run bootstrap && \
@@ -167,4 +167,4 @@ Note: a cached version of `builder` job must be on your system prior as it relie
 
 ### CI pipeline
 
-CI pipeline ensures that we have automated tests that constantly validate. For more information about pipeline workflows, see https://github.com/appliedzkp/maci/wiki/MACI-CI-pipeline.
+CI pipeline ensures that we have automated tests that constantly validate. For more information about pipeline workflows, see https://github.com/privacy-scaling-explorations/maci/wiki/MACI-CI-pipeline.

--- a/circuits/circom/trees/incrementalMerkleTree.circom
+++ b/circuits/circom/trees/incrementalMerkleTree.circom
@@ -1,7 +1,7 @@
 pragma circom 2.0.0;
 // Refer to:
 // https://github.com/peppersec/tornado-mixer/blob/master/circuits/merkleTree.circom
-// https://github.com/appliedzkp/semaphore/blob/master/circuits/circom/semaphore-base.circom
+// https://github.com/semaphore-protocol/semaphore/blob/audited/circuits/circom/semaphore-base.circom
 
 include "../../node_modules/circomlib/circuits/mux1.circom";
 include "../hasherPoseidon.circom";

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
 # maci-cli
 
 Please refer to the [documentation for the
-CLI](http://appliedzkp.github.io/maci/cli.html).
+CLI](http://privacy-scaling-explorations.github.io/maci/cli.html).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ will need it later.
 ### Install MACI
 
 ```bash
-git clone https://github.com/appliedzkp/maci.git && \
+git clone https://github.com/privacy-scaling-explorations/maci.git && \
 cd maci && \
 npm i && \
 npm run bootstrap && \

--- a/docs/trustedsetup.md
+++ b/docs/trustedsetup.md
@@ -24,7 +24,7 @@ section to install dependencies for MACI.
 Next, configure and compile circuits following instructions in
 [Circuits](./circuits.html).
 
-Finally, use the [`multisetups`](https://github.com/appliedzkp/multisetups)
+Finally, use the [`multisetups`](https://github.com/privacy-scaling-explorations/multisetups)
 tool to do this.
 
 You should perform at least one contribution to each circuit, even if you

--- a/old_specs/03_circuits.md
+++ b/old_specs/03_circuits.md
@@ -21,5 +21,5 @@ Note that the circuit pseudocode in this specification does not describe zk-SNAR
 
 See:
 
-- [The state root transition proof circuit](https://github.com/appliedzkp/maci/blob/master/specs/04_state_root_transition_circuit.md), and
-- [The quadratic vote tallying circuit](https://github.com/appliedzkp/maci/blob/master/specs/05_quadratic_vote_tallying_circuit.md)
+- [The state root transition proof circuit](https://github.com/privacy-scaling-explorations/maci/blob/master/specs/04_state_root_transition_circuit.md), and
+- [The quadratic vote tallying circuit](https://github.com/privacy-scaling-explorations/maci/blob/master/specs/05_quadratic_vote_tallying_circuit.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "maci",
   "version": "1.0.4",
   "description": "Minimal Anti-Collustion Infrastructure",
-  "repository": "https://github.com/appliedzkp/maci",
+  "repository": "https://github.com/privacy-scaling-explorations/maci",
   "license": "MIT",
   "scripts": {
     "bootstrap": "lerna bootstrap",

--- a/server/README.md
+++ b/server/README.md
@@ -2,7 +2,7 @@
 
 ### Setup
 
-Follow [instruction](https://appliedzkp.github.io/maci/) to setup environment and dependency, then
+Follow [instruction](https://privacy-scaling-explorations.github.io/maci/) to setup environment and dependency, then
 
 ```bash
 docker build -t maci-node:v0.5 - < LightDockerfile


### PR DESCRIPTION
This PR reflect the org name change happened last Friday:

https://github.com/appliedzkp -> https://github.com/privacy-scaling-explorations