### PR TITLE
Make ballot tree depth value to be stand out

### DIFF
--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -32,7 +32,8 @@ contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
     // so that there can be as many users as possible.  i.e. 5 ** 10 = 9765625
     uint8 public override stateTreeDepth = 10;
 
-    // IMPORTANT: remember to change the spent voice credits tree in Poll.sol
+    // IMPORTANT: remember to change the ballot tree depth 
+    // in contracts/ts/genEmptyBallotRootsContract.ts file
     // if we change the state tree depth!
 
     uint8 constant internal STATE_TREE_SUBDEPTH = 2;

--- a/contracts/ts/genEmptyBallotRootsContract.ts
+++ b/contracts/ts/genEmptyBallotRootsContract.ts
@@ -18,12 +18,15 @@ const genEmptyBallotRootsContract = (
         ),
     ).toString()
 
+    // This hard-coded value should be consistent with the value of `stateTreeDepth` of MACI.sol
+    const stateTreeDepth = 10
+
     let r = ''
     for (let i = 1; i < 6; i ++) {
         const ballot = new Ballot(0, i)
         const z = ballot.hash()
         // The empty Ballot tree root
-        const ballotTree = new IncrementalQuinTree(10, BigInt(`${z}`), 5, hash5)
+        const ballotTree = new IncrementalQuinTree(stateTreeDepth, BigInt(`${z}`), 5, hash5)
         const root = ballotTree.root
 
         r += `        emptyBallotRoots[${i-1}] = uint256(${root});\n`


### PR DESCRIPTION
Currently, it is hard to recognize that the **first argument** of `IncrementalQuinTree`'s constructor is for what. So this PR makes it clear by declaring variable--therefore user could easily recognize which value should they change when they are going to use a value other than 10 for `stateTreeDepth` value -- rather than directly pass the numeric literal to constructor's argument.

## Background

The first argument of `IncrementalQuinTree` should be modified to the same value as `stateTreeDepth` of the circuit to be  used. Otherwise, user could get an error when running `proveOnChain` command like following when a user uses 7 as a `stateTreeDepth` value but left `ballot tree depth` value to 10:

```
Submitting proofs of message processing...
Error: currentSbCommitment mismatch.
0
{
  provider: 'http://localhost:8545',
  maci: '0xf204a4Ef082f5c04bB89F7D5E6568B796096735a',
  pollId: 0,
  newTallyCommitment: '0x28e396cf2441dc12f71ee10ccbbb7eaa085b4cbabfe5c9ea5151fe50520629ac',
  results: {
    tally: [
      '9', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0', '0', '0', '0',
      ... 525 more items
    ],
    salt: '0x9aa6d8d513faafc7a84e88b0579dda12cbcb85a7a7e6848e681931c8fc22671'
  },
  totalSpentVoiceCredits: {
    spent: '81',
    salt: '0x1160751970a1717f5b58c4946ab40692f03a6dd04191860de4e32b0280505fbd'
  },
  perVOSpentVoiceCredits: {
    tally: [
      '81', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',  '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
      '0',
      ... 525 more items
    ],
    salt: '0x15a157ecb165f30c0c94b84885d7a0b916605b14e9c11321795ce8d494f773b2'
  }
}
Error: the on-chain tally commitment does not match.
``` 
