### PR TITLE
Remove `--max-vote-options` from `deployPoll` command

### DIFF
--- a/cli/benchmark.sh
+++ b/cli/benchmark.sh
@@ -14,8 +14,6 @@ macipk=macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391
 macisk=macisk.fd7aa614ec4a82716ffc219c24fd7e7b52a2b63b5afb17e81c22fe21515539c 
 
 duration=120
-#maxVoteOption=$((5 ** $voteOptionTreeDepth))
-maxVoteOption=25
 #maxMsg=$((5 ** $msgTreeDepth))
 maxMsg=20
 
@@ -51,7 +49,7 @@ node build/index.js setVerifyingKeys -s $stateTreeDepth -i $intStateTreeDepth -m
 node build/index.js create 
 node ./build/index.js deployPoll \
     -pk $cordpk \
-    -t $duration -g $maxMsg -mv $maxVoteOption -i $intStateTreeDepth -m $msgTreeDepth -v $voteOptionTreeDepth -b $msgBatchDepth 
+    -t $duration -g $maxMsg -i $intStateTreeDepth -m $msgTreeDepth -v $voteOptionTreeDepth -b $msgBatchDepth 
 
 
 for ((i=1;i<=$maxSignUp;i++))

--- a/cli/bsc_test.sh
+++ b/cli/bsc_test.sh
@@ -14,7 +14,7 @@ pk1=macipk.d30bf8402e7d731e86ccc6d24726446bba3ee18e8df013ebb0c96a5b14914da9
 #node build/index.js create  && \
 #node ./build/index.js deployPoll \
 #    -pk $cordpk \
-#    -t $durationInSecs -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 && \
+#    -t $durationInSecs -g 25 -i 1 -m 2 -b 1 -v 2 && \
 #node ./build/index.js signup \
 #    -p $pk1  && \
 #node build/index.js publish \

--- a/cli/deploy_test.sh
+++ b/cli/deploy_test.sh
@@ -10,7 +10,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
 node build/index.js create  && \
 node ./build/index.js deployPoll \
     -pk $cordpk \
-    -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2  && \
+    -t 20 -g 25 -i 1 -m 2 -b 1 -v 2  && \
 node ./build/index.js deployPoll \
     -pk $cordpk \
-    -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2  
+    -t 20 -g 25 -i 1 -m 2 -b 1 -v 2  

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -12,7 +12,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
 node build/index.js create 
 node ./build/index.js deployPoll \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 40 -g 20 -mv 25 -i 1 -m 2 -b 1 -v 2  
+    -t 40 -g 20 -i 1 -m 2 -b 1 -v 2  
 
 node ./build/index.js signup \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391  

--- a/cli/test1.sh
+++ b/cli/test1.sh
@@ -9,7 +9,7 @@ node build/index.js create \
     -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0 && \
 node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 && \
+    -t 20 -g 25 -i 1 -m 2 -b 1 -v 2 && \
 node ./build/index.js signup \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a && \

--- a/cli/test2.sh
+++ b/cli/test2.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 20 -g 25 -i 1 -m 2 -b 1 -v 2
 
 node ../cli/build/index.js signup -p macipk.b1672ac299bb443f89bca9aeface6edfa5319a4b2135588ca1bfb352d7d09d1e -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 node ../cli/build/index.js signup -p macipk.6be0cedb8656b09ebb1af0bb691ba134620d0325366256bb8b543f83f6d6b811 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a

--- a/cli/test3.sh
+++ b/cli/test3.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 20 -g 25 -i 1 -m 2 -b 1 -v 2
 
 node ../cli/build/index.js signup -p macipk.b1672ac299bb443f89bca9aeface6edfa5319a4b2135588ca1bfb352d7d09d1e -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 node ../cli/build/index.js signup -p macipk.193c37dcb7db9bca854448e2b99b5d7e33e4c8a6f032e472a32578972e64031a -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a

--- a/cli/test4.sh
+++ b/cli/test4.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -i 1 -m 2 -b 1 -v 2
 
 node ../cli/build/index.js signup -p macipk.b1672ac299bb443f89bca9aeface6edfa5319a4b2135588ca1bfb352d7d09d1e -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 node ../cli/build/index.js signup -p macipk.b1672ac299bb443f89bca9aeface6edfa5319a4b2135588ca1bfb352d7d09d1e -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a

--- a/cli/test5.sh
+++ b/cli/test5.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -i 1 -m 2 -b 1 -v 2
 
 node ./build/index.js signup -p macipk.4d8797043f3f54b9090cb7ddbb79a618297e3f94011e2d2b206dc05a52722498 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 

--- a/cli/test6.sh
+++ b/cli/test6.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -i 1 -m 2 -b 1 -v 2
 
 node ./build/index.js signup -p macipk.014cc8ef5a0022da608efab55e891417be0a474ba70b912dc6c2e6acea1a1499 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 

--- a/cli/testKeyChange.sh
+++ b/cli/testKeyChange.sh
@@ -12,7 +12,7 @@ node build/index.js create \
     
 node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+    -t 20 -g 25 -i 1 -m 2 -b 1 -v 2
 
 node ./build/index.js signup \
     -p macipk.b8590fdba5e9cde5606dad5db384be4d253d0a2064d1e03f9600ee021a7ebe16 \

--- a/cli/testMultiBatches.sh
+++ b/cli/testMultiBatches.sh
@@ -9,7 +9,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
 node build/index.js create 
 node ./build/index.js deployPoll \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 40 -g 20 -mv 25 -i 1 -m 2 -b 1 -v 2  
+    -t 40 -g 20 -i 1 -m 2 -b 1 -v 2  
 
 node ./build/index.js signup \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391  

--- a/cli/testMultiBatches1.sh
+++ b/cli/testMultiBatches1.sh
@@ -9,7 +9,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
 node build/index.js create 
 node ./build/index.js deployPoll \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 40 -g 20 -mv 25 -i 1 -m 2 -b 1 -v 2  
+    -t 40 -g 20 -i 1 -m 2 -b 1 -v 2  
 
 node ./build/index.js signup \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391  

--- a/cli/testMultiplePoll.sh
+++ b/cli/testMultiplePoll.sh
@@ -10,7 +10,7 @@ node build/index.js create
 echo "deploy poll 0 ..."
 node ./build/index.js deployPoll \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 
+    -t 20 -g 25 -i 1 -m 2 -b 1 -v 2 
 
 node ./build/index.js signup \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 
@@ -53,7 +53,7 @@ node build/index.js verify \
 echo "deploy poll 1..."
 node ./build/index.js deployPoll \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 120 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 && \
+    -t 120 -g 25 -i 1 -m 2 -b 1 -v 2 && \
 
 node build/index.js publish \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \

--- a/cli/testMultiplePoll1.sh
+++ b/cli/testMultiplePoll1.sh
@@ -8,7 +8,7 @@ node build/index.js create \
     -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0 && \
 node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 && \
+    -t 20 -g 25 -i 1 -m 2 -b 1 -v 2 && \
 node ./build/index.js signup \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a && \
@@ -49,7 +49,7 @@ node build/index.js verify \
 
 node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 120 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 && \
+    -t 120 -g 25 -i 1 -m 2 -b 1 -v 2 && \
 
 node build/index.js publish \
     -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \

--- a/cli/testMultiplePoll2.sh
+++ b/cli/testMultiplePoll2.sh
@@ -27,7 +27,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
 node build/index.js create  
 node ./build/index.js deployPoll \
     -pk $cordpk \
-    -t $durationInSecs -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 
+    -t $durationInSecs -g 25 -i 1 -m 2 -b 1 -v 2 
 
 
 node ./build/index.js signup \
@@ -83,10 +83,10 @@ node build/index.js verify \
 
 node ./build/index.js deployPoll \
     -pk $cordpk \
-    -t $durationInSecs -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2  
+    -t $durationInSecs -g 25 -i 1 -m 2 -b 1 -v 2  
 node ./build/index.js deployPoll \
     -pk $cordpk \
-    -t $durationInSecs -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2  
+    -t $durationInSecs -g 25 -i 1 -m 2 -b 1 -v 2  
 
 node build/index.js publish \
     -p $pk1 \

--- a/cli/ts/deployPoll.ts
+++ b/cli/ts/deployPoll.ts
@@ -60,16 +60,6 @@ const configureSubparser = (subparsers: any) => {
     )
 
     createParser.addArgument(
-        ['-mv', '--max-vote-options'],
-        {
-            action: 'store',
-            type: 'int',
-            required: true,
-            help: 'The maximum number of vote options',
-        }
-    )
-
-    createParser.addArgument(
         ['-i', '--int-state-tree-depth'],
         {
             action: 'store',
@@ -131,16 +121,11 @@ const deployPoll = async (args: any) => {
         return 1
     }
 
-    // Max vote options
-    const maxVoteOptions = args.max_vote_options
-    if (maxVoteOptions <= 0) {
-        console.error('Error: the maximum number of vote options be positive')
-        return 1
-    }
     const intStateTreeDepth = args.int_state_tree_depth
     const messageTreeSubDepth = args.msg_batch_depth
     const messageTreeDepth = args.msg_tree_depth
     const voteOptionTreeDepth = args.vote_option_tree_depth
+    const maxVoteOptions = 5 ** voteOptionTreeDepth
 
     const signer = await getDefaultSigner()
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,7 +137,7 @@ ETH_PROVIDER=http://localhost:8545 \
 node ./build/index.js deployPoll \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 30 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+    -t 30 -g 25 -i 1 -m 2 -b 1 -v 2
 ```
 
 Example output:
@@ -316,7 +316,6 @@ node ./build/index.js deployPoll \
     --pubkey macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
     --duration 1000 \
     --max-messages 25 \
-    --max-vote-options 25 \
     --int-state-tree-depth 1 \
     --msg-tree-depth 2 \
     --msg_batch_depth 1 \

--- a/integrationTests/integrations.yml
+++ b/integrationTests/integrations.yml
@@ -24,7 +24,6 @@ constants:
   maci:
     maxUsers: 15
     maxMessages: 25
-    maxVoteOptions: 25
     initialVoiceCredits: 1000
     signupDuration: 120
     votingDuration: 120

--- a/integrationTests/ts/__tests__/suites.ts
+++ b/integrationTests/ts/__tests__/suites.ts
@@ -79,7 +79,6 @@ const executeSuite = async (data: any, expect: any) => {
         ` -pk ${coordinatorKeypair.pubKey.serialize()}` +
         ` -t ${config.constants.poll.duration}` +
         ` -g ${config.constants.maci.maxMessages}` +
-        ` -mv ${config.constants.maci.maxVoteOptions}` +
         ` -i ${config.constants.poll.intStateTreeDepth}` +
         ` -m ${config.constants.poll.messageTreeDepth}` +
         ` -b ${config.constants.poll.messageBatchDepth}` +
@@ -103,7 +102,7 @@ const executeSuite = async (data: any, expect: any) => {
     const maxValues = {} as MaxValues
     maxValues.maxUsers = config.constants.maci.maxUsers
     maxValues.maxMessages = config.constants.maci.maxMessages
-    maxValues.maxVoteOptions  = config.constants.maci.maxVoteOptions
+    maxValues.maxVoteOptions  = 5 ** config.constants.maci.voteOptionTreeDepth
     const messageBatchSize = 5 ** config.constants.poll.messageBatchDepth
     maciState.deployPoll(
         config.constants.poll.duration,

--- a/server/admin.sh
+++ b/server/admin.sh
@@ -40,7 +40,7 @@ deploy(){
     eval $CMD setVerifyingKeys -s $state_tree_depth -i $int_state_tree_depth -m $msg_tree_depth \
     -v $vote_option_tree_depth -b $msg_batch_depth  -p $msg_zkey -t $tally_zkey && \
     eval $CMD create && \
-    eval $CMD deployPoll -pk $cordpk -t $duration -g $max_msgs -mv $max_votes \
+    eval $CMD deployPoll -pk $cordpk -t $duration -g $max_msgs \
                  -i $int_state_tree_depth -m $msg_tree_depth -v $vote_option_tree_depth -b $msg_batch_depth
 }
 


### PR DESCRIPTION
Figured out that `max-vote-options` is not configurable, its strictly binded with `vote-option-tree-depth`. So this PR removes this option and set this value as `5 ** vote-option-tree-depth`.

If we give a value for `--max-vote-options` smaller than `5 ** vote-option-tree-depth`, following error would occur:
```
Generating proofs of message processing...

Progress: 1 / 1

Generating proofs of vote tallying...
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error loading signal currentPerVOSpentVoiceCredits: Not enough values

Aborted (core dumped)

terminate called after throwing an instance of 'std::runtime_error'
  what():  Error loading signal currentPerVOSpentVoiceCredits: Not enough values

Aborted (core dumped)


/home/ubuntu/maci/circuits/ts/index.ts:44
        throw new Error('Error executing ' + witnessGenCmd)
              ^
Error: Error executing ./7-9-3-4/TallyVotes_7-3-4_test /tmp/tmp-4982-ErOODiNrX017/input.json /tmp/tmp-4982-ErOODiNrX017/output.wtns
    at genProof (/home/ubuntu/maci/circuits/ts/index.ts:44:15)
    at /home/ubuntu/maci/cli/ts/genProofs.ts:393:27
    at step (/home/ubuntu/maci/cli/build/genProofs.js:33:23)
    at Object.next (/home/ubuntu/maci/cli/build/genProofs.js:14:53)
    at fulfilled (/home/ubuntu/maci/cli/build/genProofs.js:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```