### PR TITLE
test(circuits): fix index to prevent assigned 0

### DIFF
--- a/circuits/ts/__tests__/TallyVotes.test.ts
+++ b/circuits/ts/__tests__/TallyVotes.test.ts
@@ -184,8 +184,16 @@ describe('TallyVotes circuit', () => {
             ).toString()
             */
 
+            
+            function generateRandomIndex() {
+                return Math.floor(Math.random() * (generatedInputs.currentResults.length - 1))
+            }
             // Start the tally from non-zero value
-            const randIdx = Math.floor(Math.random() * (generatedInputs.currentResults.length - 1))
+            let randIdx = generateRandomIndex()
+            while (randIdx === 0) {
+                randIdx = generateRandomIndex()
+            }
+            
             generatedInputs.currentResults[randIdx] = '1'
             const witness = await genWitness(circuit, generatedInputs)
             expect(witness.length > 0).toBeTruthy()


### PR DESCRIPTION
This PR fixes the bug of test case of `maci-circuits`(fixes #498).