### PR TITLE
chore: change the pronoun from `her` to `one`

### DIFF
--- a/specs/01_introduction.md
+++ b/specs/01_introduction.md
@@ -33,7 +33,7 @@ A later version of MACI will have to mitigate a [vote-buying attack](https://eth
 
 When Alice casts her vote, she signs her vote with her private key, encrypts her signature with Dave's public key, and submits the result to the smart contract.
 
-Each voter may change her keypair at any time. To do this, she creates and signs a key-change command, encrypts it, and sends it to the smart contract. This makes it impossible for a briber to ever be sure that their bribe has any effect on the bribee's vote.
+Each voter may change one's keypair at any time. To do this, she creates and signs a key-change command, encrypts it, and sends it to the smart contract. This makes it impossible for a briber to ever be sure that their bribe has any effect on the bribee's vote.
 
 If Bob, for instance, bribes Alice to vote a certain way, she can simply use the first public key she had registered ⁠— which is now void ⁠— to cast a vote. Since said vote is encrypted, as was the key-changing message which Alice had previously sent to Dave, Bob has no way to tell if Alice had indeed voted the way he wanted her to.
 


### PR DESCRIPTION
## Overview
* According to the context, it seems like each voter change their very own public key. However, the original text may imply that everyone who partake in the voting period might be able to change the keypair of Alice.