### PR TITLE
test: verify subsidy result

### DIFF
--- a/integrationTests/ts/__tests__/suites.json
+++ b/integrationTests/ts/__tests__/suites.json
@@ -6,7 +6,7 @@
             "numVotesPerUser": 1,
             "numUsers": 15,
             "expectedTally": [15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "expectedSpentVoiceCredits": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 15
         },
         {
@@ -15,7 +15,7 @@
             "numVotesPerUser": 1,
             "numUsers": 16,
             "expectedTally": [16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "expectedSpentVoiceCredits": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 16
         },
         {
@@ -24,7 +24,7 @@
             "numUsers": 4,
             "numVotesPerUser": 1,
             "expectedTally": [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "expectedSpentVoiceCredits": [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 4
         },
         {
@@ -63,7 +63,7 @@
                 }
             },
             "expectedTally": [0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "expectedSpentVoiceCredits": [4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 8
         },
         {

--- a/integrationTests/ts/__tests__/suites.json
+++ b/integrationTests/ts/__tests__/suites.json
@@ -5,8 +5,8 @@
             "description": "Full tree, 4 batches, no bribers",
             "numVotesPerUser": 1,
             "numUsers": 15,
-            "expectedTally": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
-            "expectedSpentVoiceCredits": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+            "expectedTally": [15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 15
         },
         {
@@ -14,7 +14,7 @@
             "description": "Full tree, 4 full batches,  no bribers",
             "numVotesPerUser": 1,
             "numUsers": 16,
-            "expectedTally": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
+            "expectedTally": [16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedSpentVoiceCredits": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 16
         },
@@ -23,7 +23,7 @@
             "description": "Quarter tree, 1 batch, no bribers",
             "numUsers": 4,
             "numVotesPerUser": 1,
-            "expectedTally": [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedTally": [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedSpentVoiceCredits": [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 4
         },
@@ -32,9 +32,9 @@
             "description": "2 batches, 1 briber",
             "numUsers": 3,
             "numVotesPerUser": 2,
-            "bribers": { "0": { "voteOptionIndices": [0,1] }, "1": { "voteOptionIndices": [0,1]}},
-            "expectedTally": [0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "expectedSpentVoiceCredits": [0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "bribers": { "0": { "voteOptionIndices": [1,0] }, "1": { "voteOptionIndices": [1,0]}},
+            "expectedTally": [1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             "expectedTotalSpentVoiceCredits": 3
         },
         {
@@ -62,9 +62,36 @@
                     "1": { "voteOptionIndex": 1, "voteWeight": 5, "valid": true }
                 }
             },
-            "expectedTally": [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "expectedSpentVoiceCredits": [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "expectedTotalSpentVoiceCredits": 2
+            "expectedTally": [0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedTotalSpentVoiceCredits": 8
+        },
+        {
+            "name": "Subsidy test",
+            "description": "has subsidy result",
+            "numUsers": 4,
+            "numVotesPerUser": 1,
+            "votes": {
+                "0": {
+                    "0": { "voteOptionIndex": 0, "voteWeight": 1, "valid": true }
+                },
+                "1": {
+                    "0": { "voteOptionIndex": 0, "voteWeight": 1, "valid": true }
+                },
+                "2": {
+                    "0": { "voteOptionIndex": 0, "voteWeight": 1, "valid": true }
+                },
+                "3": {
+                    "0": { "voteOptionIndex": 0, "voteWeight": 1, "valid": true }
+                }
+            },
+            "expectedTally": [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedSpentVoiceCredits": [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "expectedTotalSpentVoiceCredits": 4,
+            "subsidy": {
+                "enabled": true,
+                "expectedSubsidy": [117636, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            }
         }
     ]
 }

--- a/integrationTests/ts/__tests__/suites.ts
+++ b/integrationTests/ts/__tests__/suites.ts
@@ -143,7 +143,7 @@ const executeSuite = async (data: any, expect: any) => {
             const userKeypair = users[i].keypair
             userKeypairs.push(userKeypair)
             // Run the signup command
-            const signupCommand = `node ../cli/build/index.js signup` +
+            const signupCommand = `node build/index.js signup` +
                 ` -p ${userKeypair.pubKey.serialize()}` +
                 ` -x ${maciAddress}`
             execute(signupCommand)
@@ -257,7 +257,7 @@ const executeSuite = async (data: any, expect: any) => {
             data.expectedTotalSpentVoiceCredits,
             tally
         )
-        if (data.subsidy) {
+        if (subsidyEnabled) {
             const subsidy = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../cli/subsidy.json')).toString())
             // Validate generated proof file
             expect(JSON.stringify(subsidy.pollId)).toEqual(pollId)

--- a/integrationTests/ts/__tests__/utils.ts
+++ b/integrationTests/ts/__tests__/utils.ts
@@ -135,6 +135,17 @@ interface Tally {
     }
 }
 
+interface Subsidy {
+    provider: string,
+    maci: string,
+    pollId: number,
+    newSubsidyCommitment: string,
+    results: {
+        subsidy: string[],
+        salt: string
+    }
+}
+
 const expectTally = (
     maxMessages: number,
     expectedTally: number[],
@@ -144,13 +155,30 @@ const expectTally = (
 ) => {
     let genTally: string[] = Array(maxMessages).fill('0')
     const calculateTally =
-    expectedTally.map((voteOption) => {
-        if (voteOption != 0) genTally[voteOption - 1] = (parseInt(genTally[voteOption - 1]) + voteOption).toString()
+    expectedTally.map((voteOption, index) => {
+        if (voteOption != 0) {
+            genTally[index] = voteOption.toString()
+        }
     })
 
     expect(tallyFile.results.tally).toEqual(genTally)
     expect(tallyFile.totalSpentVoiceCredits.spent).toEqual(expectedTotalSpentVoiceCredits.toString())
 }
 
+const expectSubsidy = (
+    maxMessages: number,
+    expectedSubsidy: number[],
+    SubsidyFile: Subsidy
+) => {
+    let genSubsidy: string[] = Array(maxMessages).fill('0')
+    const calculateTally =
+    expectedSubsidy.map((value, index) => {
+        if (value != 0) {
+            genSubsidy[index] = value.toString()
+        }
+    })
 
-export { exec, delay, loadYaml, genTestAccounts, genTestUserCommands, expectTally }
+    expect(SubsidyFile.results.subsidy).toEqual(genSubsidy)
+}
+
+export { exec, delay, loadYaml, genTestAccounts, genTestUserCommands, expectTally, expectSubsidy }

--- a/integrationTests/ts/__tests__/utils.ts
+++ b/integrationTests/ts/__tests__/utils.ts
@@ -149,19 +149,26 @@ interface Subsidy {
 const expectTally = (
     maxMessages: number,
     expectedTally: number[],
-    expectedSpentVoiceCredits: number[],
+    expectedPerVOSpentVoiceCredits: number[],
     expectedTotalSpentVoiceCredits: number,
     tallyFile: Tally
 ) => {
     let genTally: string[] = Array(maxMessages).fill('0')
+    let genPerVOSpentVoiceCredits: string[] = Array(maxMessages).fill('0')
     const calculateTally =
-    expectedTally.map((voteOption, index) => {
-        if (voteOption != 0) {
-            genTally[index] = voteOption.toString()
+    expectedTally.map((voteWeight, voteOption) => {
+        if (voteWeight != 0) {
+            genTally[voteOption] = voteWeight.toString()
+        }
+    })
+    expectedPerVOSpentVoiceCredits.map((spentCredit, index) => {
+        if (spentCredit != 0) {
+            genPerVOSpentVoiceCredits[index] = spentCredit.toString()
         }
     })
 
     expect(tallyFile.results.tally).toEqual(genTally)
+    expect(tallyFile.perVOSpentVoiceCredits.tally).toEqual(genPerVOSpentVoiceCredits)
     expect(tallyFile.totalSpentVoiceCredits.spent).toEqual(expectedTotalSpentVoiceCredits.toString())
 }
 


### PR DESCRIPTION
Changes:
* test harness can verifies subsidy result
  * added one test case 
* now test harness verifies spent voice credit(s) per user as well
* fix wrong verification logic of tally