### PR TITLE
Publish type declarations

### DIFF
--- a/circuits/package.json
+++ b/circuits/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "zk-SNARK circuits for MACI",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "build-test-circuits": "bash ./scripts/build.sh",
     "watch": "tsc --watch",

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "CLI utilities for MACI",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "bin": {
     "maci-cli": "./build/index.js"
   },

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "Solidity Smart Contracts for MACI (Minimal Anti-Collusion Infrastructure)",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "watch": "tsc --watch",
     "hardhat": "./scripts/runHardhat.sh",

--- a/core/package.json
+++ b/core/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "watch": "tsc --watch",
     "build": "tsc",

--- a/crypto/package.json
+++ b/crypto/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "A package containing cryptography utilities for MACI",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "watch": "tsc --watch",
     "build": "tsc",

--- a/domainobjs/package.json
+++ b/domainobjs/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "watch": "tsc --watch",
     "build": "tsc",

--- a/integrationTests/package.json
+++ b/integrationTests/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "watch": "tsc --watch",
     "build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,23 @@
 {
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    "alwaysStrict": false,
-    "allowJs": true,
-    "noImplicitAny": false,
-    "forceConsistentCasingInFileNames": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "sourceMap": true,
-    "strict": false,
-    "outDir": "./build",
-    "declaration": true
-  },
-  "exclude": ["node_modules/**"],
-  "include": ["./**/ts"]
+    "compilerOptions": {
+        "experimentalDecorators": true,
+        "alwaysStrict": true,
+        "allowJs": true,
+        "noImplicitAny": false,
+        "forceConsistentCasingInFileNames": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "sourceMap": true,
+        "strict": true,
+        "declaration": true,
+        "outDir": "./build"
+    },
+    "exclude": [
+        "node_modules/**"
+    ],
+    "include": [
+        "./ts"
+    ]
 }


### PR DESCRIPTION
We tried using the maci npm packages from a Typescript project, but found that typings were not available. 

This PR makes sure that the build also produces type declaration files (`.d.ts`) so that consumers will get the full support of the type system.

More info: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

