### PR TITLE
rewrite float division circuit

### DIFF
--- a/circuits/circom/float.circom
+++ b/circuits/circom/float.circom
@@ -3,52 +3,93 @@ include "../node_modules/circomlib/circuits/bitify.circom";
 include "../node_modules/circomlib/circuits/comparators.circom";
 include "../node_modules/circomlib/circuits/mux1.circom";
 
+template msb(n) {
+    // require in < 2**n 
+    signal input in;
+    signal output out;
+    component n2b = Num2Bits(n);
+    n2b.in <== in;
+    n2b.out[n-1] ==> out;
+}
+
+template shift(n) {
+    // shift divident and partial rem together 
+    // divident will reduce by 1 bit each call
+    // require divident < 2**n
+    signal input divident;
+    signal input rem;
+    signal output divident1;
+    signal output rem1;
+    
+    component lmsb = msb(n);
+    lmsb.in <== divident;
+    rem1 <== rem * 2 + lmsb.out;
+    divident1 <== divident - lmsb.out * 2**(n-1);
+}
+
 template IntegerDivision(n) {
-    // require max(a, b) < 2**n
     signal input a;
     signal input b;
     signal output c;
-    assert (n < 253);
-    assert (a < 2**n);
-    assert (b < 2**n);
 
-    var r = a;
-    var d = b * 2**n;
+    component lta = LessThan(252);
+    lta.in[0] <== a;
+    lta.in[1] <== 2**n;
+    lta.out === 1;
+    component ltb = LessThan(252);
+    ltb.in[0] <== b;
+    ltb.in[1] <== 2**n;
+    ltb.out === 1;
+
+    component isz = IsZero();
+    isz.in <== b;
+    isz.out === 0;
+
+    var divident = a;
+    var rem = 0;
+
     component b2n = Bits2Num(n);
+    component shf[n];
     component lt[n];
     component mux[n];
-    component mux1[n];
 
     for (var i = n - 1; i >= 0; i--) {
-        lt[i] = LessThan(2*n);
+        shf[i] = shift(i+1);
+        lt[i] = LessEqThan(n);
         mux[i] = Mux1();
-        mux1[i] = Mux1();
     }
 
     for (var i = n-1; i >= 0; i--) {
-        lt[i].in[0] <== 2 * r; 
-        lt[i].in[1] <== d;
+        shf[i].divident <==  divident;
+        shf[i].rem <== rem;
+        divident = shf[i].divident1;
+        rem = shf[i].rem1;
+
+        lt[i].in[0] <== b; 
+        lt[i].in[1] <== rem;
 
         mux[i].s <== lt[i].out;
-        mux[i].c[0] <== 1;
-        mux[i].c[1] <== 0;
+        mux[i].c[0] <== 0;
+        mux[i].c[1] <== 1;
+        mux[i].out ==> b2n.in[i];
 
-        mux1[i].s <== lt[i].out;
-        mux1[i].c[0] <== 2 * r - d;
-        mux1[i].c[1] <== 2 * r;
-
-        b2n.in[i] <== mux[i].out;
-        r =  mux1[i].out;
+        rem = rem - b * lt[i].out;
     }
-    c <== b2n.out;
+    b2n.out ==> c;
 }
 
 template ToFloat(W) {
     // W is the number of digits in decimal part
-    assert (W <= 76); // 10^76 < 2^253
+    // 10^75 < 2^252
+    assert(W < 75);
+
+    // in*10^W <= 10^75
     signal input in;
     signal output out;
-    assert (in < (10**(76-W)));
+    component lt = LessEqThan(252);
+    lt.in[0] <== in;
+    lt.in[1] <== 10**(75-W);
+    lt.out === 1;
     out <== in * (10**W);
 }
 
@@ -59,11 +100,19 @@ template DivisionFromFloat(W, n) {
     signal input a;
     signal input b;
     signal output c;
+
+    assert(W < 75);
+    assert(n < 252);
+
+    component lt = LessThan(252);
+    lt.in[0] <== a; 
+    lt.in[1] <== 10 ** (75 - W);
+    lt.out === 1;
+
     component div = IntegerDivision(n);
     div.a <== a * (10 ** W);
     div.b <== b;
     c <== div.c;
-    log(c);
 }
 
 template DivisionFromNormal(W, n) {
@@ -90,11 +139,16 @@ template MultiplicationFromFloat(W, n) {
     signal input a;
     signal input b;
     signal output c;
-    component div = IntegerDivision(n+4*W);
+
+    assert(W < 75);
+    assert(n < 252);
+    assert(10**W < 2**n);
+
+    component div = IntegerDivision(n);
+    // TODO: check a*b is not overflow
     div.a <== a * b;
     div.b <== 10**W;
     c <== div.c;
-    log(c);
 }
 
 template MultiplicationFromNormal(W, n) {
@@ -113,5 +167,3 @@ template MultiplicationFromNormal(W, n) {
     mul.b <== tfb.out;
     c <== mul.c;
 }
-
-

--- a/circuits/circom/float.circom
+++ b/circuits/circom/float.circom
@@ -145,7 +145,17 @@ template MultiplicationFromFloat(W, n) {
     assert(10**W < 2**n);
 
     component div = IntegerDivision(n);
-    // TODO: check a*b is not overflow
+
+    // not the best way, but works in our case
+    component lta = LessThan(252);
+    lta.in[0] <== a; 
+    lta.in[1] <== 2 ** 126;
+    lta.out === 1;
+    component ltb = LessThan(252);
+    ltb.in[0] <== b; 
+    ltb.in[1] <== 2 ** 126;
+    ltb.out === 1;
+
     div.a <== a * b;
     div.b <== 10**W;
     c <== div.c;

--- a/circuits/circom/subsidy.circom
+++ b/circuits/circom/subsidy.circom
@@ -17,6 +17,7 @@ template SubsidyPerBatch (
     intStateTreeDepth,
     voteOptionTreeDepth
 ) {
+    // keep MM < 2 ** 196 to avoid overflow: https://hackmd.io/@chaosma/H1_9xmT2K
     var MM = 50; // protocol params should be consistent with MaciState.ts
     var WW = 4; // number of decimal in float representation, should consist with MaciState.ts
     var NN = 64; // maximum width of bits (10**NN < 2**253) in float division

--- a/contracts/contracts/TopupCredit.sol
+++ b/contracts/contracts/TopupCredit.sol
@@ -6,6 +6,8 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract TopupCredit is ERC20, Ownable {
     uint8 private _decimals = 1;
+    // keep the maximum amount less than 2**126 < sqrt(field_size)
+    // to avoid overflow
     uint256 MAXIMUM_AIRDROP_AMOUNT = 100000 * 10**_decimals;
 
     constructor() ERC20("TopupCredit", "TopupCredit") {


### PR DESCRIPTION
* use a similar algorithm which has more relax condition for inputs 
* check divisor not equal zero
* check inputs not overflow for float division and representation
* check multiplication a*b not overflow
*  to avoid subsidy formula overflow, add comments on voice credit contracts