### PR TITLE
ci: update the triggers to reflect latest branching strategy

### DIFF
--- a/.github/workflows/circuit-build.yml
+++ b/.github/workflows/circuit-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/circuit-build.yml
+++ b/.github/workflows/circuit-build.yml
@@ -2,9 +2,9 @@ name: Circuit
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -2,9 +2,9 @@ name: Contracts
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -2,9 +2,9 @@ name: Core
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
 
 
 concurrency: 

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/crypto-build.yml
+++ b/.github/workflows/crypto-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/crypto-build.yml
+++ b/.github/workflows/crypto-build.yml
@@ -2,9 +2,9 @@ name: Crypto
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/domainobjs-build.yml
+++ b/.github/workflows/domainobjs-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/domainobjs-build.yml
+++ b/.github/workflows/domainobjs-build.yml
@@ -2,9 +2,9 @@ name: Domainobjs
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
   schedule:
     - cron: 0 0 * * *
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,10 +1,10 @@
 name: GitHub Pages
 
 on:
-  push: 
-    branches: [ v1 ]
+  push:
+    branches: [ master, audit, dev ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ master, audit, dev ]
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This PR reflects that the `v1` branch is now deprecated.