### PR TITLE
security audits 2

### DIFF
--- a/circuits/circom/messageValidator.circom
+++ b/circuits/circom/messageValidator.circom
@@ -1,19 +1,19 @@
 pragma circom 2.0.0;
 include "./verifySignature.circom";
-include "../node_modules/circomlib/circuits/comparators.circom";
+include "./utils.circom";
 
 template MessageValidator() {
     // a) Whether the state leaf index is valid
     signal input stateTreeIndex;
     signal input numSignUps;
-    component validStateLeafIndex = LessEqThan(252);
+    component validStateLeafIndex = SafeLessEqThan(252);
     validStateLeafIndex.in[0] <== stateTreeIndex;
     validStateLeafIndex.in[1] <== numSignUps;
 
     // b) Whether the max vote option tree index is correct
     signal input voteOptionIndex;
     signal input maxVoteOptions;
-    component validVoteOptionIndex = LessThan(252);
+    component validVoteOptionIndex = SafeLessThan(252);
     validVoteOptionIndex.in[0] <== voteOptionIndex;
     validVoteOptionIndex.in[1] <== maxVoteOptions;
 
@@ -44,7 +44,7 @@ template MessageValidator() {
     // e) Whether the state leaf was inserted before the Poll period ended
     signal input slTimestamp;
     signal input pollEndTimestamp;
-    component validTimestamp = LessEqThan(252);
+    component validTimestamp = SafeLessEqThan(252);
     validTimestamp.in[0] <== slTimestamp;
     validTimestamp.in[1] <== pollEndTimestamp;
 
@@ -55,12 +55,12 @@ template MessageValidator() {
 
     // Check that voteWeight is < sqrt(field size), so voteWeight ^ 2 will not
     // overflow
-    component validVoteWeight = LessEqThan(252);
+    component validVoteWeight = SafeLessEqThan(252);
     validVoteWeight.in[0] <== voteWeight;
     validVoteWeight.in[1] <== 147946756881789319005730692170996259609;
 
     // Check that currentVoiceCreditBalance + (currentVotesForOption ** 2) >= (voteWeight ** 2)
-    component sufficientVoiceCredits = GreaterEqThan(252);
+    component sufficientVoiceCredits = SafeGreaterEqThan(252);
     sufficientVoiceCredits.in[0] <== (currentVotesForOption * currentVotesForOption) + currentVoiceCreditBalance;
     sufficientVoiceCredits.in[1] <== voteWeight * voteWeight;
 

--- a/circuits/circom/processMessages.circom
+++ b/circuits/circom/processMessages.circom
@@ -6,7 +6,7 @@ include "./privToPubKey.circom";
 include "./stateLeafAndBallotTransformer.circom";
 include "./trees/incrementalQuinTree.circom";
 include "../node_modules/circomlib/circuits/mux1.circom";
-include "../node_modules/circomlib/circuits/comparators.circom";
+include "./utils.circom";
 
 /*
  * Proves the correctness of processing a batch of messages.
@@ -194,7 +194,7 @@ template ProcessMessages(
     component muxes[batchSize];
 
     for (var i = 0; i < batchSize; i ++) {
-        lt[i] = LessThan(32);
+        lt[i] = SafeLessThan(32);
         lt[i].in[0] <== batchStartIndex + i;
         lt[i].in[1] <== batchEndIndex;
 
@@ -566,9 +566,9 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
     b <== currentVoteWeight * currentVoteWeight;
     c <== cmdNewVoteWeight * cmdNewVoteWeight;
 
-    component enoughVoiceCredits = GreaterEqThan(252);
-    enoughVoiceCredits.in[0] <== stateLeaf[STATE_LEAF_VOICE_CREDIT_BALANCE_IDX] + b - c;
-    enoughVoiceCredits.in[1] <== 0;
+    component enoughVoiceCredits = SafeGreaterEqThan(252);
+    enoughVoiceCredits.in[0] <== stateLeaf[STATE_LEAF_VOICE_CREDIT_BALANCE_IDX] + b;
+    enoughVoiceCredits.in[1] <== c;
 
     component isMessageValid = IsEqual();
     var bothValid = 2; 

--- a/circuits/circom/trees/incrementalQuinTree.circom
+++ b/circuits/circom/trees/incrementalQuinTree.circom
@@ -1,4 +1,5 @@
 pragma circom 2.0.0;
+include "../../node_modules/circomlib/circuits/bitify.circom";
 include "../../node_modules/circomlib/circuits/mux1.circom";
 include "../../node_modules/circomlib/circuits/comparators.circom";
 include "../hasherPoseidon.circom";
@@ -32,6 +33,9 @@ template QuinSelector(choices) {
     signal input index;
     signal output out;
     
+    // Ensure choices < 2^3
+    component n2b = Num2Bits(3);
+    n2b.in  <== choices;
     // Ensure that index < choices
     component lessThan = LessThan(3);
     lessThan.in[0] <== index;
@@ -280,10 +284,6 @@ template QuinGeneratePathIndices(levels) {
     n[levels] <-- m;
 
     // Do a range check on each out[i]
-    for (var i = 1; i < levels + 1; i ++) {
-        n[i - 1] === n[i] * BASE + out[i-1];
-    }
-    
     component leq[levels];
     component sum = CalculateTotal(levels);
     for (var i = 0; i < levels; i ++) {

--- a/circuits/circom/trees/incrementalQuinTree.circom
+++ b/circuits/circom/trees/incrementalQuinTree.circom
@@ -1,10 +1,10 @@
 pragma circom 2.0.0;
 include "../../node_modules/circomlib/circuits/bitify.circom";
 include "../../node_modules/circomlib/circuits/mux1.circom";
-include "../../node_modules/circomlib/circuits/comparators.circom";
 include "../hasherPoseidon.circom";
 include "./calculateTotal.circom";
 include "./checkRoot.circom";
+include "../utils.circom";
 
 // This file contains circuits for quintary Merkle tree verifcation.
 // It assumes that each node contains 5 leaves, as we use the PoseidonT6
@@ -33,11 +33,8 @@ template QuinSelector(choices) {
     signal input index;
     signal output out;
     
-    // Ensure choices < 2^3
-    component n2b = Num2Bits(3);
-    n2b.in  <== choices;
     // Ensure that index < choices
-    component lessThan = LessThan(3);
+    component lessThan = SafeLessThan(3);
     lessThan.in[0] <== index;
     lessThan.in[1] <== choices;
     lessThan.out === 1;
@@ -115,7 +112,7 @@ template Splicer(numItems) {
     */
     for (i = 0; i < numItems + 1; i ++) {
         // greaterThen[i].out will be 1 if the i is greater than the index
-        greaterThan[i] = GreaterThan(3);
+        greaterThan[i] = SafeGreaterThan(3);
         greaterThan[i].in[0] <== i;
         greaterThan[i].in[1] <== index;
 
@@ -283,12 +280,11 @@ template QuinGeneratePathIndices(levels) {
 
     n[levels] <-- m;
 
-    // Do a range check on each out[i]
     component leq[levels];
     component sum = CalculateTotal(levels);
     for (var i = 0; i < levels; i ++) {
         // Check that each output element is less than the base
-        leq[i] = LessThan(3);
+        leq[i] = SafeLessThan(3);
         leq[i].in[0] <== out[i];
         leq[i].in[1] <== BASE;
         leq[i].out === 1;

--- a/circuits/circom/utils.circom
+++ b/circuits/circom/utils.circom
@@ -20,7 +20,18 @@ template SafeLessThan(n) {
     out <== 1-n2b.out[n];
 }
 
+// N is the number of bits the input  have.
+// The MSF is the sign bit.
+template SafeLessEqThan(n) {
+    signal input in[2];
+    signal output out;
 
+    component lt = SafeLessThan(n);
+
+    lt.in[0] <== in[0];
+    lt.in[1] <== in[1]+1;
+    lt.out ==> out;
+}
 
 // N is the number of bits the input  have.
 // The MSF is the sign bit.
@@ -32,5 +43,18 @@ template SafeGreaterThan(n) {
 
     lt.in[0] <== in[1];
     lt.in[1] <== in[0];
+    lt.out ==> out;
+}
+
+// N is the number of bits the input  have.
+// The MSF is the sign bit.
+template SafeGreaterEqThan(n) {
+    signal input in[2];
+    signal output out;
+
+    component lt = SafeLessThan(n);
+
+    lt.in[0] <== in[1];
+    lt.in[1] <== in[0]+1;
     lt.out ==> out;
 }

--- a/circuits/circom/utils.circom
+++ b/circuits/circom/utils.circom
@@ -1,0 +1,36 @@
+pragma circom 2.0.0;
+include "../node_modules/circomlib/circuits/bitify.circom";
+
+// the implicit assumption of LessThan is both inputs are at most n bits
+// so we need add range check for both inputs
+template SafeLessThan(n) {
+    assert(n <= 252);
+    signal input in[2];
+    signal output out;
+
+    component n2b1 = Num2Bits(n);
+    n2b1.in  <== in[0];
+    component n2b2 = Num2Bits(n);
+    n2b2.in  <== in[1];
+
+    component n2b = Num2Bits(n+1);
+
+    n2b.in <== in[0]+ (1<<n) - in[1];
+
+    out <== 1-n2b.out[n];
+}
+
+
+
+// N is the number of bits the input  have.
+// The MSF is the sign bit.
+template SafeGreaterThan(n) {
+    signal input in[2];
+    signal output out;
+
+    component lt = SafeLessThan(n);
+
+    lt.in[0] <== in[1];
+    lt.in[1] <== in[0];
+    lt.out ==> out;
+}


### PR DESCRIPTION
* remove unnecessary condition check in incrementalQuinnTree.circom
* added SafeLessThan, SafeGreaterThan circuit for safety use comparator circuits
* replaced LessThan/GreaterThan usages by Safe ones. This includes security audits items as well as some other places. Only except is float.circom it involves too much computation for subsidy.