### PR TITLE
Security audit 1

### DIFF
--- a/circuits/circom/trees/incrementalQuinTree.circom
+++ b/circuits/circom/trees/incrementalQuinTree.circom
@@ -1,4 +1,5 @@
 pragma circom 2.0.0;
+include "../../node_modules/circomlib/circuits/bitify.circom";
 include "../../node_modules/circomlib/circuits/mux1.circom";
 include "../../node_modules/circomlib/circuits/comparators.circom";
 include "../hasherPoseidon.circom";
@@ -32,6 +33,9 @@ template QuinSelector(choices) {
     signal input index;
     signal output out;
     
+    // Ensure choices < 2^3
+    component n2b = Num2Bits(3);
+    n2b.in  <== choices;
     // Ensure that index < choices
     component lessThan = LessThan(3);
     lessThan.in[0] <== index;
@@ -280,10 +284,6 @@ template QuinGeneratePathIndices(levels) {
     n[levels] <-- m;
 
     // Do a range check on each out[i]
-    for (var i = 1; i < levels + 1; i ++) {
-        n[i - 1] === n[i] * BASE + out[i-1];
-    }
-    
     component leq[levels];
     component sum = CalculateTotal(levels);
     for (var i = 0; i < levels; i ++) {

--- a/circuits/circom/trees/incrementalQuinTree.circom
+++ b/circuits/circom/trees/incrementalQuinTree.circom
@@ -1,10 +1,10 @@
 pragma circom 2.0.0;
 include "../../node_modules/circomlib/circuits/bitify.circom";
 include "../../node_modules/circomlib/circuits/mux1.circom";
-include "../../node_modules/circomlib/circuits/comparators.circom";
 include "../hasherPoseidon.circom";
 include "./calculateTotal.circom";
 include "./checkRoot.circom";
+include "../utils.circom";
 
 // This file contains circuits for quintary Merkle tree verifcation.
 // It assumes that each node contains 5 leaves, as we use the PoseidonT6
@@ -33,11 +33,8 @@ template QuinSelector(choices) {
     signal input index;
     signal output out;
     
-    // Ensure choices < 2^3
-    component n2b = Num2Bits(3);
-    n2b.in  <== choices;
     // Ensure that index < choices
-    component lessThan = LessThan(3);
+    component lessThan = SafeLessThan(3);
     lessThan.in[0] <== index;
     lessThan.in[1] <== choices;
     lessThan.out === 1;
@@ -115,7 +112,7 @@ template Splicer(numItems) {
     */
     for (i = 0; i < numItems + 1; i ++) {
         // greaterThen[i].out will be 1 if the i is greater than the index
-        greaterThan[i] = GreaterThan(3);
+        greaterThan[i] = SafeGreaterThan(3);
         greaterThan[i].in[0] <== i;
         greaterThan[i].in[1] <== index;
 
@@ -283,12 +280,11 @@ template QuinGeneratePathIndices(levels) {
 
     n[levels] <-- m;
 
-    // Do a range check on each out[i]
     component leq[levels];
     component sum = CalculateTotal(levels);
     for (var i = 0; i < levels; i ++) {
         // Check that each output element is less than the base
-        leq[i] = LessThan(3);
+        leq[i] = SafeLessThan(3);
         leq[i].in[0] <== out[i];
         leq[i].in[1] <== BASE;
         leq[i].out === 1;

--- a/circuits/circom/utils.circom
+++ b/circuits/circom/utils.circom
@@ -1,0 +1,36 @@
+pragma circom 2.0.0;
+include "../node_modules/circomlib/circuits/bitify.circom";
+
+// the implicit assumption of LessThan is both inputs are at most n bits
+// so we need add range check for both inputs
+template SafeLessThan(n) {
+    assert(n <= 252);
+    signal input in[2];
+    signal output out;
+
+    component n2b1 = Num2Bits(n);
+    n2b1.in  <== in[0];
+    component n2b2 = Num2Bits(n);
+    n2b2.in  <== in[1];
+
+    component n2b = Num2Bits(n+1);
+
+    n2b.in <== in[0]+ (1<<n) - in[1];
+
+    out <== 1-n2b.out[n];
+}
+
+
+
+// N is the number of bits the input  have.
+// The MSF is the sign bit.
+template SafeGreaterThan(n) {
+    signal input in[2];
+    signal output out;
+
+    component lt = SafeLessThan(n);
+
+    lt.in[0] <== in[1];
+    lt.in[1] <== in[0];
+    lt.out ==> out;
+}


### PR DESCRIPTION
Due to CI issue, separate the commits into two PR.

- remove unnecessary condition check in incrementalQuinnTree.circom
- added SafeLessThan, SafeGreaterThan circuit for safety use comparator circuits
- replaced LessThan/GreaterThan usages by Safe ones. This includes security audits items as well as some other places. Only except is float.circom it involves too much computation for subsidy.