### PR TITLE
Test case to show anyone can deploy poll

### DIFF
--- a/cli/ts/deployPollWithSigner.ts
+++ b/cli/ts/deployPollWithSigner.ts
@@ -1,0 +1,244 @@
+const { ethers } = require('hardhat')
+import {
+    parseArtifact,
+    deployVerifier,
+    deployPpt,
+    getDefaultSigner,
+} from 'maci-contracts'
+
+import {
+    PubKey,
+} from 'maci-domainobjs'
+
+import {contractExists} from './utils'
+import {readJSONFile, writeJSONFile} from 'maci-common'
+import {contractFilepath} from './config'
+
+const configureSubparser = (subparsers: any) => {
+    const createParser = subparsers.addParser(
+        'deployPollWithSigner',
+        { addHelp: true },
+    )
+
+    createParser.addArgument(
+        ['-s', '--signer-private-key'],
+        {
+            action: 'store',
+            type: 'string',
+            help: 'The private key of the deployer',
+        }
+    )
+
+    createParser.addArgument(
+        ['-x', '--maci-address'],
+        {
+            action: 'store',
+            type: 'string',
+            help: 'The MACI contract address',
+        }
+    )
+
+    createParser.addArgument(
+        ['-e', '--erc20-address'],
+        {
+            action: 'store',
+            type: 'string',
+            help: 'The topup credit contract address',
+        }
+    )
+
+    createParser.addArgument(
+        ['-pk', '--pubkey'],
+        {
+            action: 'store',
+            type: 'string',
+            required: true,
+            help: 'The coordinator\'s serialized MACI public key',
+        }
+    )
+
+    createParser.addArgument(
+        ['-t', '--duration'],
+        {
+            action: 'store',
+            type: 'int',
+            required: true,
+            help: 'The poll duration in seconds',
+        }
+    )
+
+    createParser.addArgument(
+        ['-g', '--max-messages'],
+        {
+            action: 'store',
+            type: 'int',
+            required: true,
+            help: 'The maximum number of messages',
+        }
+    )
+
+    createParser.addArgument(
+        ['-mv', '--max-vote-options'],
+        {
+            action: 'store',
+            type: 'int',
+            required: true,
+            help: 'The maximum number of vote options',
+        }
+    )
+
+    createParser.addArgument(
+        ['-i', '--int-state-tree-depth'],
+        {
+            action: 'store',
+            type: 'int',
+            required: true,
+            help: 'The intermediate state tree depth',
+        }
+    )
+
+    createParser.addArgument(
+        ['-m', '--msg-tree-depth'],
+        {
+            action: 'store',
+            type: 'int',
+            required: true,
+            help: 'The message tree depth',
+        }
+    )
+
+    createParser.addArgument(
+        ['-b', '--msg_batch_depth'],
+        {
+            action: 'store',
+            type: 'int',
+            required: true,
+            help: 'The batch depth for message processing. '
+        }
+    )
+
+    createParser.addArgument(
+        ['-v', '--vote-option-tree-depth'],
+        {
+            action: 'store',
+            type: 'int',
+            required: true,
+            help: 'The vote option tree depth',
+        }
+    )
+}
+
+const deployPollWithSigner = async (args: any) => {
+    let contractAddrs = readJSONFile(contractFilepath)
+    if ((!contractAddrs||!contractAddrs["MACI"]) && !args.maci_address) {
+        console.error('Error: MACI contract address is empty') 
+        return 1
+    }
+
+    const privateKey = args.signer_private_key
+    if (!privateKey) {
+        console.error('Error: signer private key is empty') 
+        return 1
+    }
+
+    // The poll duration
+    const duration = args.duration
+    if (duration <= 0) {
+        console.error('Error: the duration should be positive')
+        return 1
+    }
+
+    // Max values
+    const maxMessages = args.max_messages
+    if (maxMessages <= 0) {
+        console.error('Error: the maximum number of messages should be positive')
+        return 1
+    }
+
+    // Max vote options
+    const maxVoteOptions = args.max_vote_options
+    if (maxVoteOptions <= 0) {
+        console.error('Error: the maximum number of vote options be positive')
+        return 1
+    }
+    const intStateTreeDepth = args.int_state_tree_depth
+    const messageTreeSubDepth = args.msg_batch_depth
+    const messageTreeDepth = args.msg_tree_depth
+    const voteOptionTreeDepth = args.vote_option_tree_depth
+
+    const defaultSigner = await getDefaultSigner()
+    const signer = new ethers.Wallet( privateKey, defaultSigner.provider)
+
+    const maciAddress = args.maci_address ? args.maci_address: contractAddrs["MACI"]
+    if (!(await contractExists(signer.provider, maciAddress))) {
+        console.error('Error: a MACI contract is not deployed at', maciAddress)
+        return 1
+    }
+
+    // The coordinator's MACI public key
+    const coordinatorPubkey = args.pubkey
+
+    if (!PubKey.isValidSerializedPubKey(coordinatorPubkey)) {
+        console.error('Error: invalid MACI public key')
+        return 1
+    }
+
+    const unserialisedPubkey = PubKey.unserialize(coordinatorPubkey)
+
+    // Deploy a PollProcessorAndTallyer contract
+    const verifierContract = await deployVerifier(true)
+    console.log('Verifier:', verifierContract.address)
+    const pptContract = await deployPpt(verifierContract.address, true)
+    await pptContract.deployTransaction.wait()
+
+    const [ maciAbi ] = parseArtifact('MACI')
+    const maciContract = new ethers.Contract(
+        maciAddress,
+        maciAbi,
+        signer,
+    )
+
+    try {
+        const tx = await maciContract.deployPoll(
+            duration,
+            { maxMessages, maxVoteOptions },
+            {
+                intStateTreeDepth,
+                messageTreeSubDepth,
+                messageTreeDepth,
+                voteOptionTreeDepth,
+            },
+            unserialisedPubkey.asContractParam(),
+	    { gasLimit: 10000000 }
+        )
+        const receipt = await tx.wait()
+        const iface = maciContract.interface
+        const log = iface.parseLog(receipt.logs[receipt.logs.length - 1])
+        const name = log.name
+        if (name !== 'DeployPoll') {
+            console.error('Error: invalid event log.')
+            return 1
+        }
+        const pollId = log.args._pollId
+        const pollAddr = log.args._pollAddr
+        console.log('Poll ID:', pollId.toString())
+        console.log('Poll contract:', pollAddr)
+        console.log('PollProcessorAndTallyer contract:', pptContract.address)
+        contractAddrs['Verifier-' + pollId.toString()] = verifierContract.address
+        contractAddrs['PollProcessorAndTally-' + pollId.toString()] = pptContract.address
+        contractAddrs['Poll-' + pollId.toString()] = pollAddr
+        writeJSONFile(contractFilepath, contractAddrs)
+
+    } catch (e) {
+        console.error('Error: could not deploy poll')
+        console.error(e.message)
+        return 1
+    }
+
+    return 0
+}
+
+export {
+    deployPollWithSigner,
+    configureSubparser,
+}

--- a/cli/ts/fundWallet.ts
+++ b/cli/ts/fundWallet.ts
@@ -1,0 +1,62 @@
+import {
+    getDefaultSigner,
+    parseArtifact,
+} from 'maci-contracts'
+
+import {
+    validateEthAddress,
+    contractExists,
+} from './utils'
+
+import {readJSONFile} from 'maci-common'
+
+const { ethers } = require('hardhat')
+
+import {contractFilepath} from './config'
+
+const configureSubparser = (subparsers: any) => {
+    const parser = subparsers.addParser(
+        'fundWallet',
+        { addHelp: true },
+    )
+
+    parser.addArgument(
+        ['-w', '--address'],
+        {
+            required: true,
+            type: 'string',
+            help: 'The wallet address',
+        }
+    )
+
+    parser.addArgument(
+        ['-a', '--amount'],
+        {
+            required: true,
+            type: 'string',
+            help: 'The amount to fund in wei'
+        }
+    )
+}
+
+const fundWallet = async (args: any) => {
+    const signer = await getDefaultSigner()
+
+    const value = ethers.BigNumber.from(args.amount)
+    const to = args.address
+    try {
+	const tx = await signer.sendTransaction({ to, value })
+	console.log('tx hash: ', tx.hash)
+	await tx.wait()
+    } catch (e) {
+        console.error(e)
+        return 1
+    }
+
+    return 0
+}
+
+export {
+    fundWallet,
+    configureSubparser,
+}

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -43,6 +43,16 @@ import {
 } from './deployPoll'
 
 import {
+    deployPollWithSigner,
+    configureSubparser as configureSubparserForDeployPollWithSigner,
+} from './deployPollWithSigner'
+
+import {
+    fundWallet,
+    configureSubparser as configureSubparserForFundWallet
+} from './fundWallet'
+
+import {
     airdrop,
     configureSubparser as configureSubparserForAirdrop,
 } from './airdrop'
@@ -123,6 +133,12 @@ const main = async () => {
     // Subcommand: deployPoll
     configureSubparserForDeployPoll(subparsers)
 
+    // Subcommand: deployPollWithSigner
+    configureSubparserForDeployPollWithSigner(subparsers)
+
+    // Subcommand: fundWallet
+    configureSubparserForFundWallet(subparsers)
+
     // Subcommand: airdrop 
     configureSubparserForAirdrop(subparsers)
 
@@ -170,6 +186,10 @@ const main = async () => {
         await create(args)
     } else if (args.subcommand === 'deployPoll') {
         await deployPoll(args)
+    } else if (args.subcommand === 'deployPollWithSigner') {
+        await deployPollWithSigner(args)
+    } else if (args.subcommand === 'fundWallet') {
+        await fundWallet(args)
     } else if (args.subcommand === 'airdrop') {
         await airdrop(args)
     } else if (args.subcommand === 'topup') {

--- a/integrationTests/package.json
+++ b/integrationTests/package.json
@@ -13,6 +13,8 @@
         "test-cli-genMaciPubkey": "jest cli-genMaciPubkey.test.ts",
         "test-cli-genMaciPubkey-debug": "node --inspect-brk ./node_modules/.bin/jest cli-genMaciPubkey.test.ts",
         "test-suites": "NODE_OPTIONS=--max-old-space-size=4096 jest suites.test.ts",
+        "test-deployPoll": "NODE_OPTIONS=--max-old-space-size=4096 jest deployPollWithRandomSigner.test.ts",
+        "download-zkeys": "./scripts/download_zkeys.sh",
         "test-suites-debug": "NODE_OPTIONS=--max-old-space-size=4096 node --inspect-brk ./node_modules/.bin/jest suites.test.ts"
     },
     "_moduleAliases": {

--- a/integrationTests/scripts/download_zkeys.sh
+++ b/integrationTests/scripts/download_zkeys.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+cd "$(dirname "$0")"
+cd ..
+
+mkdir -p ../cli/zkeys
+
+PKGS="zkeys_10-2-1-2_glibc-211.tar.gz ProcessMessages_10-2-1-2_test.0.zkey TallyVotes_10-1-2_test.0.zkey SubsidyPerBatch_10-1-2_test.0.zkey"
+
+BASE_URL=https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v1.1.1-aa4ba27/10-2-1-2
+OUT_DIR=../cli/zkeys
+
+for p in $PKGS
+do
+  url="$BASE_URL/$p"
+  echo "downloading $url"
+  curl $url -o "$OUT_DIR/$p"
+  extension="${p##*.}"
+  if [ "$extension" == "gz" ]
+  then
+    tar -xvf "$OUT_DIR/$p" -C "$OUT_DIR"
+  fi
+done

--- a/integrationTests/ts/__tests__/deployPollWithRandomSigner.test.ts
+++ b/integrationTests/ts/__tests__/deployPollWithRandomSigner.test.ts
@@ -1,0 +1,79 @@
+jest.setTimeout(3000000)
+
+import {
+    loadData,
+    execute,
+    executeSuite,
+} from './suites'
+
+import { loadYaml } from './utils'
+import * as fs from 'fs'
+import * as path from 'path'
+import { Keypair } from 'maci-domainobjs'
+import { BigNumber, providers, Contract, Wallet, utils } from 'ethers'
+
+const maciAbi = ["function getPoll(uint256 _pollId) public view returns (address)"]
+const pollAbi = ["function getDeployTimeAndDuration() public view returns (uint256, uint256) "]
+
+
+async function getPollDuration(providerUrl: string, maci: string, pollId: number): Promise<BigNumber> {
+    const provider = new providers.JsonRpcProvider(providerUrl)
+    const maciContract = new Contract(maci, maciAbi, provider)
+    const pollAddress = await maciContract.getPoll(pollId)
+    const pollContract = new Contract(pollAddress, pollAbi, provider)
+    const [_, duration] = await pollContract.getDeployTimeAndDuration()
+    return duration
+}
+
+describe('Test deployPollWithSigner', () => {
+    const data = loadData('suites.json')
+    const test = data.suites[0]
+    it(test.description, async () => {
+        const result = await executeSuite(test, expect)
+        console.log(result)
+        expect(result).toBeTruthy()
+
+
+	let caughtException = false
+	try {
+            const config = loadYaml()
+
+	    const tally = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../cli/tally.json')).toString())
+	    const coordinatorKeypair = new Keypair()
+
+	    // start another round by a random user
+	    const wallet = Wallet.createRandom()
+
+	    // fund wallet with 1 ETH
+	    const totalAmount = utils.parseEther("1")
+            const fundWalletCommand = `node build/index.js fundWallet` +
+            ` -w ${wallet.address}` +
+            ` -a ${totalAmount.toString()}`
+	    execute(fundWalletCommand)
+	    
+	    const duration = 999999
+            const deployPollCommand = `node build/index.js deployPollWithSigner` +
+            ` -x ${tally.maci}` +
+            ` -s ${wallet.privateKey}` +
+            ` -pk ${coordinatorKeypair.pubKey.serialize()}` +
+            ` -t ${duration}` +
+            ` -g ${config.constants.maci.maxMessages}` +
+            ` -mv ${config.constants.maci.maxVoteOptions}` +
+            ` -i ${config.constants.poll.intStateTreeDepth}` +
+            ` -m ${config.constants.poll.messageTreeDepth}` +
+            ` -b ${config.constants.poll.messageBatchDepth}` +
+            ` -v ${config.constants.maci.voteOptionTreeDepth}`
+	    execute(deployPollCommand)
+
+	    // this is the second poll with pollId = 1
+	    const pollId = 1
+	    const pollDuration = await getPollDuration(tally.provider, tally.maci, pollId)
+	    expect(pollDuration.toString()).toEqual(duration.toString())
+	    
+	} catch (e) {
+	    console.log(e)
+	    caughtException = true
+	    expect(caughtException).toEqual(false)
+	}
+    })
+})

--- a/integrationTests/ts/__tests__/suites.ts
+++ b/integrationTests/ts/__tests__/suites.ts
@@ -294,5 +294,6 @@ const executeSuite = async (data: any, expect: any) => {
 
 export {
     loadData,
+    execute,
     executeSuite,
 }


### PR DESCRIPTION
The test case duplicates the existing deployPoll.ts script and change it to accept a new argument, a private key of a signer which will deploy the poll.

The test case first run the first test case from the existing integration test suite to setup the environment (like deploying MACI and Poll contracts). After the first poll is tallied and finalized, the test case start a new poll using a randomly created wallet.

How to run the test:
1) Setup MACI as described in the readme file
2) run the test
```
cd integrationTests
npm run download-zkeys
npm run test-deployPoll
```

The test should pass, which means a new poll was successfully created by a random wallet.
