### PR TITLE
feat(state-tree-depth) - ensure stateTreeDepth is not hardcoded 

### DIFF
--- a/circuits/ts/__tests__/ProcessMessages.test.ts
+++ b/circuits/ts/__tests__/ProcessMessages.test.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs'
 
 import {
     MaciState,
-    STATE_TREE_DEPTH,
 } from 'maci-core'
 
 import {
@@ -21,6 +20,7 @@ import {
 } from 'maci-crypto'
 
 import { 
+    STATE_TREE_DEPTH,
     getSignal,
 } from './utils'
 import * as path from 'path'
@@ -61,7 +61,7 @@ describe('ProcessMessage circuit', function() {
     })
 
     describe('1 user, 2 messages', () => {
-        const maciState = new MaciState()
+        const maciState = new MaciState(STATE_TREE_DEPTH)
         const voteWeight = BigInt(9)
         const voteOptionIndex = BigInt(0)
         let stateIndex
@@ -221,7 +221,7 @@ describe('ProcessMessage circuit', function() {
     })
 
     describe('2 users, 1 message', () => {
-        const maciState = new MaciState()
+        const maciState = new MaciState(STATE_TREE_DEPTH)
         let pollId
         let poll
         const messages: Message[] = []
@@ -331,7 +331,7 @@ describe('ProcessMessage circuit', function() {
     })
  
     describe('1 user, key-change', () => {
-        const maciState = new MaciState()
+        const maciState = new MaciState(STATE_TREE_DEPTH)
         const voteWeight = BigInt(9)
         const voteOptionIndex = BigInt(0)
         let stateIndex
@@ -487,7 +487,7 @@ describe('ProcessMessage circuit', function() {
     const NUM_BATCHES = 2
     describe(`1 user, ${messageBatchSize * NUM_BATCHES} messages`, () => {
         it('should produce the correct state root and ballot root', async () => {
-            const maciState = new MaciState()
+            const maciState = new MaciState(STATE_TREE_DEPTH)
             const userKeypair = new Keypair()
             const stateIndex = maciState.signUp(
                 userKeypair.pubKey, 

--- a/circuits/ts/__tests__/TallyVotes.test.ts
+++ b/circuits/ts/__tests__/TallyVotes.test.ts
@@ -1,10 +1,10 @@
 import {
+    STATE_TREE_DEPTH,
     getSignal,
 } from './utils'
 
 import {
     MaciState,
-    STATE_TREE_DEPTH,
 } from 'maci-core'
 
 import {
@@ -62,7 +62,7 @@ describe('TallyVotes circuit', function() {
         const voteOptionIndex = BigInt(0)
 
         beforeEach(async () => {
-            maciState = new MaciState()
+            maciState = new MaciState(STATE_TREE_DEPTH)
             const messages: Message[] = []
             const commands: PCommand[] = []
             // Sign up and publish
@@ -194,7 +194,7 @@ describe('TallyVotes circuit', function() {
 
     describe.skip(`${x} users, ${x} messages`, () => {
         it('should produce the correct state root and ballot root', async () => {
-            const maciState = new MaciState()
+            const maciState = new MaciState(STATE_TREE_DEPTH)
             const userKeypairs: Keypair[] = []
             for (let i = 0; i < x; i ++) {
                 const k = new Keypair()

--- a/circuits/ts/__tests__/utils.ts
+++ b/circuits/ts/__tests__/utils.ts
@@ -1,4 +1,4 @@
-const str2BigInt = (s: string): BigInt => {
+export const str2BigInt = (s: string): BigInt => {
     return BigInt(parseInt(
         Buffer.from(s).toString('hex'), 16
     ))
@@ -10,7 +10,7 @@ const str2BigInt = (s: string): BigInt => {
 // ffjavascript has no types so leave circuit with untyped
 type CircuitT = any;
 
-async function getSignal(circuit: CircuitT, witness: bigint[], name: string): Promise<bigint> {
+export const getSignal = async (circuit: CircuitT, witness: bigint[], name: string): Promise<bigint> => {
     const prefix = "main"
     // E.g. the full name of the signal "root" is "main.root"
     // You can look up the signal names using `circuit.getDecoratedOutput(witness))`
@@ -26,7 +26,4 @@ async function getSignal(circuit: CircuitT, witness: bigint[], name: string): Pr
     return BigInt(witness[indexInWitness]);
 }
 
-export {
-    str2BigInt,
-    getSignal
-}
+export const STATE_TREE_DEPTH = 10

--- a/cli/ts/create.ts
+++ b/cli/ts/create.ts
@@ -118,6 +118,8 @@ const create = async (args: any) => {
     console.log("Verifier", verifierContract.address)
 
     const vkRegistryContractAddress = args.vk_registry ? args.vk_registry: contractAddrs["VkRegistry"]
+
+    const stateTreeDepth = args.state_tree_depth ? args.state_tree_depth: 10
     console.log("VkRegistry", vkRegistryContractAddress)
     const {
         maciContract,
@@ -129,7 +131,8 @@ const create = async (args: any) => {
         initialVoiceCreditProxyContractAddress,
         verifierContract.address,
         vkRegistryContractAddress,
-        topupCreditContract.address 
+        topupCreditContract.address,
+        stateTreeDepth
     )
     
     console.log('MACI:', maciContract.address)

--- a/cli/ts/create.ts
+++ b/cli/ts/create.ts
@@ -55,6 +55,15 @@ const configureSubparser = (subparsers: any) => {
             help: 'If specified, deploys the MACI contract with this address as the signup gatekeeper constructor argument. Otherwise, deploys a gatekeeper contract which allows any address to sign up.',
         }
     )
+
+    createParser.addArgument(
+        ['-s', '--state-tree-depth'],
+        {
+            action: 'store',
+            type: 'int',
+            help: 'The depth of the state tree',
+        }
+    )
 }
 
 const create = async (args: any) => {

--- a/cli/ts/deployPoll.ts
+++ b/cli/ts/deployPoll.ts
@@ -5,7 +5,6 @@ import {
     deployMessageProcessor,
     deployTally,
     deploySubsidy,
-    deployContract,
     getDefaultSigner,
 } from 'maci-contracts'
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,6 +7,17 @@ This submodule contains all the Ethereum contracts and tests for MACI.
 
 For more information please refer to the [documentation for Contracts](http://privacy-scaling-explorations.github.io/maci/contracts.html).
 
+## Compile
+
+To compile the smart contracts, please run:
+
+```bash 
+npm run compileSol $stateTreeDepth
+```
+
+The $stateTreeDepth parameter is not mandatory, however this will be set to 10 if nothing is provided. This argument is important as it will determine the size of the state tree and the number of constraints in the circuit, thus requiring a different MACI setup.
+
+
 ## Contracts
 
 * **`MACI.sol`**

--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -22,7 +22,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
     // The state tree depth is fixed. As such it should be as large as feasible
     // so that there can be as many users as possible.  i.e. 5 ** 10 = 9765625
-    uint8 public constant override stateTreeDepth = 10;
+    // this should also match the parameter of the circom circuits.
+    uint8 public immutable stateTreeDepth;
 
     // IMPORTANT: remember to change the ballot tree depth
     // in contracts/ts/genEmptyBallotRootsContract.ts file
@@ -128,7 +129,8 @@ contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
     constructor(
         PollFactory _pollFactory,
         SignUpGatekeeper _signUpGatekeeper,
-        InitialVoiceCreditProxy _initialVoiceCreditProxy
+        InitialVoiceCreditProxy _initialVoiceCreditProxy,
+        uint8 _stateTreeDepth
     ) {
         // Deploy the state AccQueue
         stateAq = new AccQueueQuinaryBlankSl(STATE_TREE_SUBDEPTH);
@@ -137,6 +139,7 @@ contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
         pollFactory = _pollFactory;
         signUpGatekeeper = _signUpGatekeeper;
         initialVoiceCreditProxy = _initialVoiceCreditProxy;
+        stateTreeDepth = _stateTreeDepth;
 
         signUpTimestamp = block.timestamp;
 
@@ -272,11 +275,11 @@ contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
         return address(p);
     }
 
-        /*
-    /* Allow Poll contracts to merge the state subroots
-    /* @param _numSrQueueOps Number of operations
-    /* @param _pollId The active Poll ID
-    */
+    /**
+     * Allow Poll contracts to merge the state subroots
+     * @param _numSrQueueOps Number of operations
+     * @param _pollId The active Poll ID
+     */
     function mergeStateAqSubRoots(uint256 _numSrQueueOps, uint256 _pollId)
         public
         override

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "watch": "tsc --watch",
         "hardhat": "./scripts/runHardhat.sh",
-        "compileSol": "./scripts/compileSol.sh && cp -r artifacts/ ../integrationTests/artifacts",
+        "compileSol": "./scripts/compileSol.sh $1",
+        "moveIntegrationArtifacts": "cp -r artifacts/ ../integrationTests/artifacts",
         "build": "tsc",
         "pretest": "npm run compileSol",
         "test": "hardhat test",

--- a/contracts/scripts/compileSol.sh
+++ b/contracts/scripts/compileSol.sh
@@ -9,10 +9,10 @@ rm -rf ./artifacts/*
 rm -rf ./cache/*
 
 echo 'Writing Merkle zeros contracts'
-./scripts/writeMerkleZeroesContracts.sh
+./scripts/writeMerkleZeroesContracts.sh 
 
 echo 'Writing empty ballot tree root contract'
-./scripts/writeEmptyBallotRoots.sh
+./scripts/writeEmptyBallotRoots.sh $1
 
 echo 'Building contracts with Hardhat'
 npx hardhat compile

--- a/contracts/scripts/writeEmptyBallotRoots.sh
+++ b/contracts/scripts/writeEmptyBallotRoots.sh
@@ -4,4 +4,5 @@ set -e
 cd "$(dirname "$0")"
 cd ..
 
-node build/genEmptyBallotRootsContract.js > contracts/trees/EmptyBallotRoots.sol
+# take the stateTreeDepth as cli arg
+node build/genEmptyBallotRootsContract.js $1 > contracts/trees/EmptyBallotRoots.sol

--- a/contracts/tests/MACI.test.ts
+++ b/contracts/tests/MACI.test.ts
@@ -110,12 +110,15 @@ describe('MACI', () => {
     let mpContract
     let tallyContract
     let pollId: number
+    let user: ethers.Signer
 
     describe('Deployment', () => {
         before(async () => {
             signer = await getDefaultSigner()
             const r = await deployTestContracts(
                 initialVoiceCreditBalance,
+                STATE_TREE_DEPTH,
+                true
             )
 
             maciContract = r.maciContract

--- a/contracts/tests/MACI.test.ts
+++ b/contracts/tests/MACI.test.ts
@@ -81,7 +81,7 @@ const users = [
 
 const signUpTxOpts = { gasLimit: 300000 }
 
-const maciState = new MaciState()
+const maciState = new MaciState(STATE_TREE_DEPTH)
 
 // Poll parameters
 const duration = 15
@@ -110,7 +110,6 @@ describe('MACI', () => {
     let mpContract
     let tallyContract
     let pollId: number
-    let user: ethers.Signer
 
     describe('Deployment', () => {
         before(async () => {

--- a/contracts/tests/MACI_overflow.test.ts
+++ b/contracts/tests/MACI_overflow.test.ts
@@ -51,6 +51,8 @@ describe('Overflow testing', () => {
         signer = await getDefaultSigner()
         const r = await deployTestContracts(
             initialVoiceCreditBalance,
+            STATE_TREE_DEPTH,
+            true
         )
         maciContract = r.maciContract
         stateAqContract = r.stateAqContract

--- a/contracts/tests/SignUpGatekeeper.test.ts
+++ b/contracts/tests/SignUpGatekeeper.test.ts
@@ -7,6 +7,7 @@ import { expect } from 'chai'
 import { utils } from 'ethers'
 
 const initialVoiceCreditBalance = 100
+const STATE_TREE_DEPTH = 10
 
 describe('SignUpGatekeeper', () => {
     let signUpToken;
@@ -34,14 +35,16 @@ describe('SignUpGatekeeper', () => {
     })
 
     describe('SignUpTokenGatekeeper', () => {
-        let maciContract
+        let maciContract: any 
         beforeEach(async () => {
             freeForAllContract = await deployFreeForAllSignUpGatekeeper(true)
             signUpToken = await deploySignupToken(true)
             signUpTokenGatekeeperContract = await deploySignupTokenGatekeeper(await signUpToken.address, true)
             const r = await deployTestContracts(
                 initialVoiceCreditBalance,
-                signUpTokenGatekeeperContract,
+                STATE_TREE_DEPTH,
+                true,
+                signUpTokenGatekeeperContract
             )
 
             maciContract = r.maciContract

--- a/contracts/ts/deploy.ts
+++ b/contracts/ts/deploy.ts
@@ -309,6 +309,7 @@ const deployMaci = async (
     verifierContractAddress: string,
     vkRegistryContractAddress: string,
     topupCreditContractAddress: string,
+    stateTreeDepth: number = 10,
     quiet = false,
 ) => {
 
@@ -352,7 +353,8 @@ const deployMaci = async (
         quiet,
         pollFactoryContract.address,
         signUpTokenGatekeeperContractAddress,
-        initialVoiceCreditBalanceAddress
+        initialVoiceCreditBalanceAddress,
+        stateTreeDepth
     )
 
     log('Transferring ownership of PollFactoryContract to MACI', quiet)

--- a/contracts/ts/genEmptyBallotRootsContract.ts
+++ b/contracts/ts/genEmptyBallotRootsContract.ts
@@ -19,7 +19,7 @@ const genEmptyBallotRootsContract = (
     ).toString()
 
     // This hard-coded value should be consistent with the value of `stateTreeDepth` of MACI.sol
-    const stateTreeDepth = 10
+    const stateTreeDepth = process.argv[2] ? parseInt(process.argv[2]) : 10
 
     let r = ''
     for (let i = 1; i < 6; i ++) {

--- a/contracts/ts/genMaciState.ts
+++ b/contracts/ts/genMaciState.ts
@@ -46,10 +46,13 @@ const genMaciStateFromContract = async (
     const maciIface = new utils.Interface(maciContractAbi)
     const pollIface = new utils.Interface(pollContractAbi)
 
-    const maciState = new MaciState()
 
     // Check stateTreeDepth
     const stateTreeDepth = await maciContract.stateTreeDepth()
+    
+    // we need to pass the stateTreeDepth 
+    const maciState = new MaciState(stateTreeDepth)
+
     assert(stateTreeDepth === maciState.stateTreeDepth)
 
     // Fetch event logs

--- a/contracts/ts/utils.ts
+++ b/contracts/ts/utils.ts
@@ -4,7 +4,6 @@ interface SnarkProof {
     pi_c: bigint[];
 }
 
-import { Contract } from 'ethers';
 import {
     deployVkRegistry,
     deployTopupCredit,
@@ -36,7 +35,9 @@ const formatProofForVerifierContract = (
 
 const deployTestContracts = async (
     initialVoiceCreditBalance: number,
-    gatekeeperContract?: Contract
+    stateTreeDepth: number,
+    quiet: boolean = false,
+    gatekeeperContract?: any
 ) => {
     const mockVerifierContract = await deployMockVerifier(true)
 
@@ -59,7 +60,8 @@ const deployTestContracts = async (
         mockVerifierContract.address,
         vkRegistryContract.address,
         topupCreditContract.address,
-        true
+        stateTreeDepth,
+        quiet
     )
     const mpContract = await deployMessageProcessor(mockVerifierContract.address, poseidonAddrs[0],poseidonAddrs[1],poseidonAddrs[2],poseidonAddrs[3], true)
     const tallyContract = await deployTally(mockVerifierContract.address, poseidonAddrs[0],poseidonAddrs[1],poseidonAddrs[2],poseidonAddrs[3], true)

--- a/core/ts/__tests__/MaciState.test.ts
+++ b/core/ts/__tests__/MaciState.test.ts
@@ -1,6 +1,5 @@
 import { 
     MaciState,
-    STATE_TREE_DEPTH,
 } from '../'
 import {
     expect 
@@ -38,6 +37,8 @@ const treeDepths = {
 }
 
 const messageBatchSize = 25
+
+const STATE_TREE_DEPTH = 10
 
 const testProcessVk = new VerifyingKey(
     new G1Point(BigInt(0), BigInt(1)),
@@ -78,8 +79,13 @@ describe('MaciState', function() {
         let stateIndex
         const userKeypair = new Keypair()
 
+<<<<<<< HEAD
         before(() => {
             maciState = new MaciState()
+=======
+        beforeAll(() => {
+            maciState = new MaciState(STATE_TREE_DEPTH)
+>>>>>>> eb30332b (feat(state-tree-depth) - ensure stateTreeDepth is not hardcoded in the smart contracts and can be passed around as an argument)
             stateTree = new IncrementalQuinTree(
                 STATE_TREE_DEPTH,
                 blankStateLeafHash,
@@ -220,8 +226,13 @@ describe('MaciState', function() {
 
         const users: Keypair[] = []
 
+<<<<<<< HEAD
         before(() => {
             maciState = new MaciState()
+=======
+        beforeAll(() => {
+            maciState = new MaciState(STATE_TREE_DEPTH)
+>>>>>>> eb30332b (feat(state-tree-depth) - ensure stateTreeDepth is not hardcoded in the smart contracts and can be passed around as an argument)
             // Sign up and vote
             for (let i = 0; i < messageBatchSize - 1; i ++) {
                 const userKeypair = new Keypair()
@@ -406,8 +417,13 @@ describe('MaciState', function() {
         let m1
         const userKeypair = new Keypair()
 
+<<<<<<< HEAD
         before(() => {
             m1 = new MaciState()
+=======
+        beforeAll(() => {
+            m1 = new MaciState(STATE_TREE_DEPTH)
+>>>>>>> eb30332b (feat(state-tree-depth) - ensure stateTreeDepth is not hardcoded in the smart contracts and can be passed around as an argument)
             m1.signUp(
                 userKeypair.pubKey,
                 voiceCreditBalance,

--- a/core/ts/__tests__/MaciState.test.ts
+++ b/core/ts/__tests__/MaciState.test.ts
@@ -79,13 +79,8 @@ describe('MaciState', function() {
         let stateIndex
         const userKeypair = new Keypair()
 
-<<<<<<< HEAD
         before(() => {
-            maciState = new MaciState()
-=======
-        beforeAll(() => {
             maciState = new MaciState(STATE_TREE_DEPTH)
->>>>>>> eb30332b (feat(state-tree-depth) - ensure stateTreeDepth is not hardcoded in the smart contracts and can be passed around as an argument)
             stateTree = new IncrementalQuinTree(
                 STATE_TREE_DEPTH,
                 blankStateLeafHash,
@@ -226,13 +221,8 @@ describe('MaciState', function() {
 
         const users: Keypair[] = []
 
-<<<<<<< HEAD
         before(() => {
-            maciState = new MaciState()
-=======
-        beforeAll(() => {
             maciState = new MaciState(STATE_TREE_DEPTH)
->>>>>>> eb30332b (feat(state-tree-depth) - ensure stateTreeDepth is not hardcoded in the smart contracts and can be passed around as an argument)
             // Sign up and vote
             for (let i = 0; i < messageBatchSize - 1; i ++) {
                 const userKeypair = new Keypair()
@@ -417,13 +407,8 @@ describe('MaciState', function() {
         let m1
         const userKeypair = new Keypair()
 
-<<<<<<< HEAD
         before(() => {
-            m1 = new MaciState()
-=======
-        beforeAll(() => {
             m1 = new MaciState(STATE_TREE_DEPTH)
->>>>>>> eb30332b (feat(state-tree-depth) - ensure stateTreeDepth is not hardcoded in the smart contracts and can be passed around as an argument)
             m1.signUp(
                 userKeypair.pubKey,
                 voiceCreditBalance,

--- a/core/ts/index.ts
+++ b/core/ts/index.ts
@@ -2,7 +2,6 @@ export {
     //genPerVOSpentVoiceCreditsCommitment,
     //genSpentVoiceCreditsCommitment,
     MaciState,
-    STATE_TREE_DEPTH,
     Poll,
     genProcessVkSig,
     genTallyVkSig,

--- a/integrationTests/ts/__tests__/suitesUtils.ts
+++ b/integrationTests/ts/__tests__/suitesUtils.ts
@@ -41,7 +41,7 @@ const executeSuite = async (data: any, expect: any) => {
         const config = loadYaml()
         const coordinatorKeypair = new Keypair()
 
-        const maciState = new MaciState()
+        const maciState = new MaciState(config.constants.maci.stateTreeDepth)
 
         const deployVkRegistryCommand = `node build/index.js deployVkRegistry`
         const vkDeployOutput = exec(deployVkRegistryCommand)


### PR DESCRIPTION
We do not want to hardcode the stateTreeDepth in the smart contracts, but instead we want to pass them as arguments.

Changes:

* in the smart contract this is an immutable param thus passed in the constructor
* MaciState.ts and Poll.ts take them as constructor argument
* in tests we hardcode to 10 for the sake of testing
* contracts package.json's script `compileSol` takes an additional parameter so that we can compile the trees contracts with the correct params