### PR TITLE
docs: fix typo

### DIFF
--- a/old_specs/01_introduction.md
+++ b/old_specs/01_introduction.md
@@ -116,7 +116,7 @@ The following steps are needed to sign and encrypt a message:
 
 ## Glossary
 
-Some terms in this specification are similar to one another but should not be used interchangably. This glossary should help to resolve such ambiguities.
+Some terms in this specification are similar to one another but should not be used interchangeably. This glossary should help to resolve such ambiguities.
 
 | Term | Meaning |
 |-|-|


### PR DESCRIPTION
fix a typo in doc: interchangably-> interchangeably