### PR TITLE
Add clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
+    "clean": "lerna exec -- rm -rf node_modules build",
     "lint": "eslint './**/**/*.ts'",
     "lint-fix": "eslint './**/**/*.ts' --fix",
     "test": "lerna run test --ignore maci-common --ignore maci-server --ignore maci-integrationtests --ignore maci-cli"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "clean": "lerna exec -- rm -rf node_modules build",
+    "clean": "lerna exec -- rm -rf node_modules build && rm -rf node_modules",
     "lint": "eslint './**/**/*.ts'",
     "lint-fix": "eslint './**/**/*.ts' --fix",
     "test": "lerna run test --ignore maci-common --ignore maci-server --ignore maci-integrationtests --ignore maci-cli"


### PR DESCRIPTION
Simple script to flush out /build & /node_modules for all submodules. I've found this useful with the various refactoring work we're doing to get clean installs of dependencies