### PR TITLE
Add verifyTallyResult, verifyPerVOSpentVoiceCredits, verifySpentVoiceCredits

### DIFF
--- a/cli/ts/commands/verify.ts
+++ b/cli/ts/commands/verify.ts
@@ -120,8 +120,8 @@ export const verify = async (
 
   // verify total spent voice credits on-chain
   const isValid = await tallyContract.verifySpentVoiceCredits(
-    tallyData.totalSpentVoiceCredits.spent,
-    tallyData.totalSpentVoiceCredits.salt,
+    tallyResults.totalSpentVoiceCredits.spent,
+    tallyResults.totalSpentVoiceCredits.salt,
     newResultsCommitment,
     newPerVOSpentVoiceCreditsCommitment,
   );
@@ -134,7 +134,7 @@ export const verify = async (
   // verify per vote option voice credits on-chain
   const failedSpentCredits = await verifyPerVOSpentVoiceCredits(
     tallyContract,
-    tallyData,
+    tallyResults,
     voteOptionTreeDepth,
     newSpentVoiceCreditsCommitment,
     newResultsCommitment,
@@ -148,7 +148,7 @@ export const verify = async (
   // verify tally result on-chain for each vote option
   const failedTallyResults = await verifyTallyResults(
     tallyContract,
-    tallyData,
+    tallyResults,
     voteOptionTreeDepth,
     newSpentVoiceCreditsCommitment,
     newPerVOSpentVoiceCreditsCommitment,

--- a/cli/ts/commands/verify.ts
+++ b/cli/ts/commands/verify.ts
@@ -142,21 +142,25 @@ export const verify = async (
   if (failedSpentCredits.length === 0) {
     logGreen(quiet, success("The on-chain verification of per vote option spent voice credits passed"));
   } else {
-    logError(`These spent voice credits failed on-chain verifications ${failedSpentCredits}`);
+    logError(
+      `At least one tally result failed the on-chain verification. Please check your Tally data at these indexes: ${failedSpentCredits}`,
+    );
   }
 
   // verify tally result on-chain for each vote option
-  const failedTallyResults = await verifyTallyResults(
+  const failedPerVOSpentCredits = await verifyTallyResults(
     tallyContract,
     tallyResults,
     voteOptionTreeDepth,
     newSpentVoiceCreditsCommitment,
     newPerVOSpentVoiceCreditsCommitment,
   );
-  if (failedTallyResults.length === 0) {
+  if (failedPerVOSpentCredits.length === 0) {
     logGreen(quiet, success("The on-chain verification of tally results passed"));
   } else {
-    logError(`These tally results failed on-chain verifications ${failedTallyResults}`);
+    logError(
+      `At least one spent voice credits entry in the tally results failed the on-chain verification. Please check your tally results at these indexes: ${failedPerVOSpentCredits}`,
+    );
   }
 
   // verify subsidy result if subsidy file is provided

--- a/cli/ts/utils/verifiers.ts
+++ b/cli/ts/utils/verifiers.ts
@@ -1,0 +1,90 @@
+import { Contract } from "ethers";
+import { genTreeProof } from "maci-crypto";
+import { TallyData } from "./interfaces";
+
+/**
+ * Loop through each per vote option spent voice credits and verify it on-chain
+ *
+ * @param tallyContract The tally contract
+ * @param tallyData The tally.json file data
+ * @param voteOptionTreeDepth The vote option tree depth
+ * @param newSpentVoiceCreditsCommitment The total spent voice credits commitment
+ * @param newResultsCommitment The tally result commitment
+ *
+ * @returns list of the indexes of the tally result that failed on-chain verification
+ */
+export const verifyPerVOSpentVoiceCredits = async (
+  tallyContract: Contract,
+  tallyData: TallyData,
+  voteOptionTreeDepth: number,
+  newSpentVoiceCreditsCommitment: bigint,
+  newResultsCommitment: bigint,
+): Promise<number[]> => {
+  const failedIndices: number[] = [];
+
+  for (let i = 0; i < tallyData.perVOSpentVoiceCredits.tally.length; i += 1) {
+    const proof = genTreeProof(
+      i,
+      tallyData.perVOSpentVoiceCredits.tally.map((x) => BigInt(x)),
+      voteOptionTreeDepth,
+    );
+
+    const isValid = await tallyContract.verifyPerVOSpentVoiceCredits(
+      i,
+      tallyData.perVOSpentVoiceCredits.tally[i],
+      proof,
+      tallyData.perVOSpentVoiceCredits.salt,
+      voteOptionTreeDepth,
+      newSpentVoiceCreditsCommitment,
+      newResultsCommitment,
+    );
+    if (!isValid) {
+      failedIndices.push(i);
+    }
+  }
+
+  return failedIndices;
+};
+
+/**
+ * Loop through each tally result and verify it on-chain
+ * @param tallyContract The tally contract
+ * @param tallyData The tally.json file data
+ * @param voteOptionTreeDepth The vote option tree depth
+ * @param newSpentVoiceCreditsCommitment The total spent voice credits commitment
+ * @param newPerVOSpentVoiceCreditsCommitment The per vote option voice credits commitment
+ * @returns list of the indexes of the tally result that failed on-chain verification
+ */
+export const verifyTallyResults = async (
+  tallyContract: Contract,
+  tallyData: TallyData,
+  voteOptionTreeDepth: number,
+  newSpentVoiceCreditsCommitment: bigint,
+  newPerVOSpentVoiceCreditsCommitment: bigint,
+): Promise<number[]> => {
+  const failedIndices: number[] = [];
+
+  for (let i = 0; i < tallyData.results.tally.length; i += 1) {
+    const proof = genTreeProof(
+      i,
+      tallyData.results.tally.map((x) => BigInt(x)),
+      voteOptionTreeDepth,
+    );
+
+    const isValid = await tallyContract.verifyTallyResult(
+      i,
+      tallyData.results.tally[i],
+      proof,
+      tallyData.results.salt,
+      voteOptionTreeDepth,
+      newSpentVoiceCreditsCommitment,
+      newPerVOSpentVoiceCreditsCommitment,
+    );
+
+    if (!isValid) {
+      failedIndices.push(i);
+    }
+  }
+
+  return failedIndices;
+};

--- a/crypto/ts/index.ts
+++ b/crypto/ts/index.ts
@@ -8,6 +8,7 @@ export {
   deepCopyBigIntArray,
   calcDepthFromNumLeaves,
   genTreeCommitment,
+  genTreeProof,
 } from "./utils";
 
 export { SNARK_FIELD_SIZE, NOTHING_UP_MY_SLEEVE, babyJubMaxValue } from "./constants";

--- a/crypto/ts/utils.ts
+++ b/crypto/ts/utils.ts
@@ -58,3 +58,20 @@ export const genTreeCommitment = (leaves: bigint[], salt: bigint, depth: number)
 
   return hashLeftRight(tree.root, salt);
 };
+
+/**
+ * A helper function to generate the tree proof for the value at the given index in the leaves
+ * @param index The index of the value to generate the proof for
+ * @param leaves A list of values
+ * @param depth The tree depth
+ * @returns The proof
+ */
+export const genTreeProof = (index: number, leaves: bigint[], depth: number): bigint[][] => {
+  const tree = new IncrementalQuinTree(depth, BigInt(0), 5, hash5);
+  leaves.forEach((leaf) => {
+    tree.insert(leaf);
+  });
+
+  const proof = tree.genMerklePath(index);
+  return proof.pathElements;
+};


### PR DESCRIPTION
This PR adds the functions to the new Tally contract as I think they were accidentally removed from code refactoring as they were available in v0.10 and v1.1 (incorrect implementation, see PR #742 )

Clrfund uses these functions to verify the tally results in the tally.json file on-chain as part of the round finalization and when recipients invoke the `claimFunds` function.

Note: I moved the standalone test `deployPollWithRandomSigner.test.ts` in the `suites.test.ts` as it was failing with `nonce` error caused by running the tests in parallel.

Run the integration test suites to test the new functions:
```
cd integrationTests
npm run test
```
