### PR TITLE
fix(optimisedmt) - update package to the latest version and generate the correct d.ts file

### DIFF
--- a/crypto/package-lock.json
+++ b/crypto/package-lock.json
@@ -12,7 +12,7 @@
         "circomlib": "https://github.com/weijiekoh/circomlib.git#24ed08eee0bb613b8c0135d66c1013bd9f78d50a",
         "ethers": "^5.4.7",
         "ffjavascript": "^0.2.62",
-        "optimisedmt": "^0.0.7"
+        "optimisedmt": "^0.0.9"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.23.3",
@@ -3072,9 +3072,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.603",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.603.tgz",
-      "integrity": "sha512-Dvo5OGjnl7AZTU632dFJtWj0uJK835eeOVQIuRcmBmsFsTNn3cL05FqOyHAfGQDIoHfLhyJ1Tya3PJ0ceMz54g==",
+      "version": "1.4.605",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.605.tgz",
+      "integrity": "sha512-V52j+P5z6cdRqTjPR/bYNxx7ETCHIkm5VIGuyCy3CMrfSnbEpIlLnk5oHmZo7gYvDfh2TfHeanB6rawyQ23ktg==",
       "dev": true,
       "peer": true
     },
@@ -5707,9 +5707,9 @@
       }
     },
     "node_modules/optimisedmt": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/optimisedmt/-/optimisedmt-0.0.7.tgz",
-      "integrity": "sha512-yVlKMmP/egqiAtg12KFZxqKx35STm+RB5kSSvo9q0B0sIx/7HbWj7fJcFLUFtWzbYp2IvdOhx31s4IC7RmU5pQ==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/optimisedmt/-/optimisedmt-0.0.9.tgz",
+      "integrity": "sha512-NgpgliUnd8hY8HG3i+mUJ8n+g4zuv/GrcMQDciOZC8OEOYSiBr2gUlM/trnh28YFKKm0VInMECEOA6nr1swoEg==",
       "dependencies": {
         "assert": "^2.0.0",
         "circomlibjs": "0.0.8",

--- a/crypto/package.json
+++ b/crypto/package.json
@@ -15,7 +15,7 @@
     "circomlib": "https://github.com/weijiekoh/circomlib.git#24ed08eee0bb613b8c0135d66c1013bd9f78d50a",
     "ethers": "^5.4.7",
     "ffjavascript": "^0.2.62",
-    "optimisedmt": "^0.0.7"
+    "optimisedmt": "^0.0.9"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.3",

--- a/crypto/ts/@types/optimisedmt.d.ts
+++ b/crypto/ts/@types/optimisedmt.d.ts
@@ -2,6 +2,8 @@ declare module "optimisedmt" {
   export type Leaf = bigint;
   export type PathElements = bigint[][];
   export type Indices = number[];
+  export type FilledPath = Record<number, bigint>;
+
   interface MerkleProof {
     pathElements: PathElements;
     indices: Indices;
@@ -9,6 +11,7 @@ declare module "optimisedmt" {
     root: bigint;
     leaf: Leaf;
   }
+
   export class IncrementalTree {
     leavesPerNode: number;
 
@@ -25,37 +28,38 @@ declare module "optimisedmt" {
     zeros: bigint[];
 
     filledSubtrees: bigint[][];
-    /* eslint-disable-next-line */
-    filledPaths: any;
+
+    filledPaths: FilledPath;
 
     hashFunc: (leaves: bigint[]) => bigint;
 
     constructor(
-      _depth: number,
-      _zeroValue: bigint | number,
-      _leavesPerNode: number,
-      _hashFunc: (leaves: bigint[]) => bigint,
+      depth: number,
+      zeroValue: bigint | number,
+      leavesPerNode: number,
+      hashFunc: (leaves: bigint[]) => bigint,
     );
 
-    insert(_value: Leaf): void;
+    insert(value: Leaf): void;
 
-    update(_index: number, _value: Leaf): void;
+    update(index: number, value: Leaf): void;
 
-    getLeaf(_index: number): Leaf;
+    getLeaf(index: number): Leaf;
 
     genMerkleSubrootPath(
-      _startIndex: number, // inclusive
-      _endIndex: number,
+      startIndex: number, // inclusive
+      endIndex: number,
     ): MerkleProof;
 
-    genMerklePath(_index: number): MerkleProof;
+    genMerklePath(index: number): MerkleProof;
 
-    static verifyMerklePath(_proof: MerkleProof, _hashFunc: (leaves: bigint[]) => bigint): boolean;
+    static verifyMerklePath(proof: MerkleProof, hashFunc: (leaves: bigint[]) => bigint): boolean;
 
     copy(): IncrementalTree;
 
     equals(t: IncrementalTree): boolean;
   }
+
   export class MultiIncrementalTree {
     leavesPerNode: number;
 
@@ -74,37 +78,38 @@ declare module "optimisedmt" {
     zeros: bigint[];
 
     filledSubtrees: bigint[][][];
-    /* eslint-disable-next-line */
-    filledPaths: any[];
+
+    filledPaths: FilledPath[];
 
     hashFunc: (leaves: bigint[]) => bigint;
 
     constructor(
-      _depth: number,
-      _zeroValue: bigint | number,
-      _leavesPerNode: number,
-      _hashFunc: (leaves: bigint[]) => bigint,
+      depth: number,
+      zeroValue: bigint | number,
+      leavesPerNode: number,
+      hashFunc: (leaves: bigint[]) => bigint,
     );
 
-    insert(_value: Leaf): void;
+    insert(value: Leaf): void;
 
-    update(_absoluteIndex: number, _value: Leaf): void;
+    update(absoluteIndex: number, value: Leaf): void;
 
-    getLeaf(_index: number): Leaf;
+    getLeaf(index: number): Leaf;
 
     genMerkleSubrootPath(
-      _absoluteStartIndex: number, // inclusive
-      _absoluteEndIndex: number,
+      absoluteStartIndex: number, // inclusive
+      absoluteEndIndex: number,
     ): MerkleProof;
 
-    genMerklePath(_absoluteIndex: number): MerkleProof;
+    genMerklePath(absoluteIndex: number): MerkleProof;
 
-    static verifyMerklePath(_proof: MerkleProof, _hashFunc: (leaves: bigint[]) => bigint): boolean;
+    static verifyMerklePath(proof: MerkleProof, hashFunc: (leaves: bigint[]) => bigint): boolean;
 
     copy(): MultiIncrementalTree;
 
     equals(t: MultiIncrementalTree): boolean;
   }
+
   export class OptimisedMT {
     depth: number;
 
@@ -126,34 +131,34 @@ declare module "optimisedmt" {
 
     capacity: number;
 
-    constructor(_depth: number, _zeroValue: bigint, _leavesPerNode: number, _hashFunc: (leaves: bigint[]) => bigint);
+    constructor(depth: number, zeroValue: bigint, leavesPerNode: number, _hashFunc: (leaves: bigint[]) => bigint);
 
-    insert(_value: Leaf): void;
+    insert(value: Leaf): void;
 
-    update(_index: number, _value: Leaf): void;
+    update(index: number, value: Leaf): void;
 
-    genMerklePath(_index: number): MerkleProof;
+    genMerklePath(index: number): MerkleProof;
 
     genMerkleSubrootPath(
-      _startIndex: number, // inclusive
-      _endIndex: number,
+      startIndex: number, // inclusive
+      endIndex: number,
     ): MerkleProof;
 
-    static verifyMerklePath: (_proof: MerkleProof, _hashFunc: (leaves: bigint[]) => bigint) => boolean;
+    static verifyMerklePath: (proof: MerkleProof, hashFunc: (leaves: bigint[]) => bigint) => boolean;
 
-    getLeaf(_index: number): bigint;
+    getLeaf(index: number): bigint;
 
-    getNode(_index: number): bigint;
+    getNode(index: number): bigint;
 
-    setNode(_index: number, _value: bigint): void;
+    setNode(index: number, value: bigint): void;
 
     private getChildIndices;
 
-    static calcChildIndices(_index: number, _leavesPerNode: number, _depth: number): number[];
+    static calcChildIndices(index: number, leavesPerNode: number, depth: number): number[];
 
     private getParentIndices;
 
-    static calcParentIndices(_index: number, _leavesPerNode: number, _depth: number): number[];
+    static calcParentIndices(index: number, leavesPerNode: number, depth: number): number[];
 
     copy(): OptimisedMT;
 
@@ -172,6 +177,7 @@ declare module "optimisedmt" {
     zeros: bigint[];
     root: bigint;
   };
+
   export type MTNode = Record<number, bigint>;
   export const calculateRoot: (leaves: bigint[], arity: number, hashFunc: (leaves: bigint[]) => bigint) => bigint;
 }

--- a/crypto/ts/@types/optimisedmt.d.ts
+++ b/crypto/ts/@types/optimisedmt.d.ts
@@ -1,25 +1,177 @@
 declare module "optimisedmt" {
-  export class OptimisedMT {
+  export type Leaf = bigint;
+  export type PathElements = bigint[][];
+  export type Indices = number[];
+  interface MerkleProof {
+    pathElements: PathElements;
+    indices: Indices;
+    depth: number;
+    root: bigint;
+    leaf: Leaf;
+  }
+  export class IncrementalTree {
+    leavesPerNode: number;
+
+    depth: number;
+
+    zeroValue: bigint;
+
     root: bigint;
 
     nextIndex: number;
 
+    leaves: Leaf[];
+
+    zeros: bigint[];
+
+    filledSubtrees: bigint[][];
+    /* eslint-disable-next-line */
+    filledPaths: any;
+
+    hashFunc: (leaves: bigint[]) => bigint;
+
+    constructor(
+      _depth: number,
+      _zeroValue: bigint | number,
+      _leavesPerNode: number,
+      _hashFunc: (leaves: bigint[]) => bigint,
+    );
+
+    insert(_value: Leaf): void;
+
+    update(_index: number, _value: Leaf): void;
+
+    getLeaf(_index: number): Leaf;
+
+    genMerkleSubrootPath(
+      _startIndex: number, // inclusive
+      _endIndex: number,
+    ): MerkleProof;
+
+    genMerklePath(_index: number): MerkleProof;
+
+    static verifyMerklePath(_proof: MerkleProof, _hashFunc: (leaves: bigint[]) => bigint): boolean;
+
+    copy(): IncrementalTree;
+
+    equals(t: IncrementalTree): boolean;
+  }
+  export class MultiIncrementalTree {
+    leavesPerNode: number;
+
+    depth: number;
+
     zeroValue: bigint;
 
-    constructor(depth: number, root: bigint, degree: number, hash: (elements: bigint[]) => bigint);
+    currentTreeNum: number;
 
-    static verifyMerklePath(elements: { pathElements: bigint[] }, hash: (elements: bigint[]) => bigint): boolean;
+    roots: bigint[];
 
-    hashFunc(elements: bigint[]): bigint;
+    nextIndex: number;
 
-    insert(leaf: bigint): void;
+    leaves: Leaf[];
+
+    zeros: bigint[];
+
+    filledSubtrees: bigint[][][];
+    /* eslint-disable-next-line */
+    filledPaths: any[];
+
+    hashFunc: (leaves: bigint[]) => bigint;
+
+    constructor(
+      _depth: number,
+      _zeroValue: bigint | number,
+      _leavesPerNode: number,
+      _hashFunc: (leaves: bigint[]) => bigint,
+    );
+
+    insert(_value: Leaf): void;
+
+    update(_absoluteIndex: number, _value: Leaf): void;
+
+    getLeaf(_index: number): Leaf;
+
+    genMerkleSubrootPath(
+      _absoluteStartIndex: number, // inclusive
+      _absoluteEndIndex: number,
+    ): MerkleProof;
+
+    genMerklePath(_absoluteIndex: number): MerkleProof;
+
+    static verifyMerklePath(_proof: MerkleProof, _hashFunc: (leaves: bigint[]) => bigint): boolean;
+
+    copy(): MultiIncrementalTree;
+
+    equals(t: MultiIncrementalTree): boolean;
+  }
+  export class OptimisedMT {
+    depth: number;
+
+    zeroValue: bigint;
+
+    leavesPerNode: number;
+
+    hashFunc: (leaves: bigint[]) => bigint;
+
+    nextIndex: number;
+
+    zeros: bigint[];
+
+    root: bigint;
+
+    nodes: MTNode;
+
+    numNodes: number;
+
+    capacity: number;
+
+    constructor(_depth: number, _zeroValue: bigint, _leavesPerNode: number, _hashFunc: (leaves: bigint[]) => bigint);
+
+    insert(_value: Leaf): void;
+
+    update(_index: number, _value: Leaf): void;
+
+    genMerklePath(_index: number): MerkleProof;
+
+    genMerkleSubrootPath(
+      _startIndex: number, // inclusive
+      _endIndex: number,
+    ): MerkleProof;
+
+    static verifyMerklePath: (_proof: MerkleProof, _hashFunc: (leaves: bigint[]) => bigint) => boolean;
+
+    getLeaf(_index: number): bigint;
+
+    getNode(_index: number): bigint;
+
+    setNode(_index: number, _value: bigint): void;
+
+    private getChildIndices;
+
+    static calcChildIndices(_index: number, _leavesPerNode: number, _depth: number): number[];
+
+    private getParentIndices;
+
+    static calcParentIndices(_index: number, _leavesPerNode: number, _depth: number): number[];
 
     copy(): OptimisedMT;
 
-    update(index: number, leaf: bigint): void;
+    serialize: () => string;
 
-    genMerkleSubrootPath(start: number, end: number): { pathElements: bigint[] };
+    equals: (o: OptimisedMT) => boolean;
 
-    genMerklePath(index: number): { pathElements: bigint[] };
+    static unserialize: (s: string) => OptimisedMT;
   }
+  export const calcInitialVals: (
+    leavesPerNode: number,
+    depth: number,
+    zeroValue: bigint,
+    hashFunc: (leaves: bigint[]) => bigint,
+  ) => {
+    zeros: bigint[];
+    root: bigint;
+  };
+  export type MTNode = Record<number, bigint>;
+  export const calculateRoot: (leaves: bigint[], arity: number, hashFunc: (leaves: bigint[]) => bigint) => bigint;
 }


### PR DESCRIPTION
The version of [optimisedmt](https://github.com/weijiekoh/optimisedmt) currently in use is outdated, and the d.ts (declarations) file has some mistakes. This PR fixes these issues (fix #874) by
*  upgrading to version 0.0.9. The upgrade includes adding the `getLeaf(index: number)` and `equals()` methods
* generating a new d.ts directly from the repo's code