### PR TITLE
fix: update GH repo links to v1.1.1 tag

### DIFF
--- a/website/blog/2023-01-18-maci-v1.1.1.md
+++ b/website/blog/2023-01-18-maci-v1.1.1.md
@@ -54,7 +54,7 @@ All of these issues have been successfully resolved, on top of fixing minor issu
 | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | [Top Up Credit](https://hackmd.io/@chaosma/rkyPfI7Iq)                                                          | Users can now top up credits rather than having to sign up with a different MACI key |
 | [Pairwise Subsidy](https://ethresear.ch/t/pairwise-coordination-subsidies-a-new-quadratic-funding-design/5553) | Enhanced protection against collusion in quadratic funding                           |
-| [Coordinator Service](https://github.com/privacy-scaling-explorations/maci/tree/v1/server)                     | Sample coordinator server for easier MACI use                                        |
+| [Coordinator Service](https://github.com/privacy-scaling-explorations/maci/tree/v1.1.1/server)                 | Sample coordinator server for easier MACI use                                        |
 
 ### Top Up Credit
 
@@ -80,7 +80,7 @@ Finally, please note that currently it is not possible to generate the `zkeys` f
 
 ### Coordinator Service
 
-MACI now includes a sample [coordinator service](https://github.com/privacy-scaling-explorations/maci/tree/v1/server).
+MACI now includes a sample [coordinator service](https://github.com/privacy-scaling-explorations/maci/tree/v1.1.1/server).
 
 There are two roles in the cordinator service: admin (i.e. MACI coordinator) and user (i.e. a voter). The admin's responsibility is to ensure that the code remains updated and that the backend services are live. The user can then simply send HTTP requests to the backend server to interact with MACI, for instance, by signing up and publishing a message on chain.
 
@@ -102,13 +102,13 @@ MACI version 0.x will be discontinued. MACI 1.x has feature parity, more robust 
 
 ## How to get involved
 
-Should you wish to get involved with MACI or simply report a bug, feel free to visit the [repository](https://github.com/privacy-scaling-explorations/maci/tree/v1) and open an issue, or comment under an open issue to notify the team of your intention to work on it.
+Should you wish to get involved with MACI or simply report a bug, feel free to visit the [repository](https://github.com/privacy-scaling-explorations/maci/tree/v1.1.1) and open an issue, or comment under an open issue to notify the team of your intention to work on it.
 
 For any other enquiry, please reach out to us via the Privacy and Scaling Explorations (PSE) [Discord](https://discord.gg/bTdZfpc69U).
 
 ## References
 
-- [MACI GitHub repository](https://github.com/privacy-scaling-explorations/maci/tree/v1)
+- [MACI GitHub repository](https://github.com/privacy-scaling-explorations/maci/tree/v1.1.1)
 - [A technical introduction to MACI 1.0 - Kyle Charbonnet](https://medium.com/privacy-scaling-explorations/a-technical-introduction-to-maci-1-0-db95c3a9439a)
 - [Minimal anti-collusion infrastructure - Vitalik](https://ethresear.ch/t/minimal-anti-collusion-infrastructure/5413)
 - [Pairwise Subsidy](https://ethresear.ch/t/pairwise-coordination-subsidies-a-new-quadratic-funding-design/5553)


### PR DESCRIPTION
Current links to `https://github.com/privacy-scaling-explorations/maci/tree/v1/` are broken - looks like that tree no longer exists.

h/t to @crisgarner for reporting!
https://discord.com/channels/943612659163602974/1164613809730748507/1182043669398827059