### PR TITLE
chore: update blog slugs to kebab case

### DIFF
--- a/website/blog/2021-10-12-maci-v1.md
+++ b/website/blog/2021-10-12-maci-v1.md
@@ -1,5 +1,5 @@
 ---
-slug: MACI 1.0
+slug: maci-1-0-release
 title: MACI 1.0 Release
 authors:
   name: Koh Wei Jie

--- a/website/blog/2022-09-22-maci-v1-technical-introduction.md
+++ b/website/blog/2022-09-22-maci-v1-technical-introduction.md
@@ -1,5 +1,5 @@
 ---
-slug: MACI 1.0 Technical Introduction
+slug: maci-1-0-technical-introduction
 title: A Technical Introduction to MACI 1.0
 authors:
   name: Kyle Charbonnet

--- a/website/blog/2023-01-18-maci-v1.1.1.md
+++ b/website/blog/2023-01-18-maci-v1.1.1.md
@@ -1,5 +1,5 @@
 ---
-slug: maci v1.1.1
+slug: maci-v1-1-1-release
 title: Maci v1.1.1 Release
 authors:
   name: ctrlc03 & chao
@@ -104,7 +104,7 @@ MACI version 0.x will be discontinued. MACI 1.x has feature parity, more robust 
 
 Should you wish to get involved with MACI or simply report a bug, feel free to visit the [repository](https://github.com/privacy-scaling-explorations/maci/tree/v1) and open an issue, or comment under an open issue to notify the team of your intention to work on it.
 
-For any other enquiry, please reach out to us via the Privacy and Scaling Explorations (PSE) [Discord](https://discord.gg/bTdZfpc69U).
+For any other enquiry, please reach out to us via the Privacy and Scaling Explorations (PSE) [Discord](https://discord.gg/bTdZfpc69U).\*\*\*\*
 
 ## References
 


### PR DESCRIPTION
This is very much a subjective nitpick (I'm a bit OCD from my SEO days), so open to a discussion here...

I'd just like to adopt a simple convention for URLs. I suggest we use kebab case, so pretty much:
- Use lowercase letters
- Separate words with hyphens (don't use spaces)
- Avoid other characters (periods, underscores,etc)

I just personally hate seeing encoded spaces, e.g. 
https://maci.pse.dev/blog/MACI%201.0%20Technical%20Introduction

Thoughts?