### PR TITLE
tests(key-change): add tests and docs related to MACI's key change

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -16,7 +16,8 @@
     "postbuild": "cp package.json ./build",
     "test": "ts-mocha --exit tests/*.test.ts",
     "test:e2e": "ts-mocha --exit tests/e2e.test.ts",
-    "test:e2e-subsidy": "ts-mocha --exit tests/e2e.subsidy.test.ts"
+    "test:e2e-subsidy": "ts-mocha --exit tests/e2e.subsidy.test.ts",
+    "test:keyChange": "ts-mocha --exit tests/keyChange.test.ts"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",

--- a/cli/tests/keyChange.test.ts
+++ b/cli/tests/keyChange.test.ts
@@ -1,0 +1,326 @@
+import { isArm } from "maci-circuits";
+import {
+  deploy,
+  deployPoll,
+  deployVkRegistryContract,
+  genProofs,
+  mergeMessages,
+  mergeSignups,
+  proveOnChain,
+  publish,
+  setVerifyingKeys,
+  signup,
+  timeTravel,
+  verify,
+} from "../ts/commands";
+import {
+  INT_STATE_TREE_DEPTH,
+  MSG_BATCH_DEPTH,
+  MSG_TREE_DEPTH,
+  STATE_TREE_DEPTH,
+  VOTE_OPTION_TREE_DEPTH,
+  coordinatorPrivKey,
+  coordinatorPubKey,
+  processMessageTestZkeyPath,
+  tallyVotesTestZkeyPath,
+  testProcessMessagesWasmPath,
+  testProcessMessagesWitnessPath,
+  testProofsDirPath,
+  testRapidsnarkPath,
+  testTallyFilePath,
+  testTallyVotesWasmPath,
+  testTallyVotesWitnessPath,
+} from "./constants";
+import { Keypair } from "maci-domainobjs";
+import { cleanVanilla } from "./utils";
+import { readFileSync } from "fs";
+import { expect } from "chai";
+import { genRandomSalt } from "maci-crypto";
+import { DeployedContracts } from "../ts";
+
+describe("keyChange tests", function () {
+  const useWasm = isArm();
+  this.timeout(900000);
+
+  let maciAddresses: DeployedContracts;
+
+  // before all tests we deploy the vk registry contract and set the verifying keys
+  before(async () => {
+    // we deploy the vk registry contract
+    await deployVkRegistryContract(true);
+    // we set the verifying keys
+    await setVerifyingKeys(
+      STATE_TREE_DEPTH,
+      INT_STATE_TREE_DEPTH,
+      MSG_TREE_DEPTH,
+      VOTE_OPTION_TREE_DEPTH,
+      MSG_BATCH_DEPTH,
+      processMessageTestZkeyPath,
+      tallyVotesTestZkeyPath,
+    );
+  });
+
+  describe("keyChange and new vote (new vote has same nonce)", () => {
+    after(async () => {
+      cleanVanilla();
+    });
+    const keypair1 = new Keypair();
+    const keypair2 = new Keypair();
+    const initialNonce = 1;
+    const initialVoteOption = 0;
+    const initialVoteAmount = 9;
+    const pollId = 0;
+    let stateIndex = 0;
+    const expectedTally = initialVoteAmount - 1;
+    const expectedPerVoteOptionTally = (initialVoteAmount - 1) ** 2;
+
+    before(async () => {
+      // deploy the smart contracts
+      maciAddresses = await deploy(STATE_TREE_DEPTH);
+      // deploy a poll contract
+      await deployPoll(
+        90,
+        25,
+        25,
+        INT_STATE_TREE_DEPTH,
+        MSG_BATCH_DEPTH,
+        MSG_TREE_DEPTH,
+        VOTE_OPTION_TREE_DEPTH,
+        coordinatorPubKey,
+      );
+      stateIndex = parseInt(await signup(keypair1.pubKey.serialize()));
+      await publish(
+        keypair1.pubKey.serialize(),
+        stateIndex,
+        initialVoteOption,
+        initialNonce,
+        pollId,
+        initialVoteAmount,
+        maciAddresses.maciAddress,
+        genRandomSalt().toString(),
+        keypair1.privKey.serialize(),
+      );
+    });
+    it("should publish a message to change the user maci key and cast a new vote", async () => {
+      await publish(
+        keypair2.pubKey.serialize(),
+        stateIndex,
+        initialVoteOption,
+        initialNonce,
+        pollId,
+        initialVoteAmount - 1,
+        maciAddresses.maciAddress,
+        genRandomSalt().toString(),
+        keypair1.privKey.serialize(),
+      );
+    });
+    it("should generate zk-SNARK proofs and verify them", async () => {
+      await timeTravel(90, true);
+      await mergeMessages(0);
+      await mergeSignups(0);
+      await genProofs(
+        testProofsDirPath,
+        testTallyFilePath,
+        tallyVotesTestZkeyPath,
+        processMessageTestZkeyPath,
+        0,
+        undefined,
+        undefined,
+        testRapidsnarkPath,
+        testProcessMessagesWitnessPath,
+        testTallyVotesWitnessPath,
+        undefined,
+        coordinatorPrivKey,
+        maciAddresses.maciAddress,
+        undefined,
+        testProcessMessagesWasmPath,
+        testTallyVotesWasmPath,
+        undefined,
+        useWasm,
+      );
+      await proveOnChain("0", testProofsDirPath);
+      await verify("0", testTallyFilePath);
+    });
+    it("should confirm the tally is correct", () => {
+      const tallyData = JSON.parse(readFileSync(testTallyFilePath).toString());
+      expect(tallyData.results.tally[0]).to.equal(expectedTally.toString());
+      expect(tallyData.perVOSpentVoiceCredits.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
+    });
+  });
+
+  describe("keyChange and new vote (new vote has greater nonce and different vote option)", () => {
+    after(async () => {
+      cleanVanilla();
+    });
+    const keypair1 = new Keypair();
+    const keypair2 = new Keypair();
+    const initialNonce = 1;
+    const initialVoteOption = 0;
+    const initialVoteAmount = 9;
+    const pollId = 0;
+    let stateIndex = 0;
+    const expectedTally = initialVoteAmount;
+    const expectedPerVoteOptionTally = initialVoteAmount ** 2;
+
+    before(async () => {
+      // deploy the smart contracts
+      maciAddresses = await deploy(STATE_TREE_DEPTH);
+      // deploy a poll contract
+      await deployPoll(
+        90,
+        25,
+        25,
+        INT_STATE_TREE_DEPTH,
+        MSG_BATCH_DEPTH,
+        MSG_TREE_DEPTH,
+        VOTE_OPTION_TREE_DEPTH,
+        coordinatorPubKey,
+      );
+      stateIndex = parseInt(await signup(keypair1.pubKey.serialize()));
+      await publish(
+        keypair1.pubKey.serialize(),
+        stateIndex,
+        initialVoteOption,
+        initialNonce,
+        pollId,
+        initialVoteAmount,
+        maciAddresses.maciAddress,
+        genRandomSalt().toString(),
+        keypair1.privKey.serialize(),
+      );
+    });
+    it("should publish a message to change the user maci key and cast a new vote", async () => {
+      await publish(
+        keypair2.pubKey.serialize(),
+        stateIndex,
+        initialVoteOption + 1,
+        initialNonce + 1,
+        pollId,
+        initialVoteAmount - 1,
+        maciAddresses.maciAddress,
+        genRandomSalt().toString(),
+        keypair1.privKey.serialize(),
+      );
+    });
+    it("should generate zk-SNARK proofs and verify them", async () => {
+      await timeTravel(90, true);
+      await mergeMessages(0);
+      await mergeSignups(0);
+      await genProofs(
+        testProofsDirPath,
+        testTallyFilePath,
+        tallyVotesTestZkeyPath,
+        processMessageTestZkeyPath,
+        0,
+        undefined,
+        undefined,
+        testRapidsnarkPath,
+        testProcessMessagesWitnessPath,
+        testTallyVotesWitnessPath,
+        undefined,
+        coordinatorPrivKey,
+        maciAddresses.maciAddress,
+        undefined,
+        testProcessMessagesWasmPath,
+        testTallyVotesWasmPath,
+        undefined,
+        useWasm,
+      );
+      await proveOnChain("0", testProofsDirPath);
+      await verify("0", testTallyFilePath);
+    });
+    it("should confirm the tally is correct", () => {
+      const tallyData = JSON.parse(readFileSync(testTallyFilePath).toString());
+      expect(tallyData.results.tally[0]).to.equal(expectedTally.toString());
+      expect(tallyData.perVOSpentVoiceCredits.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
+    });
+  });
+
+  describe("keyChange and new vote (new vote has same nonce and different vote option)", () => {
+    after(async () => {
+      cleanVanilla();
+    });
+    const keypair1 = new Keypair();
+    const keypair2 = new Keypair();
+    const initialNonce = 1;
+    const initialVoteOption = 0;
+    const initialVoteAmount = 9;
+    const pollId = 0;
+    let stateIndex = 0;
+    const expectedTally = initialVoteAmount - 3;
+    const expectedPerVoteOptionTally = (initialVoteAmount - 3) ** 2;
+
+    before(async () => {
+      // deploy the smart contracts
+      maciAddresses = await deploy(STATE_TREE_DEPTH);
+      // deploy a poll contract
+      await deployPoll(
+        90,
+        25,
+        25,
+        INT_STATE_TREE_DEPTH,
+        MSG_BATCH_DEPTH,
+        MSG_TREE_DEPTH,
+        VOTE_OPTION_TREE_DEPTH,
+        coordinatorPubKey,
+      );
+      stateIndex = parseInt(await signup(keypair1.pubKey.serialize()));
+      await publish(
+        keypair1.pubKey.serialize(),
+        stateIndex,
+        initialVoteOption,
+        initialNonce,
+        pollId,
+        initialVoteAmount,
+        maciAddresses.maciAddress,
+        genRandomSalt().toString(),
+        keypair1.privKey.serialize(),
+      );
+    });
+    it("should publish a message to change the user maci key, and a new vote", async () => {
+      await publish(
+        keypair2.pubKey.serialize(),
+        stateIndex,
+        initialVoteOption + 2,
+        initialNonce,
+        pollId,
+        initialVoteAmount - 3,
+        maciAddresses.maciAddress,
+        genRandomSalt().toString(),
+        keypair1.privKey.serialize(),
+      );
+    });
+    it("should generate zk-SNARK proofs and verify them", async () => {
+      await timeTravel(90, true);
+      await mergeMessages(0);
+      await mergeSignups(0);
+      await genProofs(
+        testProofsDirPath,
+        testTallyFilePath,
+        tallyVotesTestZkeyPath,
+        processMessageTestZkeyPath,
+        0,
+        undefined,
+        undefined,
+        testRapidsnarkPath,
+        testProcessMessagesWitnessPath,
+        testTallyVotesWitnessPath,
+        undefined,
+        coordinatorPrivKey,
+        maciAddresses.maciAddress,
+        undefined,
+        testProcessMessagesWasmPath,
+        testTallyVotesWasmPath,
+        undefined,
+        useWasm,
+      );
+      await proveOnChain("0", testProofsDirPath);
+      await verify("0", testTallyFilePath);
+    });
+    it("should confirm the tally is correct", () => {
+      const tallyData = JSON.parse(readFileSync(testTallyFilePath).toString());
+      expect(tallyData.results.tally[2]).to.equal(expectedTally.toString());
+      expect(tallyData.perVOSpentVoiceCredits.tally[2]).to.equal(expectedPerVoteOptionTally.toString());
+    });
+  });
+});

--- a/website/versioned_docs/version-v1.x/key-change.md
+++ b/website/versioned_docs/version-v1.x/key-change.md
@@ -1,0 +1,182 @@
+---
+title: MACI key change
+description: How key change messages work
+sidebar_label: Key change
+sidebar_position: 15
+---
+
+# MACI Key Change
+
+MACI's voters are identified by their MACI public key. Together with their private key, they can sign and submit messages to live Polls.
+
+As MACI's main property is to provide collusion resistence in digital voting applications, it is important to have a mechanism for a user to change their voting key, should this become compromised, or they wish to revoke past actions.
+
+## How MACI messages are processed
+
+In order to understand how key changing currenctly works in MACI, we need to understand how messages are processed.
+
+After a poll ends, the coordinator processes messages off chain in reverse order. To improve efficiency, messages are processed in batches, and correctness is proved for each batch using a zk-SNARK circuit.
+
+Due to messages being processed in reverse order, key change messages would work a bit differently than if they were processed in the same order as they were submitted.
+
+## Why are messages processed in reverse order?
+
+Reverse processing was introduced to prevent a type of attack where a briber would collude with a voter to sign up, and then submit a message to change their key to a key that the briber controls. This way the briber would have assurance that they could submit the vote they want.
+
+Let's take as an example the following:
+
+1. Alice signs up with pub key $pub1$
+2. Bob (Briber) bribes Alice and asks her to submit a key change message to $pub2$ (owned by Bob)
+3. Bob submits a vote with $pub2$
+4. Alice submits a vote with $pub1$
+
+If messages were processed in the same order as they were submitted, Alice's vote would not be valid, due to it being signed with a private key $priv1$ - which now would not be valid.
+
+On the other hand, due to messages being processed in reverse order, Alice's last message would be counted as valid as the key change would have not been processed yet. Then, Bob's vote would not be counted as valid as the current key for Alice would be $pub2$.
+
+> Note that a key change message should have the nonce set to 1 in order for it to be valid. We'll see it a code example in the next sections.
+
+## Then how can a voter change their key and submit a new vote?
+
+A user, can submit a key change message, by simply sending a new message signed with their signup key, and setting the nonce to 1. This is because the code checks that the first message to be processed has the nonce set to 1.
+
+Let's take a look into a code example:
+
+> We have two users, and three keypairs
+
+- Create three keypairs
+
+```ts
+const user1Keypair = new Keypair();
+const user2Keypair = new Keypair();
+const secondKeyPair = new Keypair();
+```
+
+- Votes will be
+
+```ts
+// user1 votes for project 0
+const user1VoteOptionIndex = BigInt(0);
+// user2 votes for project 1
+const user2VoteOptionIndex = BigInt(1);
+// user1 votes 9 for the first vote
+const user1VoteWeight = BigInt(9);
+// user2 votes 3
+const user2VoteWeight = BigInt(3);
+// user1 will change their vote to 5
+const user1NewVoteWeight = BigInt(5);
+```
+
+- What do we expect as result
+
+```
+project 0 = 5 * 5 -> 25
+project 1 = 3 * 3 -> 9
+```
+
+As seen above, we expect the first vote weight 9 to not be counted, but instead the second vote weight 5 to be counted.
+
+- Deploy a MaciState locally and sign up
+
+```ts
+const maciState: MaciState = new MaciState(STATE_TREE_DEPTH);
+// Sign up
+user1StateIndex = maciState.signUp(user1Keypair.pubKey, voiceCreditBalance, BigInt(Math.floor(Date.now() / 1000)));
+user2StateIndex = maciState.signUp(user2Keypair.pubKey, voiceCreditBalance, BigInt(Math.floor(Date.now() / 1000)));
+// deploy a poll
+pollId = maciState.deployPoll(
+  duration,
+  BigInt(Math.floor(Date.now() / 1000) + duration),
+  maxValues,
+  treeDepths,
+  messageBatchSize,
+  coordinatorKeypair,
+);
+```
+
+- User1 and user2 submit their first votes
+
+```ts
+const poll = maciState.polls[pollId];
+const command1 = new PCommand(
+  BigInt(user1StateIndex),
+  user1Keypair.pubKey,
+  user1VoteOptionIndex,
+  user1VoteWeight,
+  BigInt(1),
+  BigInt(pollId),
+);
+
+const signature1 = command1.sign(user1Keypair.privKey);
+
+const ecdhKeypair1 = new Keypair();
+const sharedKey1 = Keypair.genEcdhSharedKey(ecdhKeypair1.privKey, coordinatorKeypair.pubKey);
+
+const message1 = command1.encrypt(signature1, sharedKey1);
+poll.publishMessage(message1, ecdhKeypair1.pubKey);
+
+const command2 = new PCommand(
+  BigInt(user2StateIndex),
+  user2Keypair.pubKey,
+  user2VoteOptionIndex,
+  user2VoteWeight,
+  BigInt(1),
+  BigInt(pollId),
+);
+
+const signature2 = command2.sign(user2Keypair.privKey);
+
+const ecdhKeypair2 = new Keypair();
+const sharedKey2 = Keypair.genEcdhSharedKey(ecdhKeypair2.privKey, coordinatorKeypair.pubKey);
+
+const message2 = command2.encrypt(signature2, sharedKey2);
+poll.publishMessage(message2, ecdhKeypair2.pubKey);
+```
+
+- User1 submits a key change message with the new vote
+
+```ts
+const poll = maciState.polls[pollId];
+const command = new PCommand(
+  BigInt(user1StateIndex),
+  secondKeyPair.pubKey,
+  user1VoteOptionIndex,
+  user1NewVoteWeight,
+  BigInt(1),
+  BigInt(pollId),
+);
+
+const signature = command.sign(user1Keypair.privKey);
+
+const ecdhKeypair = new Keypair();
+const sharedKey = Keypair.genEcdhSharedKey(ecdhKeypair.privKey, coordinatorKeypair.pubKey);
+
+const message = command.encrypt(signature, sharedKey);
+poll.publishMessage(message, ecdhKeypair.pubKey);
+```
+
+- We process the votes and check that the result is as expected (`user1NewVoteWeight` was 5 and `user2VoteWeight` 3)
+
+```ts
+const poll = maciState.polls[pollId];
+poll.processMessages(pollId);
+poll.tallyVotes();
+expect(poll.perVOSpentVoiceCredits[0].toString()).to.eq((user1NewVoteWeight * user1NewVoteWeight).toString());
+expect(poll.perVOSpentVoiceCredits[1].toString()).to.eq((user2VoteWeight * user2VoteWeight).toString());
+```
+
+- Finally confirm that the keypair was changed for the user1
+
+```ts
+const poll = maciState.polls[pollId];
+const stateLeaf1 = poll.stateLeaves[user1StateIndex];
+const stateLeaf2 = poll.stateLeaves[user2StateIndex];
+expect(stateLeaf1.pubKey.equals(user1SecondKeypair.pubKey)).to.eq(true);
+expect(stateLeaf2.pubKey.equals(user2Keypair.pubKey)).to.eq(true);
+```
+
+We see that is important that we set the final message (the one with the new vote) with nonce 1, as this vote would be counted as the first vote.
+
+:::info
+Tests related to key changes have been added to the [core package](https://github.com/privacy-scaling-explorations/maci/blob/dev/core/ts/__tests__/) and to the [cli package](https://github.com/privacy-scaling-explorations/maci/blob/dev/cli/tests/).
+:::

--- a/website/versioned_docs/version-v1.x/troubleshooting.md
+++ b/website/versioned_docs/version-v1.x/troubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshooting
 description: How to troubleshoot MACI's failures
 sidebar_label: Troubleshooting
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # Troubleshooting


### PR DESCRIPTION
Currently, it is not clear how the key change mechanism works (or doesn't), hence this PR aims to provide some clarification on this front, by adding docs and test cases.

This is in reference to this: https://github.com/privacy-scaling-explorations/maci/issues/717