### PR TITLE
docs(typedoc): Typedoc Indexing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "prettier-plugin-solidity": "^1.2.0",
         "solhint": "^4.0.0",
         "typedoc": "^0.25.4",
+        "typedoc-plugin-markdown": "^3.17.1",
         "typescript": "^5.3.2"
       }
     },
@@ -14530,6 +14531,18 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz",
+      "integrity": "sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.24.0"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "lerna run build",
+    "build": "lerna run build --ignore=website",
     "clean": "lerna exec -- rm -rf node_modules build && rm -rf node_modules",
     "commit": "git cz",
     "prettier": "prettier -c .",
@@ -18,7 +18,7 @@
     "test:cli": "lerna run test --scope \"maci-cli\"",
     "test:integration": "lerna run test --scope \"maci-integrationtests\"",
     "test": "lerna run test --ignore maci-integrationtests --ignore maci-cli",
-    "typedoc": "typedoc --options typedoc.json",
+    "typedoc": "typedoc --plugin typedoc-plugin-markdown --options typedoc.json",
     "prepare": "is-ci || husky install"
   },
   "author": "PSE",
@@ -48,6 +48,7 @@
     "prettier-plugin-solidity": "^1.2.0",
     "solhint": "^4.0.0",
     "typedoc": "^0.25.4",
+    "typedoc-plugin-markdown": "^3.17.1",
     "typescript": "^5.3.2"
   },
   "config": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,5 +11,5 @@
     "./circuits/**/*",
     "./integrationTests/**/*"
   ],
-  "out": "./website/static/typedoc_output/"
+  "out": "./website/typedoc/"
 }

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -19,5 +19,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-static/typedoc_output
 versioned_docs/version-v1.x/solidity-docs
+versioned_docs/version-v1.x/typedoc

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log*
 
 versioned_docs/version-v1.x/solidity-docs
 versioned_docs/version-v1.x/typedoc
+typedoc

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -97,11 +97,6 @@ const config: Config = {
           position: "left",
         },
         {
-          to: "/typedoc",
-          label: "TypeScript Docs",
-          position: "left",
-        },
-        {
           to: "/blog",
           label: "Blog",
           position: "left",

--- a/website/src/scripts/setupSolidityDocs.ts
+++ b/website/src/scripts/setupSolidityDocs.ts
@@ -1,38 +1,12 @@
 import fs from "fs";
 import path from "path";
 
+import { copyDirectory } from "./utils";
+
 // where to move the solidity doc files over
 const solidityDocDir = path.resolve(__dirname, "../../versioned_docs/version-v1.x/solidity-docs");
 // the origin folder (from the contracts package)
 const sourceDir = path.resolve(__dirname, "../../../contracts/docs");
-
-/**
- * Allow to copy a directory from source to target
- * @param source - the source directory
- * @param target - the target directory
- */
-function copyDirectory(source: string, target: string) {
-  if (!fs.existsSync(target)) {
-    fs.mkdirSync(target, { recursive: true });
-  }
-
-  if (!fs.existsSync(source)) {
-    return;
-  }
-
-  const files = fs.readdirSync(source);
-
-  files.forEach((file: string) => {
-    const sourcePath = path.join(source, file);
-    const targetPath = path.join(target, file);
-
-    if (fs.lstatSync(sourcePath).isDirectory()) {
-      copyDirectory(sourcePath, targetPath);
-    } else {
-      fs.copyFileSync(sourcePath, targetPath);
-    }
-  });
-}
 
 /**
  * Currently, Solidity docgen generates the same heading for all files.

--- a/website/src/scripts/setupTypedoc.ts
+++ b/website/src/scripts/setupTypedoc.ts
@@ -5,6 +5,10 @@ import { copyDirectory } from "./utils";
 
 const TYPEDOC_DIR = path.resolve(__dirname, "../../typedoc");
 
+/**
+ * The Typedoc tool automatically generates related documentation links in each file. The link for the introduction of MACI is initially set to `README.md` of the entire project, but this should be changed to `introduction.md`. Simultaneously, references to `modules.md` should be updated to `index.md` since it is slated to be renamed as Typedoc's homepage.
+ * @param dirName - the name of the typedoc directory
+ */
 function updateMentionFiles(dirName: string) {
   const dir = path.join(TYPEDOC_DIR, dirName);
   const files = fs.readdirSync(dir);
@@ -43,7 +47,7 @@ let versionDir = "";
 try {
   const versionContent = fs.readFileSync(versionFile, "utf8");
   if (versionContent) {
-    const versionContentJson: string[] = JSON.parse(versionContent) as string[];
+    const versionContentJson = JSON.parse(versionContent) as string[];
     versionDir = path.resolve(__dirname, `../../versioned_docs/version-${versionContentJson[0]}/typedoc`);
   }
 } catch (e) {

--- a/website/src/scripts/setupTypedoc.ts
+++ b/website/src/scripts/setupTypedoc.ts
@@ -1,42 +1,56 @@
 import fs from "fs";
 import path from "path";
 
-// Define the directory where the Typedoc HTML files are located
-const typedocDir = path.resolve(__dirname, "../../static/typedoc_output");
+import { copyDirectory } from "./utils";
 
-// Define a recursive function to find all HTML files in a directory
-function findHtmlFiles(dir: string): string[] {
-  if (!fs.existsSync(dir)) {
-    return [];
-  }
+const TYPEDOC_DIR = path.resolve(__dirname, "../../typedoc");
+
+function updateMentionFiles(dirName: string) {
+  const dir = path.join(TYPEDOC_DIR, dirName);
   const files = fs.readdirSync(dir);
-  const list: string[] = [];
-
-  files.forEach((file: string) => {
-    if (fs.statSync(path.resolve(dir, file)).isDirectory()) {
-      list.concat(findHtmlFiles(path.resolve(dir, file)));
-    } else if (file.endsWith(".html")) {
-      list.push(path.resolve(dir, file));
-    }
+  files.forEach((file) => {
+    const filename = path.join(dir, file);
+    let content = fs.readFileSync(filename, "utf8");
+    content = content.replaceAll("../README.md", "../../introduction.md");
+    content = content.replaceAll("../modules.md", "../index.md");
+    fs.writeFileSync(filename, content);
   });
-
-  return list;
 }
 
-// Find all HTML files in the Typedoc directory
-const htmlFiles = findHtmlFiles(typedocDir);
+// Remove the README.md file if exists
+const readmeFile = path.join(TYPEDOC_DIR, "README.md");
+if (fs.existsSync(readmeFile)) {
+  fs.unlinkSync(readmeFile);
+}
 
-// Go through each HTML file and add the target="_parent" attribute to the external links
-htmlFiles.forEach((file: string) => {
-  let content = fs.readFileSync(file, "utf8");
+// Rename modules.md to index.md, and change the README.md mention to ../introduction.md
+const modulesFile = path.join(TYPEDOC_DIR, "modules.md");
+if (fs.existsSync(modulesFile)) {
+  let content = fs.readFileSync(modulesFile, "utf8");
+  content = content.replaceAll("README.md", "../introduction.md");
+  fs.writeFileSync(modulesFile, content);
+  fs.renameSync(modulesFile, path.join(TYPEDOC_DIR, "index.md"));
+}
 
-  // Add the target="_parent" attribute to the external links
-  content = content.replace(/<a href="http/g, '<a target="_parent" href="http');
+// Change all ../README.md mention to ../../introduction.md, and change all ../modeuls.md mention to ../index.md
+updateMentionFiles("classes");
+updateMentionFiles("interfaces");
+updateMentionFiles("modules");
 
-  content = content.replace(
-    /<a href="\.\//g,
-    '<a target="_parent" href="https://github.com/privacy-scaling-explorations/maci/tree/dev/',
-  );
+// find the target moving directory
+const versionFile = path.resolve(__dirname, "../../versions.json");
+let versionDir = "";
+try {
+  const versionContent = fs.readFileSync(versionFile, "utf8");
+  if (versionContent) {
+    const versionContentJson: string[] = JSON.parse(versionContent) as string[];
+    versionDir = path.resolve(__dirname, `../../versioned_docs/version-${versionContentJson[0]}/typedoc`);
+  }
+} catch (e) {
+  versionDir = path.resolve(__dirname, "../../docs/typedoc");
+}
 
-  fs.writeFileSync(file, content);
-});
+// move the typedoc/ directory to target directory
+copyDirectory(TYPEDOC_DIR, versionDir);
+
+fs.rmSync(TYPEDOC_DIR, { recursive: true, force: true });

--- a/website/src/scripts/utils.ts
+++ b/website/src/scripts/utils.ts
@@ -1,0 +1,30 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Allow to copy a directory from source to target
+ * @param source - the source directory
+ * @param target - the target directory
+ */
+export function copyDirectory(source: string, target: string): void {
+  if (!fs.existsSync(target)) {
+    fs.mkdirSync(target, { recursive: true });
+  }
+
+  if (!fs.existsSync(source)) {
+    return;
+  }
+
+  const files = fs.readdirSync(source);
+
+  files.forEach((file: string) => {
+    const sourcePath = path.join(source, file);
+    const targetPath = path.join(target, file);
+
+    if (fs.lstatSync(sourcePath).isDirectory()) {
+      copyDirectory(sourcePath, targetPath);
+    } else {
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  });
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -9,7 +9,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "target": "ES2020",
-    "lib": ["es2020", "DOM"],
+    "lib": ["es2020", "DOM", "ES2021.String"],
     "experimentalDecorators": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,
@@ -30,5 +30,5 @@
     "sourceMap": true,
     "stripInternal": true
   },
-  "include": ["./src", "./docusaurus.config.ts", "./setupTypedoc.ts"]
+  "include": ["./src", "./docusaurus.config.ts"]
 }


### PR DESCRIPTION
**Description**
Try the package [docusaurus-plugin-typedoc](https://www.npmjs.com/package/docusaurus-plugin-typedoc) at the beginning, it could automatically generate markdown files for typedocs, and put them inside `doc/` folder, which is default for the **Next** version document in Docusaurus. Also the sidebar will also be auto-generated.
However, we will need to do something before we actually start or build the docusaurus:
1. replace the package folder link in `README.md` (which should be the index page of typedoc) to github links. (currently we are doing it in the `setupTypedoc.ts`, by replacing the route in html file ➡️ https://github.com/privacy-scaling-explorations/maci/blob/88bfae966ec602592691b3d3ae8ad53e4a4c9a6c/website/src/scripts/setupTypedoc.ts#L38
2. `docs/` is not the actual folder we put our documents, so will also need to move or copy the whole `typedoc/` folder to `versioned_docs/v1.x/`.

It's hard to split the command in [docusaurus-plugin-typedoc](https://www.npmjs.com/package/docusaurus-plugin-typedoc), so I instead, tried to use only [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown). I put the scripts doing the above 2 steps in the `setupTypedoc.ts` file.

But there's still a problem, that the sidebar name is not setup as **Typedoc**. I will fix it.

Also wanna ask that the if we wanna auto-generate the index page of typedoc from the `README.md`? or we wanna write our own?

Last is that should we put the generated markdown files in the repo instead of ignoring them?