### PR TITLE
docs: fix markdown syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MACI blog, resources, and documentation for developers and integrators can be fo
 https://maci.pse.dev/
 
 We welcome contributions to this project. Please join our
-[Discord server][https://discord.com/invite/sF5CT5rzrR] (in the `#🗳️-maci` channel) to discuss.
+[Discord server](https://discord.com/invite/sF5CT5rzrR) (in the `#🗳️-maci` channel) to discuss.
 
 ## Packages
 


### PR DESCRIPTION
# Description

This PR fixes markdown syntax in README.md

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](../CONTRIBUTING.md) and [code of conduct requirements](../CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847) documentation.
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
