### PR TITLE
test(ceremony): test ceremony artifacts and params

### DIFF
--- a/.github/scripts/ceremony-param-tests-c-witness.sh
+++ b/.github/scripts/ceremony-param-tests-c-witness.sh
@@ -12,13 +12,20 @@ HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js setVerifyingKeys
     --msg-tree-depth 8 \
     --vote-option-tree-depth 3 \
     --msg-batch-depth 2 \
-    --process-messages-zkey ./zkeys/processmessages_6-8-2-3_final.zkey \
-    --tally-votes-zkey ./zkeys/tallyvotes_6-2-3_final.zkey \
+    --process-messages-zkey ./zkeys/processMessages_6-8-2-3.zkey \
+    --tally-votes-zkey ./zkeys/tallyVotes_6-2-3.zkey \
     -q true
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js create -s 6 -q true
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js deployPoll \
     -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
-    -t 30 -g 25 -mv 25 -i 2 -m 8 -b 2 -v 3 -q true
+    --duration 30 \
+    --max-messages 390625 \
+    --max-vote-options 125 \
+    --int-state-tree-depth 2 \
+    --msg-tree-depth 8 \
+    --msg-batch-depth 2 \
+    --vote-option-tree-depth 3 \
+    -q true 
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js signup \
     --pubkey macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
     -q true
@@ -47,8 +54,8 @@ HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js genProofs \
     --privkey macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
     --poll-id 0 \
     --rapidsnark ~/rapidsnark/build/prover \
-    --process-zkey ./zkeys/processmessages_6-8-2-3_final.zkey \
-    --tally-zkey ./zkeys/tallyvotes_6-2-3_final.zkey \
+    --process-zkey ./zkeys/processMessages_6-8-2-3.zkey \
+    --tally-zkey ./zkeys/tallyVotes_6-2-3.zkey \
     --tally-file tally.json \
     --output proofs/ \
     --tally-witnessgen ./zkeys/tallyVotes_6-2-3 \

--- a/.github/scripts/ceremony-param-tests.sh
+++ b/.github/scripts/ceremony-param-tests.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+cd ../../cli
+
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js deployVkRegistry -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js setVerifyingKeys \
+    --state-tree-depth 6 \
+    --int-state-tree-depth 2 \
+    --msg-tree-depth 8 \
+    --vote-option-tree-depth 3 \
+    --msg-batch-depth 2 \
+    --process-messages-zkey ./zkeys/processmessages_6-8-2-3_final.zkey \
+    --tally-votes-zkey ./zkeys/tallyvotes_6-2-3_final.zkey \
+    -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js create -s 6 -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js deployPoll \
+    -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
+    -t 30 -g 25 -mv 25 -i 2 -m 8 -b 2 -v 3 -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js signup \
+    --pubkey macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
+    -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js publish \
+    --pubkey macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
+    --privkey macisk.fd7aa614ec4a82716ffc219c24fd7e7b52a2b63b5afb17e81c22fe21515539c \
+    --state-index 1 \
+    --vote-option-index 0 \
+    --new-vote-weight 9 \
+    --nonce 1 \
+    --poll-id 0 \
+    -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js publish \
+    --pubkey macipk.d5788ea6ccf1ec295df99aaef859031fe7bd359e7e03acb80eb6e8a192f2ce19 \
+    --privkey macisk.fd7aa614ec4a82716ffc219c24fd7e7b52a2b63b5afb17e81c22fe21515539c \
+    --state-index 1 \
+    --vote-option-index 1 \
+    --new-vote-weight 9 \
+    --nonce 2 \
+    --poll-id 0 \
+    -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js timeTravel -s 100 -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js mergeSignups --poll-id 0 -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js mergeMessages --poll-id 0 -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js genProofs \
+    --privkey macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
+    --poll-id 0 \
+    --rapidsnark ~/rapidsnark/build/prover \
+    --process-zkey ./zkeys/processmessages_6-8-2-3_final.zkey \
+    --tally-zkey ./zkeys/tallyvotes_6-2-3_final.zkey \
+    --tally-file tally.json \
+    --output proofs/ \
+    --tally-witnessgen ./zkeys/tallyVotes_6-2-3 \
+    --process-witnessgen ./zkeys/processMessages_6-8-2-3 \
+    -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js proveOnChain \
+    --poll-id 0 \
+    --proof-dir proofs/ \
+    -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js verify \
+    --poll-id 0 \
+    --tally-file tally.json \
+    -q true

--- a/.github/scripts/download-ceremony-artifacts.sh
+++ b/.github/scripts/download-ceremony-artifacts.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 cd ..
 mkdir -p ../cli/zkeys
 
-URL=https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v1.2.0/maci_keys_6-8-2-3_ceremony.tar.gz
+URL=https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v1.2.0/maci-ceremony-artifacts-v1.2.0.tar.gz
 DIR_NAME="maci_keys.tar.gz"
 OUT_DIR=../cli/
 

--- a/.github/scripts/download-ceremony-artifacts.sh
+++ b/.github/scripts/download-ceremony-artifacts.sh
@@ -1,0 +1,15 @@
+#!/bin/bash 
+
+set -e 
+
+cd "$(dirname "$0")"
+cd ..
+mkdir -p ../cli/zkeys
+
+URL=https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v1.2.0/maci_keys_6-8-2-3_ceremony.tar.gz
+DIR_NAME="maci_keys.tar.gz"
+OUT_DIR=../cli/
+
+echo "downloading $URL"
+curl $URL -o "$OUT_DIR/$DIR_NAME"
+tar -xvf "$OUT_DIR/$DIR_NAME" -C "$OUT_DIR"

--- a/.github/workflows/nightly-ceremony.yml
+++ b/.github/workflows/nightly-ceremony.yml
@@ -1,0 +1,54 @@
+name: Nightly Ceremony
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-with-ceremony-keys:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            build-essential \
+            libgmp-dev \
+            libsodium-dev \
+            nasm \
+            nlohmann-json3-dev
+
+      - name: Initialize Project
+        run: |
+          npm install
+          npm run bootstrap
+          npm run build
+
+      - name: Compile contracts with ceremony params and run hardhat fork
+        run: |
+          cd contracts
+          npm run compileSol 6
+          npm run hardhat &
+
+      - name: Download rapidsnark (1c137)
+        run: |
+          mkdir -p ~/rapidsnark/build
+          wget -qO ~/rapidsnark/build/prover https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/rapidsnark-linux-amd64-1c137
+          chmod +x ~/rapidsnark/build/prover
+
+      - name: Download ceremony artifacts
+        run: ./.github/scripts/download-ceremony-artifacts.sh
+
+      - name: Run tests
+        run: ./.github/scripts/ceremony-param-tests.sh
+
+      - name: Stop Hardhat
+        run: kill $(lsof -t -i:8545)

--- a/.github/workflows/nightly-ceremony.yml
+++ b/.github/workflows/nightly-ceremony.yml
@@ -1,8 +1,8 @@
 name: Nightly Ceremony
 
 on:
-  push:
-  pull_request:
+  schedule:
+    - cron: 0 0 * * *
 
 jobs:
   test-with-ceremony-keys:
@@ -10,6 +10,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: dev
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4
@@ -47,8 +49,8 @@ jobs:
       - name: Download ceremony artifacts
         run: ./.github/scripts/download-ceremony-artifacts.sh
 
-      - name: Run tests
-        run: ./.github/scripts/ceremony-param-tests.sh
+      - name: Run e2e tests
+        run: ./.github/scripts/ceremony-param-tests-c-witness.sh
 
       - name: Stop Hardhat
         run: kill $(lsof -t -i:8545)

--- a/circuits/circom/test/ceremonyParams/processMessages_test.circom
+++ b/circuits/circom/test/ceremonyParams/processMessages_test.circom
@@ -1,0 +1,10 @@
+pragma circom 2.0.0;
+include "../../processMessages.circom";
+/*
+stateTreeDepth,
+msgTreeDepth,
+msgSubTreeDepth
+voteOptionTreeDepth,
+*/
+
+component main {public [inputHash]} = ProcessMessages(6, 8, 2, 3);

--- a/circuits/circom/test/ceremonyParams/tallyVotes_test.circom
+++ b/circuits/circom/test/ceremonyParams/tallyVotes_test.circom
@@ -1,0 +1,7 @@
+pragma circom 2.0.0;
+include "../../tallyVotes.circom";
+
+component main {public [inputHash]} = TallyVotes(6, 2, 3);
+/*stateTreeDepth,*/
+/*intStateTreeDepth,*/
+/*voteOptionTreeDepth*/

--- a/circuits/package.json
+++ b/circuits/package.json
@@ -20,7 +20,8 @@
     "test-privToPubKey": "ts-mocha --exit ts/__tests__/PrivToPubKey.test.ts",
     "test-calculateTotal": "ts-mocha --exit ts/__tests__/CalculateTotal.test.ts",
     "test-processMessages": "NODE_OPTIONS=--max-old-space-size=4096 ts-mocha --exit ts/__tests__/ProcessMessages.test.ts",
-    "test-tallyVotes": "NODE_OPTIONS=--max-old-space-size=4096 ts-mocha --exit ts/__tests__/TallyVotes.test.ts"
+    "test-tallyVotes": "NODE_OPTIONS=--max-old-space-size=4096 ts-mocha --exit ts/__tests__/TallyVotes.test.ts",
+    "test-ceremonyParams": "ts-mocha --exit ts/__tests__/CeremonyParams.test.ts"
   },
   "dependencies": {
     "circomlib": "https://github.com/weijiekoh/circomlib#ac85e82c1914d47789e2032fb11ceb2cfdd38a2b",

--- a/circuits/ts/__tests__/CeremonyParams.test.ts
+++ b/circuits/ts/__tests__/CeremonyParams.test.ts
@@ -1,0 +1,285 @@
+import { MaciState, Poll, packProcessMessageSmallVals, STATE_TREE_ARITY } from "maci-core";
+import { PrivKey, Keypair, PCommand, Message, Ballot } from "maci-domainobjs";
+import { hash5, IncrementalQuinTree, stringifyBigInts, NOTHING_UP_MY_SLEEVE, AccQueue } from "maci-crypto";
+import path from "path";
+import { expect } from "chai";
+import tester from "circom_tester";
+import { generateRandomIndex, getSignal } from "./utils/utils";
+
+describe("Ceremony param tests", function () {
+  const params = {
+    // processMessages and Tally
+    stateTreeDepth: 6,
+    // processMessages
+    messageTreeDepth: 8,
+    // processMessages
+    messageBatchTreeDepth: 2,
+    // processMessages and Tally
+    voteOptionTreeDepth: 3,
+    // Tally
+    stateLeafBatchDepth: 2,
+  };
+
+  const maxValues = {
+    maxUsers: STATE_TREE_ARITY ** params.stateTreeDepth,
+    maxMessages: STATE_TREE_ARITY ** params.messageTreeDepth,
+    maxVoteOptions: STATE_TREE_ARITY ** params.voteOptionTreeDepth,
+  };
+
+  const treeDepths = {
+    intStateTreeDepth: params.messageBatchTreeDepth,
+    messageTreeDepth: params.messageTreeDepth,
+    messageTreeSubDepth: params.messageBatchTreeDepth,
+    voteOptionTreeDepth: params.voteOptionTreeDepth,
+  };
+
+  const messageBatchSize = STATE_TREE_ARITY ** params.messageBatchTreeDepth;
+
+  const voiceCreditBalance = BigInt(100);
+  const duration = 30;
+
+  const coordinatorKeypair = new Keypair();
+
+  describe("ProcessMessage circuit", function () {
+    this.timeout(900000);
+
+    let circuit: tester.WasmTester;
+    let hasherCircuit: tester.WasmTester;
+
+    before(async () => {
+      const circuitPath = path.resolve(__dirname, "../../circom/test/ceremonyParams", `processMessages_test.circom`);
+      circuit = await tester.wasm(circuitPath);
+      const hasherCircuitPath = path.resolve(__dirname, "../../circom/test/", `processMessagesInputHasher_test.circom`);
+      hasherCircuit = await tester.wasm(hasherCircuitPath);
+    });
+
+    describe("1 user, 2 messages", () => {
+      const maciState = new MaciState(params.stateTreeDepth);
+      const voteWeight = BigInt(9);
+      const voteOptionIndex = BigInt(0);
+      let stateIndex: bigint;
+      let pollId: number;
+      let poll: Poll;
+      const messages: Message[] = [];
+      const commands: PCommand[] = [];
+
+      before(async () => {
+        // Sign up and publish
+        const userKeypair = new Keypair(new PrivKey(BigInt(1)));
+        stateIndex = BigInt(
+          maciState.signUp(userKeypair.pubKey, voiceCreditBalance, BigInt(Math.floor(Date.now() / 1000))),
+        );
+
+        pollId = maciState.deployPoll(
+          BigInt(Math.floor(Date.now() / 1000) + duration),
+          maxValues,
+          treeDepths,
+          messageBatchSize,
+          coordinatorKeypair,
+        );
+
+        poll = maciState.polls[pollId];
+
+        // First command (valid)
+        const command = new PCommand(
+          stateIndex, //BigInt(1),
+          userKeypair.pubKey,
+          voteOptionIndex, // voteOptionIndex,
+          voteWeight, // vote weight
+          BigInt(2), // nonce
+          BigInt(pollId),
+        );
+
+        const signature = command.sign(userKeypair.privKey);
+
+        const ecdhKeypair = new Keypair();
+        const sharedKey = Keypair.genEcdhSharedKey(ecdhKeypair.privKey, coordinatorKeypair.pubKey);
+        const message = command.encrypt(signature, sharedKey);
+        messages.push(message);
+        commands.push(command);
+
+        poll.publishMessage(message, ecdhKeypair.pubKey);
+
+        // Second command (valid)
+        const command2 = new PCommand(
+          stateIndex,
+          userKeypair.pubKey,
+          voteOptionIndex, // voteOptionIndex,
+          BigInt(1), // vote weight
+          BigInt(1), // nonce
+          BigInt(pollId),
+        );
+        const signature2 = command2.sign(userKeypair.privKey);
+
+        const ecdhKeypair2 = new Keypair();
+        const sharedKey2 = Keypair.genEcdhSharedKey(ecdhKeypair2.privKey, coordinatorKeypair.pubKey);
+        const message2 = command2.encrypt(signature2, sharedKey2);
+        messages.push(message2);
+        commands.push(command2);
+        poll.publishMessage(message2, ecdhKeypair2.pubKey);
+
+        // Use the accumulator queue to compare the root of the message tree
+        const accumulatorQueue: AccQueue = new AccQueue(
+          params.messageTreeDepth,
+          STATE_TREE_ARITY,
+          NOTHING_UP_MY_SLEEVE,
+        );
+        accumulatorQueue.enqueue(message.hash(ecdhKeypair.pubKey));
+        accumulatorQueue.enqueue(message2.hash(ecdhKeypair2.pubKey));
+        accumulatorQueue.mergeSubRoots(0);
+        accumulatorQueue.merge(params.messageTreeDepth);
+
+        expect(poll.messageTree.root.toString()).to.be.eq(
+          accumulatorQueue.mainRoots[params.messageTreeDepth].toString(),
+        );
+      });
+
+      it("should produce the correct state root and ballot root", async () => {
+        // The current roots
+        const emptyBallot = new Ballot(poll.maxValues.maxVoteOptions, poll.treeDepths.voteOptionTreeDepth);
+        const emptyBallotHash = emptyBallot.hash();
+        const ballotTree = new IncrementalQuinTree(params.stateTreeDepth, emptyBallot.hash(), STATE_TREE_ARITY, hash5);
+        ballotTree.insert(emptyBallot.hash());
+
+        for (let i = 0; i < poll.stateLeaves.length; i++) {
+          ballotTree.insert(emptyBallotHash);
+        }
+
+        const currentStateRoot = maciState.stateTree.root;
+        const currentBallotRoot = ballotTree.root;
+
+        const generatedInputs = poll.processMessages(pollId);
+
+        // Calculate the witness
+        const witness = await circuit.calculateWitness(generatedInputs, true);
+        await circuit.checkConstraints(witness);
+
+        // The new roots, which should differ, since at least one of the
+        // messages modified a Ballot or State Leaf
+        const newStateRoot = poll.stateTree.root;
+        const newBallotRoot = poll.ballotTree.root;
+
+        expect(newStateRoot.toString()).not.to.be.eq(currentStateRoot.toString());
+        expect(newBallotRoot.toString()).not.to.be.eq(currentBallotRoot.toString());
+
+        const packedVals = packProcessMessageSmallVals(
+          BigInt(maxValues.maxVoteOptions),
+          BigInt(poll.maciStateRef.numSignUps),
+          0,
+          2,
+        );
+
+        // Test the ProcessMessagesInputHasher circuit
+        const hasherCircuitInputs = stringifyBigInts({
+          packedVals,
+          coordPubKey: generatedInputs.coordPubKey,
+          msgRoot: generatedInputs.msgRoot,
+          currentSbCommitment: generatedInputs.currentSbCommitment,
+          newSbCommitment: generatedInputs.newSbCommitment,
+          pollEndTimestamp: generatedInputs.pollEndTimestamp,
+        });
+
+        const hasherWitness = await hasherCircuit.calculateWitness(hasherCircuitInputs, true);
+        await hasherCircuit.checkConstraints(hasherWitness);
+        const hash = await getSignal(hasherCircuit, hasherWitness, "hash");
+        expect(hash.toString()).to.be.eq(generatedInputs.inputHash.toString());
+      });
+    });
+
+    describe("TallyVotes circuit", function () {
+      this.timeout(900000);
+
+      let circuit: tester.WasmTester;
+
+      before(async () => {
+        const circuitPath = path.resolve(__dirname, "../../circom/test/ceremonyParams", `tallyVotes_test.circom`);
+        circuit = await tester.wasm(circuitPath);
+      });
+
+      describe("1 user, 2 messages", () => {
+        let stateIndex: bigint;
+        let pollId: number;
+        let poll: Poll;
+        let maciState: MaciState;
+        const voteWeight = BigInt(9);
+        const voteOptionIndex = BigInt(0);
+
+        beforeEach(async () => {
+          maciState = new MaciState(params.stateTreeDepth);
+          const messages: Message[] = [];
+          const commands: PCommand[] = [];
+          // Sign up and publish
+          const userKeypair = new Keypair();
+          stateIndex = BigInt(
+            maciState.signUp(userKeypair.pubKey, voiceCreditBalance, BigInt(Math.floor(Date.now() / 1000))),
+          );
+
+          pollId = maciState.deployPoll(
+            BigInt(Math.floor(Date.now() / 1000) + duration),
+            maxValues,
+            treeDepths,
+            messageBatchSize,
+            coordinatorKeypair,
+          );
+
+          poll = maciState.polls[pollId];
+
+          // First command (valid)
+          const command = new PCommand(
+            stateIndex,
+            userKeypair.pubKey,
+            voteOptionIndex, // voteOptionIndex,
+            voteWeight, // vote weight
+            BigInt(1), // nonce
+            BigInt(pollId),
+          );
+
+          const signature = command.sign(userKeypair.privKey);
+
+          const ecdhKeypair = new Keypair();
+          const sharedKey = Keypair.genEcdhSharedKey(ecdhKeypair.privKey, coordinatorKeypair.pubKey);
+          const message = command.encrypt(signature, sharedKey);
+          messages.push(message);
+          commands.push(command);
+
+          poll.publishMessage(message, ecdhKeypair.pubKey);
+          // Use the accumulator queue to compare the root of the message tree
+          const accumulatorQueue: AccQueue = new AccQueue(
+            params.messageTreeDepth,
+            STATE_TREE_ARITY,
+            NOTHING_UP_MY_SLEEVE,
+          );
+          accumulatorQueue.enqueue(message.hash(ecdhKeypair.pubKey));
+          accumulatorQueue.mergeSubRoots(0);
+          accumulatorQueue.merge(params.messageTreeDepth);
+
+          expect(poll.messageTree.root.toString()).to.be.eq(
+            accumulatorQueue.mainRoots[params.messageTreeDepth].toString(),
+          );
+          // Process messages
+          poll.processMessages(pollId);
+        });
+
+        it("should produce the correct result commitments", async () => {
+          const generatedInputs = poll.tallyVotes();
+          const witness = await circuit.calculateWitness(generatedInputs);
+          await circuit.checkConstraints(witness);
+        });
+
+        it("should produce the correct result if the inital tally is not zero", async () => {
+          const generatedInputs = poll.tallyVotes();
+
+          // Start the tally from non-zero value
+          let randIdx = generateRandomIndex(Object.keys(generatedInputs).length);
+          while (randIdx === 0) {
+            randIdx = generateRandomIndex(Object.keys(generatedInputs).length);
+          }
+
+          generatedInputs.currentResults[randIdx] = "1";
+          const witness = await circuit.calculateWitness(generatedInputs);
+          await circuit.checkConstraints(witness);
+        });
+      });
+    });
+  });
+});

--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -174,7 +174,7 @@ export const genProofs = async (
   // check that the main root is set
   const mainRoot = (await messageAqContract.getMainRoot(messageTreeDepth.toString())).toString();
   if (mainRoot === "0")
-    logError("The message tree has not been merged yet. " + "Please use the mergeMessages subcommmand to do so.");
+    logError("The message tree has not been merged yet. Please use the mergeMessages subcommmand to do so.");
 
   let maciState: MaciState;
   if (stateFile) {
@@ -223,7 +223,6 @@ export const genProofs = async (
   while (poll.hasUnprocessedMessages()) {
     // process messages in batches
     const circuitInputs = poll.processMessages(pollId);
-
     try {
       // generate the proof for this batch
       const r = await genProof({

--- a/cli/ts/commands/setVerifyingKeys.ts
+++ b/cli/ts/commands/setVerifyingKeys.ts
@@ -65,7 +65,7 @@ export const setVerifyingKeys = async (
   if (stateTreeDepth < intStateTreeDepth) logError("Invalid state tree depth or intermediate state tree depth");
 
   // Check the pm zkey filename against specified params
-  const pmMatch = processMessagesZkeyPath.match(/.+_(\d+)-(\d+)-(\d+)-(\d+)_/);
+  const pmMatch = processMessagesZkeyPath.match(/.+_(\d+)-(\d+)-(\d+)-(\d+)/);
   if (!pmMatch) logError(`${processMessagesZkeyPath} has an invalid filename`);
 
   const pmStateTreeDepth = Number(pmMatch[1]);
@@ -73,7 +73,7 @@ export const setVerifyingKeys = async (
   const pmMsgBatchDepth = Number(pmMatch[3]);
   const pmVoteOptionTreeDepth = Number(pmMatch[4]);
 
-  const tvMatch = tallyVotesZkeyPath.match(/.+_(\d+)-(\d+)-(\d+)_/);
+  const tvMatch = tallyVotesZkeyPath.match(/.+_(\d+)-(\d+)-(\d+)/);
   if (!tvMatch) logError(`${tallyVotesZkeyPath} has an invalid filename`);
 
   const tvStateTreeDepth = Number(tvMatch[1]);
@@ -114,7 +114,7 @@ export const setVerifyingKeys = async (
 
   // do the same for the subsidy vk if any
   if (subsidyZkeyPath) {
-    const ssMatch = subsidyZkeyPath.match(/.+_(\d+)-(\d+)-(\d+)_/);
+    const ssMatch = subsidyZkeyPath.match(/.+_(\d+)-(\d+)-(\d+)/);
     if (!ssMatch) logError(`${subsidyZkeyPath} has an invalid filename`);
 
     const ssStateTreeDepth = Number(ssMatch[1]);

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -352,6 +352,7 @@ program
       await verify(
         cmdObj.pollId,
         cmdObj.tallyFile,
+        undefined,
         cmdObj.contract,
         cmdObj.tallyContract,
         cmdObj.subsidyContract,


### PR DESCRIPTION
# Description

This PR adds a new CI workflow that can be used to run certain e2e tests with the process messages and tally votes zkeys generated during MACI's v1 trusted setup ceremony.

It also adds tests which use the params used in the ceremony (6,8,2,3 and 6,2,3) both e2e and on the circuits package

## Related issue(s)

fix #840 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](../CONTRIBUTING.md) and [code of conduct requirements](../CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847) documentation.
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
