### PR TITLE
feat(proofs): add preferred witness type in circuit's genProof function

### DIFF
--- a/circuits/ts/index.ts
+++ b/circuits/ts/index.ts
@@ -1,2 +1,2 @@
 export { genProof, verifyProof, extractVk } from "./proofs";
-export { isArm, cleanThreads } from "./utils";
+export { cleanThreads } from "./utils";

--- a/circuits/ts/types.ts
+++ b/circuits/ts/types.ts
@@ -6,6 +6,7 @@ import type { CircuitInputs } from "maci-core";
 export interface IGenProofOptions {
   inputs: CircuitInputs;
   zkeyPath: string;
+  useWasm?: boolean;
   rapidsnarkExePath?: string;
   witnessExePath?: string;
   wasmPath?: string;

--- a/cli/tests/e2e.subsidy.test.ts
+++ b/cli/tests/e2e.subsidy.test.ts
@@ -39,8 +39,7 @@ import {
   testTallyVotesWasmPath,
   testTallyVotesWitnessPath,
 } from "./constants";
-import { cleanSubsidy } from "./utils";
-import { isArm } from "maci-circuits";
+import { cleanSubsidy, isArm } from "./utils";
 import { genRandomSalt } from "maci-crypto";
 import { DeployedContracts, PollContracts } from "../ts/utils";
 

--- a/cli/tests/e2e.test.ts
+++ b/cli/tests/e2e.test.ts
@@ -36,8 +36,7 @@ import {
   testTallyVotesWasmPath,
   testTallyVotesWitnessPath,
 } from "./constants";
-import { cleanVanilla } from "./utils";
-import { isArm } from "maci-circuits";
+import { cleanVanilla, isArm } from "./utils";
 import { DeployedContracts, PollContracts } from "../ts/utils";
 import { Keypair } from "maci-domainobjs";
 import { genRandomSalt } from "maci-crypto";

--- a/cli/tests/keyChange.test.ts
+++ b/cli/tests/keyChange.test.ts
@@ -1,4 +1,3 @@
-import { isArm } from "maci-circuits";
 import {
   deploy,
   deployPoll,
@@ -32,7 +31,7 @@ import {
   testTallyVotesWitnessPath,
 } from "./constants";
 import { Keypair } from "maci-domainobjs";
-import { cleanVanilla } from "./utils";
+import { cleanVanilla, isArm } from "./utils";
 import { readFileSync } from "fs";
 import { expect } from "chai";
 import { genRandomSalt } from "maci-crypto";

--- a/cli/tests/utils.ts
+++ b/cli/tests/utils.ts
@@ -1,5 +1,7 @@
 import { existsSync, readdirSync, rmSync } from "fs";
-import { join } from "path";
+import { arch } from "os";
+
+import path from "path";
 
 /**
  * Test utility to clean up the proofs directory
@@ -8,7 +10,7 @@ import { join } from "path";
 export const cleanVanilla = () => {
   const files = readdirSync("./proofs");
   for (const file of files) {
-    rmSync(join("./proofs", file));
+    rmSync(path.join("./proofs", file));
   }
   if (existsSync("./tally.json")) rmSync("./tally.json");
 };
@@ -20,4 +22,12 @@ export const cleanVanilla = () => {
 export const cleanSubsidy = () => {
   cleanVanilla();
   if (existsSync("./subsidy.json")) rmSync("./subsidy.json");
+};
+
+/**
+ * Check if we are running on an arm chip
+ * @returns whether we are running on an arm chip
+ */
+export const isArm = (): boolean => {
+  return arch().includes("arm");
 };

--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -228,6 +228,7 @@ export const genProofs = async (
       const r = await genProof({
         inputs: circuitInputs,
         zkeyPath: processZkey,
+        useWasm,
         rapidsnarkExePath: rapidsnark,
         witnessExePath: processWitgen,
         wasmPath: processWasm,
@@ -287,6 +288,7 @@ export const genProofs = async (
         const r = await genProof({
           inputs: subsidyCircuitInputs,
           zkeyPath: subsidyZkey,
+          useWasm,
           rapidsnarkExePath: rapidsnark,
           witnessExePath: subsidyWitgen,
           wasmPath: subsidyWasm,
@@ -350,6 +352,7 @@ export const genProofs = async (
       const r = await genProof({
         inputs: tallyCircuitInputs,
         zkeyPath: tallyZkey,
+        useWasm,
         rapidsnarkExePath: rapidsnark,
         witnessExePath: tallyWitgen,
         wasmPath: tallyWasm,


### PR DESCRIPTION
# Description

Remove `isArm` check in circuits and instead accept a parameter to decide which witness type to use. Made appropriate changes in tests and cli. 

This allows to use wasm witness in an intel chip as well should this be preferred.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](../CONTRIBUTING.md) and [code of conduct requirements](../CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847) documentation.
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
