### PR TITLE
test(crypto): add a test to verify that the keypair generation does not fail

### DIFF
--- a/crypto/ts/__tests__/Crypto.test.ts
+++ b/crypto/ts/__tests__/Crypto.test.ts
@@ -195,4 +195,15 @@ describe("Cryptographic operations", function test() {
       expect(commitment).to.eq(commitment2);
     });
   });
+
+  describe("genKeypair", () => {
+    it("should consistently generate a valid keypair (500 runs)", () => {
+      for (let i = 0; i < 500; i += 1) {
+        const key = genKeypair();
+        expect(key.privKey < SNARK_FIELD_SIZE).to.eq(true);
+        expect(key.pubKey[0] < SNARK_FIELD_SIZE).to.eq(true);
+        expect(key.pubKey[1] < SNARK_FIELD_SIZE).to.eq(true);
+      }
+    });
+  });
 });


### PR DESCRIPTION
# Description

Add a test case which attemps to generate a new MACI keypair 500 times in a row to check whether issue #239 still applies to the current codebase.


TODO: 

- [ ] test in a browser app

## Related issue(s)

fix #239 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](../CONTRIBUTING.md) and [code of conduct requirements](../CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847) documentation.
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
