### PR TITLE
fix(signups): ensure we account for the blank state leaf

### DIFF
--- a/cli/ts/commands/proveOnChain.ts
+++ b/cli/ts/commands/proveOnChain.ts
@@ -303,12 +303,11 @@ export const proveOnChain = async (
   if (Object.keys(data.subsidyProofs).length !== 0) {
     let rbi = Number(await subsidyContract.rbi());
     let cbi = Number(await subsidyContract.cbi());
-    const numLeaves = numSignUps + 1;
-    const num1DBatches = Math.ceil(numLeaves / subsidyBatchSize);
+    const num1DBatches = Math.ceil(numSignUps / subsidyBatchSize);
     let subsidyBatchNum = rbi * num1DBatches + cbi;
     const totalBatchNum = (num1DBatches * (num1DBatches + 1)) / 2;
 
-    logYellow(quiet, info(`number of subsidy batch processed: ${subsidyBatchNum}, numleaf=${numLeaves}`));
+    logYellow(quiet, info(`number of subsidy batch processed: ${subsidyBatchNum}, numleaf=${numSignUps}`));
 
     // process all batches
     for (let i = subsidyBatchNum; i < totalBatchNum; i++) {
@@ -373,7 +372,11 @@ export const proveOnChain = async (
   }
 
   // vote tallying proofs
-  const totalTallyBatches = numSignUps < tallyBatchSize ? 1 : Math.floor(numSignUps / tallyBatchSize) + 1;
+  const totalTallyBatches =
+    numSignUps % tallyBatchSize === 0
+      ? Math.floor(numSignUps / tallyBatchSize)
+      : Math.floor(numSignUps / tallyBatchSize) + 1;
+
   let tallyBatchNum = Number(await tallyContract.tallyBatchNum());
 
   if (tallyBatchNum < totalTallyBatches) logYellow(quiet, info("Submitting proofs of vote tallying..."));

--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -101,6 +101,12 @@ contract MACI is IMACI, DomainObjs, Params, Utilities, Ownable {
     stateAq = new AccQueueQuinaryBlankSl(STATE_TREE_SUBDEPTH);
     stateAq.enqueue(BLANK_STATE_LEAF_HASH);
 
+    // because we add a blank leaf we need to count one signup
+    // so we don't allow max + 1
+    unchecked {
+      numSignUps++;
+    }
+
     pollFactory = _pollFactory;
     topupCredit = _topupCredit;
     signUpGatekeeper = _signUpGatekeeper;

--- a/contracts/contracts/Subsidy.sol
+++ b/contracts/contracts/Subsidy.sol
@@ -103,10 +103,9 @@ contract Subsidy is Ownable, CommonUtilities, Hasher, SnarkCommon {
     uint256 subsidyBatchSize = uint256(treeArity) ** intStateTreeDepth;
 
     (uint256 numSignUps, ) = _poll.numSignUpsAndMessages();
-    uint256 numLeaves = numSignUps + 1;
 
     // Require that there are unfinished ballots left
-    if (rbi * subsidyBatchSize > numLeaves) {
+    if (rbi * subsidyBatchSize > numSignUps) {
       revert AllSubsidyCalculated();
     }
 
@@ -115,7 +114,7 @@ contract Subsidy is Ownable, CommonUtilities, Hasher, SnarkCommon {
       revert InvalidSubsidyProof();
     }
     subsidyCommitment = _newSubsidyCommitment;
-    increaseSubsidyIndex(subsidyBatchSize, numLeaves);
+    increaseSubsidyIndex(subsidyBatchSize, numSignUps);
   }
 
   /// @notice Increase the subsidy batch index (rbi, cbi) to next,

--- a/contracts/tests/MACI.test.ts
+++ b/contracts/tests/MACI.test.ts
@@ -121,7 +121,8 @@ describe("MACI", () => {
       const maci = (await deployTestContracts(initialVoiceCreditBalance, stateTreeDepthTest, signer, true))
         .maciContract;
       const keypair = new Keypair();
-      for (let i = 0; i < maxUsers; i += 1) {
+      // start from one as we already have one signup (blank state leaf)
+      for (let i = 1; i < maxUsers; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await maci.signUp(
           keypair.pubKey.asContractParam(),

--- a/core/ts/MaciState.ts
+++ b/core/ts/MaciState.ts
@@ -39,6 +39,9 @@ export class MaciState implements IMaciState {
     // we put a blank state leaf to prevent a DoS attack
     this.stateLeaves.push(blankStateLeaf);
     this.stateTree.insert(blankStateLeafHash);
+    // we need to increase the number of signups by one given
+    // that we already added the blank leaf
+    this.numSignUps += 1;
   }
 
   /**


### PR DESCRIPTION
# Description

currently the blank state leaf is not counted as one signup, and thus we could go over the supported amount of signups (based on the circuits parameters) by 1, potentially preventing one voters' votes from being tallied
## Additional Notes

## Related issue(s)

fix #947

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
