### PR TITLE
chore: ignore dependabot commit messages for linting

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  ignores: [(message) => /Signed-off-by: dependabot\[bot]/m.test(message)],
 };


### PR DESCRIPTION
# Description

No need to lint commit messages for dependabot

## Additional Notes

N/A

## Related issue(s)

Related to #793 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
