### PR TITLE
fix(nightly): add back snarkjs to cli as dev dependency and fix poll duration

### DIFF
--- a/.github/scripts/ceremony-param-tests-c-witness.sh
+++ b/.github/scripts/ceremony-param-tests-c-witness.sh
@@ -18,7 +18,7 @@ HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js setVerifyingKeys
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js create -s 6 -q true
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js deployPoll \
     -pk macipk.ea638a3366ed91f2e955110888573861f7c0fc0bb5fb8b8dca9cd7a08d7d6b93 \
-    --duration 30 \
+    --duration 300 \
     --max-messages 390625 \
     --max-vote-options 125 \
     --int-state-tree-depth 2 \
@@ -47,7 +47,7 @@ HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js publish \
     --nonce 2 \
     --poll-id 0 \
     -q true
-HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js timeTravel -s 100 -q true
+HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js timeTravel -s 300 -q true
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js mergeSignups --poll-id 0 -q true
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js mergeMessages --poll-id 0 -q true
 HARDHAT_CONFIG=./build/hardhat.config.js node build/ts/index.js genProofs \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Publish Project
         run: |
           # Prevent `git commit error` when running `lerna version`
-          # It will not pushed to GitHub. It is ephemeral
+          # It creates an ephemeral commit that will not be pushed to GitHub
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -20,8 +20,7 @@
         "maci-core": "^1.1.2",
         "maci-crypto": "^1.1.2",
         "maci-domainobjs": "^1.1.2",
-        "prompt": "^1.3.0",
-        "zkey-manager": "^0.1.1"
+        "prompt": "^1.3.0"
       },
       "bin": {
         "maci-cli": "build/ts/index.js"
@@ -34,8 +33,10 @@
         "chai": "^4.3.10",
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
+        "snarkjs": "^0.7.2",
         "ts-mocha": "^10.0.0",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.2",
+        "zkey-manager": "^0.1.2"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -3551,32 +3552,26 @@
       }
     },
     "node_modules/circom_runtime": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.21.tgz",
-      "integrity": "sha512-qTkud630B/GK8y76hnOaaS1aNuF6prfV0dTrkeRsiJKnlP1ryQbP2FWLgDOPqn6aKyaPlam+Z+DTbBhkEzh8dA==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.24.tgz",
+      "integrity": "sha512-H7/7I2J/cBmRnZm9docOCGhfxzS61BEm4TMCWcrZGsWNBQhePNfQq88Oj2XpUfzmBTCd8pRvRb3Mvazt3TMrJw==",
+      "dev": true,
       "dependencies": {
-        "ffjavascript": "0.2.56"
+        "ffjavascript": "0.2.60"
       },
       "bin": {
         "calcwit": "calcwit.js"
       }
     },
     "node_modules/circom_runtime/node_modules/ffjavascript": {
-      "version": "0.2.56",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
-      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
+      "version": "0.2.60",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.60.tgz",
+      "integrity": "sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==",
+      "dev": true,
       "dependencies": {
         "wasmbuilder": "0.0.16",
-        "wasmcurves": "0.2.0",
+        "wasmcurves": "0.2.2",
         "web-worker": "^1.2.0"
-      }
-    },
-    "node_modules/circom_runtime/node_modules/wasmcurves": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
-      "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
-      "dependencies": {
-        "wasmbuilder": "0.0.16"
       }
     },
     "node_modules/circom/node_modules/ansi-colors": {
@@ -7798,11 +7793,71 @@
         "tmp": "^0.2.1"
       }
     },
+    "node_modules/maci-circuits/node_modules/circom_runtime": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.21.tgz",
+      "integrity": "sha512-qTkud630B/GK8y76hnOaaS1aNuF6prfV0dTrkeRsiJKnlP1ryQbP2FWLgDOPqn6aKyaPlam+Z+DTbBhkEzh8dA==",
+      "dependencies": {
+        "ffjavascript": "0.2.56"
+      },
+      "bin": {
+        "calcwit": "calcwit.js"
+      }
+    },
     "node_modules/maci-circuits/node_modules/circomlib": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/weijiekoh/circomlib.git#ac85e82c1914d47789e2032fb11ceb2cfdd38a2b",
       "integrity": "sha512-z8hPfwbTop2nTOraRIftp/fRnTPZ9HBIwt001v5keaAVNCgB3WYPV/OxJ10eSpGc8ZYyDDYcgzwgv/eOWYCAog==",
       "license": "GPL-3.0"
+    },
+    "node_modules/maci-circuits/node_modules/ffjavascript": {
+      "version": "0.2.56",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
+      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
+        "web-worker": "^1.2.0"
+      }
+    },
+    "node_modules/maci-circuits/node_modules/r1csfile": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.41.tgz",
+      "integrity": "sha512-Q1WDF3u1vYeAwjHo4YuddkA8Aq0TulbKjmGm99+Atn13Lf5fTsMZBnBV9T741w8iSyPFG6Uh6sapQby77sREqA==",
+      "dependencies": {
+        "@iden3/bigarray": "0.0.2",
+        "@iden3/binfileutils": "0.0.11",
+        "fastfile": "0.0.20",
+        "ffjavascript": "0.2.56"
+      }
+    },
+    "node_modules/maci-circuits/node_modules/snarkjs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.5.0.tgz",
+      "integrity": "sha512-KWz8mZ2Y+6wvn6GGkQo6/ZlKwETdAGohd40Lzpwp5TUZCn6N6O4Az1SuX1rw/qREGL6Im+ycb19suCFE8/xaKA==",
+      "dependencies": {
+        "@iden3/binfileutils": "0.0.11",
+        "bfj": "^7.0.2",
+        "blake2b-wasm": "^2.4.0",
+        "circom_runtime": "0.1.21",
+        "ejs": "^3.1.6",
+        "fastfile": "0.0.20",
+        "ffjavascript": "0.2.56",
+        "js-sha3": "^0.8.0",
+        "logplease": "^1.2.15",
+        "r1csfile": "0.0.41"
+      },
+      "bin": {
+        "snarkjs": "build/cli.cjs"
+      }
+    },
+    "node_modules/maci-circuits/node_modules/wasmcurves": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
+      "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16"
+      }
     },
     "node_modules/maci-contracts": {
       "version": "1.1.2",
@@ -9532,32 +9587,26 @@
       }
     },
     "node_modules/r1csfile": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.41.tgz",
-      "integrity": "sha512-Q1WDF3u1vYeAwjHo4YuddkA8Aq0TulbKjmGm99+Atn13Lf5fTsMZBnBV9T741w8iSyPFG6Uh6sapQby77sREqA==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.47.tgz",
+      "integrity": "sha512-oI4mAwuh1WwuFg95eJDNDDL8hCaZkwnPuNZrQdLBWvDoRU7EG+L/MOHL7SwPW2Y+ZuYcTLpj3rBkgllBQZN/JA==",
+      "dev": true,
       "dependencies": {
         "@iden3/bigarray": "0.0.2",
         "@iden3/binfileutils": "0.0.11",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.56"
+        "ffjavascript": "0.2.60"
       }
     },
     "node_modules/r1csfile/node_modules/ffjavascript": {
-      "version": "0.2.56",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
-      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
+      "version": "0.2.60",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.60.tgz",
+      "integrity": "sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==",
+      "dev": true,
       "dependencies": {
         "wasmbuilder": "0.0.16",
-        "wasmcurves": "0.2.0",
+        "wasmcurves": "0.2.2",
         "web-worker": "^1.2.0"
-      }
-    },
-    "node_modules/r1csfile/node_modules/wasmcurves": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
-      "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
-      "dependencies": {
-        "wasmbuilder": "0.0.16"
       }
     },
     "node_modules/randombytes": {
@@ -9628,7 +9677,8 @@
     "node_modules/readline": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
+      "dev": true
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
@@ -10417,41 +10467,24 @@
       }
     },
     "node_modules/snarkjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.5.0.tgz",
-      "integrity": "sha512-KWz8mZ2Y+6wvn6GGkQo6/ZlKwETdAGohd40Lzpwp5TUZCn6N6O4Az1SuX1rw/qREGL6Im+ycb19suCFE8/xaKA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.7.2.tgz",
+      "integrity": "sha512-A8yPFm9pRnZ7XYXfPSjSFnugEV1rsHGjb8W7c0Qk7nzXl5h3WANTkpVC5FYxakmw/GKWekz7wjjHaOFtPp823Q==",
+      "dev": true,
       "dependencies": {
         "@iden3/binfileutils": "0.0.11",
         "bfj": "^7.0.2",
         "blake2b-wasm": "^2.4.0",
-        "circom_runtime": "0.1.21",
+        "circom_runtime": "0.1.24",
         "ejs": "^3.1.6",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.56",
+        "ffjavascript": "0.2.62",
         "js-sha3": "^0.8.0",
         "logplease": "^1.2.15",
-        "r1csfile": "0.0.41"
+        "r1csfile": "0.0.47"
       },
       "bin": {
         "snarkjs": "build/cli.cjs"
-      }
-    },
-    "node_modules/snarkjs/node_modules/ffjavascript": {
-      "version": "0.2.56",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
-      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
-      "dependencies": {
-        "wasmbuilder": "0.0.16",
-        "wasmcurves": "0.2.0",
-        "web-worker": "^1.2.0"
-      }
-    },
-    "node_modules/snarkjs/node_modules/wasmcurves": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
-      "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
-      "dependencies": {
-        "wasmbuilder": "0.0.16"
       }
     },
     "node_modules/solc": {
@@ -12740,6 +12773,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/zkey-manager/-/zkey-manager-0.1.2.tgz",
       "integrity": "sha512-Ig+QQrS8IZYkLgbdrbdCgji+1NeEatzWoIqH1G0OoF9+cNrf/qFOFr1hq2k52wVcUudCboqGKDpPbl3KRpnpVw==",
+      "dev": true,
       "dependencies": {
         "argparse": "2.0.1",
         "circomlib": "^2.0.0",
@@ -12755,6 +12789,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@iden3/binfileutils/-/binfileutils-0.0.8.tgz",
       "integrity": "sha512-/GqTsujUssGuQY+sd/XaLrA+OiCwzm+6yH28C57QQDWCHET2Logry9fGxU10n6XKdhCQBjZ7T/YMQkLwwkpRTQ==",
+      "dev": true,
       "dependencies": {
         "fastfile": "0.0.19",
         "ffjavascript": "^0.2.30"
@@ -12764,6 +12799,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.13.tgz",
       "integrity": "sha512-vmv19/0p5OTe5uCI7PWqPtB5vPoYWjczqKYnabaC5HOxX99R4K1MuNqEXsNEAoEfZrmfAQd7vXLcATN9NVnsPA==",
+      "dev": true,
       "dependencies": {
         "ffjavascript": "0.2.35",
         "fnv-plus": "^1.3.1"
@@ -12776,6 +12812,7 @@
       "version": "0.2.35",
       "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.35.tgz",
       "integrity": "sha512-xnC51tWbi0ah4SH+02jEfJyO+P+NiZWnxQrLDLtBYY1Dv3QM5ydxzd+gxnLEfWdT8i1bMM5pIh5P25l6fNCaVQ==",
+      "dev": true,
       "dependencies": {
         "big-integer": "^1.6.48",
         "wasmcurves": "0.0.14",
@@ -12785,12 +12822,14 @@
     "node_modules/zkey-manager/node_modules/fastfile": {
       "version": "0.0.19",
       "resolved": "https://registry.npmjs.org/fastfile/-/fastfile-0.0.19.tgz",
-      "integrity": "sha512-tz9nWR5KYb6eR2odFQ7oxqEkx8F3YQZ6NBJoJR92YEG3DqYOqyxMck8PKvTVNKx3uwvOqGnLXNScnqpdHRdHGQ=="
+      "integrity": "sha512-tz9nWR5KYb6eR2odFQ7oxqEkx8F3YQZ6NBJoJR92YEG3DqYOqyxMck8PKvTVNKx3uwvOqGnLXNScnqpdHRdHGQ==",
+      "dev": true
     },
     "node_modules/zkey-manager/node_modules/ffjavascript": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.37.tgz",
       "integrity": "sha512-wWOkQB07d6eKFRMMtryTVsWrMsR4ImdikhEuu6ZcFYaxufJaBKUiQHYxsPzZEScPa+okkHzf1/2YVPU7xUIHMQ==",
+      "dev": true,
       "dependencies": {
         "big-integer": "^1.6.48",
         "wasmcurves": "0.0.14",
@@ -12801,6 +12840,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
       "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -12812,6 +12852,7 @@
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.32.tgz",
       "integrity": "sha512-DkRXeOg0iRmfhgIuWICvdkOiLHpyb7+AcUd/WHpqBJEUp27pe7wKXBR4Jr3TPYCT4sTV9a/F3bovyAC4wystnQ==",
+      "dev": true,
       "dependencies": {
         "@iden3/bigarray": "0.0.2",
         "@iden3/binfileutils": "0.0.8",
@@ -12823,6 +12864,7 @@
       "version": "0.2.35",
       "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.35.tgz",
       "integrity": "sha512-xnC51tWbi0ah4SH+02jEfJyO+P+NiZWnxQrLDLtBYY1Dv3QM5ydxzd+gxnLEfWdT8i1bMM5pIh5P25l6fNCaVQ==",
+      "dev": true,
       "dependencies": {
         "big-integer": "^1.6.48",
         "wasmcurves": "0.0.14",
@@ -12834,6 +12876,7 @@
       "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.4.7.tgz",
       "integrity": "sha512-gehpEKZwhBZEYPLokfBqtHIxaHHy50LYDI4xFVopNEwICInHPIbG4nJ0nJ1vgqz+bv824UFQC84XnQ0C/mPjag==",
       "deprecated": "Sucurity bug fixed",
+      "dev": true,
       "dependencies": {
         "@iden3/binfileutils": "0.0.8",
         "blake2b-wasm": "^2.3.0",
@@ -12854,6 +12897,7 @@
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.0.14.tgz",
       "integrity": "sha512-G1iMkxlRaQSdqQ1JrwHcU+awLmwyH6kFKfT8g9obd8MWe+u5oSdFXrODB0zmSI5aGGvJPG+4cAmqCGYv9R+7qg==",
+      "dev": true,
       "dependencies": {
         "big-integer": "^1.6.42",
         "blakejs": "^1.1.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,8 +39,7 @@
     "maci-core": "^1.1.2",
     "maci-crypto": "^1.1.2",
     "maci-domainobjs": "^1.1.2",
-    "prompt": "^1.3.0",
-    "zkey-manager": "^0.1.1"
+    "prompt": "^1.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.9",
@@ -50,8 +49,10 @@
     "chai": "^4.3.10",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
+    "snarkjs": "^0.7.2",
     "ts-mocha": "^10.0.0",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "zkey-manager": "^0.1.2"
   },
   "nyc": {
     "reporter": [


### PR DESCRIPTION
# Description

There have been some issues in the nightly workflows, which compile circuits and generate zkeys from scratch to ensure the whole process works as expected.

This PR fixes two issues:

* having removed snarkjs from the cli package we cannot use zkey-manager anymore to generate new zkeys - this was added back as a dev dependency
* the nightly workflow with the ceremony params has a very small poll duration set causing it to fail

## Related issue(s)

re #977 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
