### PR TITLE
chore(publish): fix publishing scripts to publish contracts with ceremony params

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Initialize Project
         run: |
           npm install
-          npx lerna bootstrap
+          npm run bootstrap
           npm run build
+        env:
+          STATE_TREE_DEPTH: ${{ vars.STATE_TREE_DEPTH }}
 
       - name: Compile Contracts
         run: |

--- a/.github/workflows/nightly-ceremony.yml
+++ b/.github/workflows/nightly-ceremony.yml
@@ -33,11 +33,12 @@ jobs:
           npm install
           npm run bootstrap
           npm run build
+        env:
+          STATE_TREE_DEPTH: 6
 
-      - name: Compile contracts with ceremony params and run hardhat fork
+      - name: Run hardhat fork
         run: |
           cd contracts
-          npm run compileSol 6
           npm run hardhat &
 
       - name: Download rapidsnark (1c137)
@@ -53,4 +54,5 @@ jobs:
         run: ./.github/scripts/ceremony-param-tests-c-witness.sh
 
       - name: Stop Hardhat
+        if: always()
         run: kill $(lsof -t -i:8545)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,6 +68,7 @@ jobs:
         run: npm run ${{ matrix.command }}
 
       - name: Stop Hardhat
+        if: always()
         run: kill $(lsof -t -i:8545)
 
   unit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,10 @@ jobs:
         run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
           npm install
-          npx lerna bootstrap
+          npm run bootstrap
           npm run build
+        env:
+          STATE_TREE_DEPTH: ${{ vars.STATE_TREE_DEPTH }}
 
       - name: Publish NPM
         run: |

--- a/contracts/scripts/compileSol.sh
+++ b/contracts/scripts/compileSol.sh
@@ -15,7 +15,7 @@ echo 'Writing Merkle zeros contracts'
 ./scripts/writeMerkleZeroesContracts.sh 
 
 echo 'Writing empty ballot tree root contract'
-./scripts/writeEmptyBallotRoots.sh $1
+./scripts/writeEmptyBallotRoots.sh
 
 echo 'Building contracts with Hardhat'
 npx hardhat compile

--- a/contracts/scripts/writeEmptyBallotRoots.sh
+++ b/contracts/scripts/writeEmptyBallotRoots.sh
@@ -4,5 +4,4 @@ set -e
 cd "$(dirname "$0")"
 cd ..
 
-# take the stateTreeDepth as cli arg
-npx ts-node ts/genEmptyBallotRootsContract.ts $1 > contracts/trees/EmptyBallotRoots.sol
+npx ts-node ts/genEmptyBallotRootsContract.ts > contracts/trees/EmptyBallotRoots.sol

--- a/contracts/ts/genEmptyBallotRootsContract.ts
+++ b/contracts/ts/genEmptyBallotRootsContract.ts
@@ -10,7 +10,7 @@ const genEmptyBallotRootsContract = (): string => {
     .toString();
 
   // This hard-coded value should be consistent with the value of `stateTreeDepth` of MACI.sol
-  const stateTreeDepth = process.argv[2] ? Number.parseInt(process.argv[2], 10) : 10;
+  const stateTreeDepth = process.env.STATE_TREE_DEPTH ? Number.parseInt(process.env.STATE_TREE_DEPTH, 10) : 10;
 
   let r = "";
   for (let i = 1; i < 6; i += 1) {


### PR DESCRIPTION
# Description

Add environment variable so that contracts can be built using a different state tree depth param, and thus allow for publishing to npm contracts that work with the ceremony params

## Related issue(s)

close: #973

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
