### PR TITLE
fix(publish): ensure we commit unstaged files first

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, dev]
+    branches: [dev]
   pull_request:
 
 env:
@@ -42,6 +42,11 @@ jobs:
           # It creates an ephemeral commit that will not be pushed to GitHub
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
+
+          # Depending on the STATE_TREE_DEPTH param, there 
+          # might be changes in the EmptyBallotRoots.sol file
+          git add contracts/contracts/trees/EmptyBallotRoots.sol
+          git diff --staged --quiet || git commit -m "Commit changes before publishing"
 
           lerna version 0.0.0-ci.$(git rev-parse --short HEAD) --no-push --yes
           lerna publish from-git --dist-tag ci --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
 
       - name: Publish NPM
         run: |
+          # Depending on the STATE_TREE_DEPTH param, there 
+          # might be changes in the EmptyBallotRoots.sol file
+          git add contracts/contracts/trees/EmptyBallotRoots.sol
+          git diff --staged --quiet || git commit -m "Commit changes before publishing"
+
           npx lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description

When `stateTreeDepth` is different from 10, `npm run build` will generate a different `emptyBallotRootsContract.sol` file which without being staged for commit, will prevent lerna from publishing it to npm.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
