### PR TITLE
feat(cli): enable environmental variables

### DIFF
--- a/cli/.env.template
+++ b/cli/.env.template
@@ -2,6 +2,10 @@
 ## and that none of these values are mandatory for testing 
 ## purposes
 
+# Ethereum provider, replace with your own 
+# needed if running in production against
+# a test network
+ETH_PROVIDER="the_eth_provider_url"
 # Ethereum secret key, replace with your own 
 # needed if running in production against
 # a test network

--- a/cli/hardhat.config.ts
+++ b/cli/hardhat.config.ts
@@ -1,10 +1,13 @@
 import "@nomicfoundation/hardhat-toolbox";
+import { config as envConfig } from "dotenv";
 
 import path from "path";
 
 import type { HardhatUserConfig } from "hardhat/config";
 
 import { DEFAULT_ETH_SK, DEFAULT_ETH_PROVIDER } from "./ts/utils/defaults";
+
+envConfig();
 
 const parentDir = __dirname.includes("build") ? ".." : "";
 


### PR DESCRIPTION
# Description

- Add `ETH_PROVIDER` in the `.env.template` file.
- import `dotenv` package to enable `hardhat.config.ts` to read environmental variables.

## Related issue(s)

close issue #995.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
