### PR TITLE
chore: use pnpm instead of npx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,6 @@ jobs:
           git add contracts/contracts/trees/EmptyBallotRoots.sol
           git diff --staged --quiet || git commit -m "Commit changes before publishing"
 
-          npx lerna publish from-git --yes
+          pnpm exec lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description

Use `pnpm exec` instead of `npx`

## Additional Notes

@0xmad I was reviewing #1005 & noticed this was the only remaining place we use `npx`. Figured it wouldn't hurt to update this for consistency but LMK if I'm missing something

## Related issue(s)

#1005

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
