### PR TITLE
fix(cli): add env initialization for hardhat conifg

### DIFF
--- a/cli/ts/cliInit.ts
+++ b/cli/ts/cliInit.ts
@@ -1,0 +1,7 @@
+import path from "path";
+
+const parentDir = __dirname.includes("build") ? ".." : "";
+
+if (parentDir) {
+  process.env.HARDHAT_CONFIG = path.resolve(__dirname, parentDir, "hardhat.config.js");
+}

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+
 import { Command } from "@commander-js/extra-typings";
 
 import fs from "fs";
 import path from "path";
 
+import "./cliInit";
 import {
   genKeyPair,
   genMaciPubKey,


### PR DESCRIPTION
# Description

Fix for cli run without specifying hardhat conifg

## Additional Notes

N/A

## Related issue(s)

Related to #1011

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
