### PR TITLE
fix(publishing): do not publish benchmarks folder

### DIFF
--- a/core/tsconfig.build.json
+++ b/core/tsconfig.build.json
@@ -4,5 +4,5 @@
     "outDir": "./build"
   },
   "include": ["./ts"],
-  "exclude": ["**/__tests__/**", "**/__tests__/**/*.test.ts"]
+  "exclude": ["**/__tests__/**", "**/__tests__/**/*.test.ts", "**/__benchmarks__/**"]
 }

--- a/crypto/tsconfig.build.json
+++ b/crypto/tsconfig.build.json
@@ -4,5 +4,5 @@
     "outDir": "./build"
   },
   "include": ["./ts"],
-  "exclude": ["**/__tests__/**", "**/__tests__/**/*.test.ts"]
+  "exclude": ["**/__tests__/**", "**/__tests__/**/*.test.ts", "**/__benchmarks__/**"]
 }


### PR DESCRIPTION
# Description

Exclude benchmarks folder from build.


## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
