### PR TITLE
refactor(cli): use object args for cli commands

### DIFF
--- a/cli/tests/constants.ts
+++ b/cli/tests/constants.ts
@@ -2,6 +2,17 @@ import { Keypair } from "maci-domainobjs";
 
 import { homedir } from "os";
 
+import {
+  CheckVerifyingKeysArgs,
+  DeployArgs,
+  DeployPollArgs,
+  MergeMessagesArgs,
+  MergeSignupsArgs,
+  ProveOnChainArgs,
+  SetVerifyingKeysArgs,
+  VerifyArgs,
+} from "../ts/utils";
+
 export const STATE_TREE_DEPTH = 10;
 export const INT_STATE_TREE_DEPTH = 1;
 export const MSG_TREE_DEPTH = 2;
@@ -38,3 +49,60 @@ export const testRapidsnarkPath = `${homedir()}/rapidsnark/build/prover`;
 export const pollDuration = 90;
 export const maxMessages = 25;
 export const maxVoteOptions = 25;
+
+export const setVerifyingKeysArgs: SetVerifyingKeysArgs = {
+  quiet: true,
+  stateTreeDepth: STATE_TREE_DEPTH,
+  intStateTreeDepth: INT_STATE_TREE_DEPTH,
+  messageTreeDepth: MSG_TREE_DEPTH,
+  voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
+  messageBatchDepth: MSG_BATCH_DEPTH,
+  processMessagesZkeyPath: processMessageTestZkeyPath,
+  tallyVotesZkeyPath: tallyVotesTestZkeyPath,
+};
+
+export const checkVerifyingKeysArgs: CheckVerifyingKeysArgs = {
+  stateTreeDepth: STATE_TREE_DEPTH,
+  intStateTreeDepth: INT_STATE_TREE_DEPTH,
+  messageTreeDepth: MSG_TREE_DEPTH,
+  voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
+  messageBatchDepth: MSG_BATCH_DEPTH,
+  processMessagesZkeyPath: processMessageTestZkeyPath,
+  tallyVotesZkeyPath: tallyVotesTestZkeyPath,
+};
+
+export const mergeMessagesArgs: MergeMessagesArgs = {
+  pollId: 0,
+};
+
+export const mergeSignupsArgs: MergeSignupsArgs = {
+  pollId: 0,
+};
+
+export const proveOnChainArgs: ProveOnChainArgs = {
+  pollId: "0",
+  proofDir: testProofsDirPath,
+  subsidyEnabled: false,
+};
+
+export const verifyArgs: VerifyArgs = {
+  pollId: "0",
+  subsidyEnabled: false,
+  tallyFile: testTallyFilePath,
+};
+
+export const deployArgs: DeployArgs = {
+  stateTreeDepth: STATE_TREE_DEPTH,
+};
+
+export const deployPollArgs: DeployPollArgs = {
+  pollDuration,
+  maxMessages,
+  maxVoteOptions,
+  intStateTreeDepth: INT_STATE_TREE_DEPTH,
+  messageTreeSubDepth: MSG_BATCH_DEPTH,
+  messageTreeDepth: MSG_TREE_DEPTH,
+  voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
+  coordinatorPubkey: coordinatorPubKey,
+  subsidyEnabled: false,
+};

--- a/cli/tests/e2e/e2e.subsidy.test.ts
+++ b/cli/tests/e2e/e2e.subsidy.test.ts
@@ -16,20 +16,17 @@ import {
   timeTravel,
   verify,
 } from "../../ts/commands";
-import { DeployedContracts, PollContracts } from "../../ts/utils";
+import { DeployedContracts, GenProofsArgs, PollContracts } from "../../ts/utils";
 import {
-  INT_STATE_TREE_DEPTH,
-  MSG_BATCH_DEPTH,
-  MSG_TREE_DEPTH,
-  STATE_TREE_DEPTH,
-  VOTE_OPTION_TREE_DEPTH,
   coordinatorPrivKey,
-  coordinatorPubKey,
-  maxMessages,
-  maxVoteOptions,
   pollDuration,
+  verifyArgs,
+  proveOnChainArgs,
   processMessageTestZkeyPath,
   subsidyTestZkeyPath,
+  checkVerifyingKeysArgs,
+  mergeMessagesArgs,
+  mergeSignupsArgs,
   tallyVotesTestZkeyPath,
   testProcessMessagesWasmPath,
   testProcessMessagesWitnessDatPath,
@@ -44,6 +41,9 @@ import {
   testTallyVotesWasmPath,
   testTallyVotesWitnessDatPath,
   testTallyVotesWitnessPath,
+  setVerifyingKeysArgs,
+  deployArgs,
+  deployPollArgs,
 } from "../constants";
 import { cleanSubsidy, isArm } from "../utils";
 
@@ -56,22 +56,35 @@ describe("e2e with Subsidy tests", function test() {
   let vkRegistryContractAddress: string;
 
   const subsidyEnabled = true;
+  deployPollArgs.subsidyEnabled = subsidyEnabled;
+
+  const genProofsArgs: GenProofsArgs = {
+    outputDir: testProofsDirPath,
+    tallyFile: testTallyFilePath,
+    tallyZkey: tallyVotesTestZkeyPath,
+    processZkey: processMessageTestZkeyPath,
+    pollId: 0,
+    rapidsnark: testRapidsnarkPath,
+    processWitgen: testProcessMessagesWitnessPath,
+    processDatFile: testProcessMessagesWitnessDatPath,
+    tallyWitgen: testTallyVotesWitnessPath,
+    tallyDatFile: testTallyVotesWitnessDatPath,
+    coordinatorPrivKey,
+    processWasm: testProcessMessagesWasmPath,
+    tallyWasm: testTallyVotesWasmPath,
+    useWasm,
+    subsidyZkey: subsidyTestZkeyPath,
+    subsidyFile: testSubsidyFilePath,
+    subsidyWitgen: testSubsidyWitnessPath,
+    subsidyDatFile: testSubsidyWitnessDatPath,
+    subsidyWasm: testSubsidyWasmPath,
+  };
 
   before(async () => {
     // we deploy the vk registry contract
     vkRegistryContractAddress = await deployVkRegistryContract(true);
     // we set the verifying keys
-    await setVerifyingKeys(
-      STATE_TREE_DEPTH,
-      INT_STATE_TREE_DEPTH,
-      MSG_TREE_DEPTH,
-      VOTE_OPTION_TREE_DEPTH,
-      MSG_BATCH_DEPTH,
-      processMessageTestZkeyPath,
-      tallyVotesTestZkeyPath,
-      undefined,
-      subsidyTestZkeyPath,
-    );
+    await setVerifyingKeys({ ...setVerifyingKeysArgs, subsidyZkeyPath: subsidyTestZkeyPath });
   });
 
   describe("4 signups, 6 messages", () => {
@@ -83,136 +96,94 @@ describe("e2e with Subsidy tests", function test() {
 
     before(async () => {
       // deploy the smart contracts
-      maciAddresses = await deploy(STATE_TREE_DEPTH);
+      maciAddresses = await deploy(deployArgs);
       // deploy a poll contract
-      pollAddresses = await deployPoll(
-        pollDuration,
-        maxMessages,
-        maxVoteOptions,
-        INT_STATE_TREE_DEPTH,
-        MSG_BATCH_DEPTH,
-        MSG_TREE_DEPTH,
-        VOTE_OPTION_TREE_DEPTH,
-        coordinatorPubKey,
-        subsidyEnabled,
-      );
+      pollAddresses = await deployPoll(deployPollArgs);
     });
 
     it("should signup four users", async () => {
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
       for (let i = 0; i < users.length; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        await signup(users[i].pubKey.serialize());
+        await signup({ maciPubKey: users[i].pubKey.serialize() });
       }
     });
 
     it("should publish six messages", async () => {
-      await publish(
-        users[0].pubKey.serialize(),
-        1,
-        0,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[0].privKey.serialize(),
-      );
-      await publish(
-        users[1].pubKey.serialize(),
-        2,
-        1,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[1].privKey.serialize(),
-      );
-      await publish(
-        users[2].pubKey.serialize(),
-        3,
-        2,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[2].privKey.serialize(),
-      );
-      await publish(
-        users[3].pubKey.serialize(),
-        4,
-        3,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[3].privKey.serialize(),
-      );
-      await publish(
-        users[3].pubKey.serialize(),
-        4,
-        3,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[3].privKey.serialize(),
-      );
-      await publish(
-        users[3].pubKey.serialize(),
-        4,
-        3,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[3].privKey.serialize(),
-      );
+      await publish({
+        pubkey: users[0].pubKey.serialize(),
+        stateIndex: 1,
+        voteOptionIndex: 0,
+        nonce: 1,
+        pollId: 0,
+        newVoteWeight: 9,
+        salt: genRandomSalt().toString(),
+        privateKey: users[0].privKey.serialize(),
+      });
+
+      await publish({
+        pubkey: users[1].pubKey.serialize(),
+        stateIndex: 2,
+        voteOptionIndex: 1,
+        nonce: 1,
+        pollId: 0,
+        newVoteWeight: 9,
+        salt: genRandomSalt().toString(),
+        privateKey: users[1].privKey.serialize(),
+      });
+
+      await publish({
+        pubkey: users[2].pubKey.serialize(),
+        stateIndex: 3,
+        voteOptionIndex: 2,
+        nonce: 1,
+        pollId: 0,
+        newVoteWeight: 9,
+        salt: genRandomSalt().toString(),
+        privateKey: users[2].privKey.serialize(),
+      });
+
+      await publish({
+        pubkey: users[3].pubKey.serialize(),
+        stateIndex: 4,
+        voteOptionIndex: 3,
+        nonce: 1,
+        pollId: 0,
+        newVoteWeight: 9,
+        salt: genRandomSalt().toString(),
+        privateKey: users[3].privKey.serialize(),
+      });
+
+      await publish({
+        pubkey: users[3].pubKey.serialize(),
+        stateIndex: 4,
+        voteOptionIndex: 3,
+        nonce: 2,
+        pollId: 0,
+        newVoteWeight: 9,
+        salt: genRandomSalt().toString(),
+        privateKey: users[3].privKey.serialize(),
+      });
+
+      await publish({
+        pubkey: users[3].pubKey.serialize(),
+        stateIndex: 4,
+        voteOptionIndex: 3,
+        nonce: 3,
+        pollId: 0,
+        newVoteWeight: 9,
+        salt: genRandomSalt().toString(),
+        privateKey: users[3].privKey.serialize(),
+      });
     });
 
     it("should generate zk-SNARK proofs and verify them", async () => {
       await timeTravel(pollDuration, true);
-      await mergeMessages(0);
-      await mergeSignups(0);
-      const tallyData = await genProofs(
-        testProofsDirPath,
-        testTallyFilePath,
-        tallyVotesTestZkeyPath,
-        processMessageTestZkeyPath,
-        0,
-        testSubsidyFilePath,
-        subsidyTestZkeyPath,
-        testRapidsnarkPath,
-        testProcessMessagesWitnessPath,
-        testProcessMessagesWitnessDatPath,
-        testTallyVotesWitnessPath,
-        testTallyVotesWitnessDatPath,
-        testSubsidyWitnessPath,
-        testSubsidyWitnessDatPath,
-        coordinatorPrivKey,
-        maciAddresses.maciAddress,
-        undefined,
-        testProcessMessagesWasmPath,
-        testTallyVotesWasmPath,
-        testSubsidyWasmPath,
-        useWasm,
-      );
-      await proveOnChain("0", testProofsDirPath, subsidyEnabled);
-      await verify(
-        "0",
-        subsidyEnabled,
-        testTallyFilePath,
-        tallyData,
-        maciAddresses.maciAddress,
-        pollAddresses.tally,
-        pollAddresses.subsidy,
-        testSubsidyFilePath,
-      );
+      await mergeMessages(mergeMessagesArgs);
+      await mergeSignups(mergeSignupsArgs);
+      await genProofs(genProofsArgs);
+      await proveOnChain(proveOnChainArgs);
+      await verify(verifyArgs);
     });
   });
 
@@ -235,81 +206,40 @@ describe("e2e with Subsidy tests", function test() {
 
     before(async () => {
       // deploy the smart contracts
-      maciAddresses = await deploy(STATE_TREE_DEPTH);
+      maciAddresses = await deploy(deployArgs);
       // deploy a poll contract
-      pollAddresses = await deployPoll(
-        pollDuration,
-        maxMessages,
-        maxVoteOptions,
-        INT_STATE_TREE_DEPTH,
-        MSG_BATCH_DEPTH,
-        MSG_TREE_DEPTH,
-        VOTE_OPTION_TREE_DEPTH,
-        coordinatorPubKey,
-        subsidyEnabled,
-      );
+      pollAddresses = await deployPoll(deployPollArgs);
     });
 
     it("should signup nine users", async () => {
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
       for (let i = 0; i < users.length; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        await signup(users[i].pubKey.serialize());
+        await signup({ maciPubKey: users[i].pubKey.serialize() });
       }
     });
 
     it("should publish one message", async () => {
-      await publish(
-        users[0].pubKey.serialize(),
-        1,
-        0,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[0].privKey.serialize(),
-      );
+      await publish({
+        pubkey: users[0].pubKey.serialize(),
+        stateIndex: 1,
+        voteOptionIndex: 0,
+        nonce: 1,
+        pollId: 0,
+        newVoteWeight: 9,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[0].privKey.serialize(),
+      });
     });
 
     it("should generate zk-SNARK proofs and verify them", async () => {
       await timeTravel(pollDuration, true);
-      await mergeMessages(0);
-      await mergeSignups(0);
-      const tallyData = await genProofs(
-        testProofsDirPath,
-        testTallyFilePath,
-        tallyVotesTestZkeyPath,
-        processMessageTestZkeyPath,
-        0,
-        testSubsidyFilePath,
-        subsidyTestZkeyPath,
-        testRapidsnarkPath,
-        testProcessMessagesWitnessPath,
-        testProcessMessagesWitnessDatPath,
-        testTallyVotesWitnessPath,
-        testTallyVotesWitnessDatPath,
-        testSubsidyWitnessPath,
-        testSubsidyWitnessDatPath,
-        coordinatorPrivKey,
-        maciAddresses.maciAddress,
-        undefined,
-        testProcessMessagesWasmPath,
-        testTallyVotesWasmPath,
-        testSubsidyWasmPath,
-        useWasm,
-      );
-      await proveOnChain("0", testProofsDirPath, subsidyEnabled);
-      await verify(
-        "0",
-        subsidyEnabled,
-        testTallyFilePath,
-        tallyData,
-        maciAddresses.maciAddress,
-        pollAddresses.tally,
-        pollAddresses.subsidy,
-        testSubsidyFilePath,
-      );
+      await mergeMessages(mergeMessagesArgs);
+      await mergeSignups(mergeSignupsArgs);
+      const tallyData = await genProofs(genProofsArgs);
+      await proveOnChain(proveOnChainArgs);
+      await verify({ ...verifyArgs, tallyData });
     });
   });
 
@@ -322,83 +252,42 @@ describe("e2e with Subsidy tests", function test() {
 
     before(async () => {
       // deploy the smart contracts
-      maciAddresses = await deploy(STATE_TREE_DEPTH);
+      maciAddresses = await deploy(deployArgs);
       // deploy a poll contract
-      pollAddresses = await deployPoll(
-        pollDuration,
-        maxMessages,
-        maxVoteOptions,
-        INT_STATE_TREE_DEPTH,
-        MSG_BATCH_DEPTH,
-        MSG_TREE_DEPTH,
-        VOTE_OPTION_TREE_DEPTH,
-        coordinatorPubKey,
-        subsidyEnabled,
-      );
+      pollAddresses = await deployPoll(deployPollArgs);
     });
 
     it("should signup eight users (same pub key)", async () => {
       for (let i = 0; i < 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        await signup(user.pubKey.serialize());
+        await signup({ maciPubKey: user.pubKey.serialize() });
       }
     });
 
     it("should publish 12 messages with the same nonce", async () => {
       for (let i = 0; i < 12; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        await publish(
-          user.pubKey.serialize(),
-          1,
-          0,
-          1,
-          0,
-          9,
-          maciAddresses.maciAddress,
-          genRandomSalt().toString(),
-          user.privKey.serialize(),
-        );
+        await publish({
+          pubkey: user.pubKey.serialize(),
+          stateIndex: 1,
+          voteOptionIndex: 0,
+          nonce: 1,
+          pollId: 0,
+          newVoteWeight: 9,
+          maciContractAddress: maciAddresses.maciAddress,
+          salt: genRandomSalt().toString(),
+          privateKey: user.privKey.serialize(),
+        });
       }
     });
 
     it("should generate zk-SNARK proofs and verify them", async () => {
       await timeTravel(pollDuration, true);
-      await mergeMessages(0);
-      await mergeSignups(0);
-      const tallyData = await genProofs(
-        testProofsDirPath,
-        testTallyFilePath,
-        tallyVotesTestZkeyPath,
-        processMessageTestZkeyPath,
-        0,
-        testSubsidyFilePath,
-        subsidyTestZkeyPath,
-        testRapidsnarkPath,
-        testProcessMessagesWitnessPath,
-        testProcessMessagesWitnessDatPath,
-        testTallyVotesWitnessPath,
-        testTallyVotesWitnessDatPath,
-        testSubsidyWitnessPath,
-        testSubsidyWitnessDatPath,
-        coordinatorPrivKey,
-        maciAddresses.maciAddress,
-        undefined,
-        testProcessMessagesWasmPath,
-        testTallyVotesWasmPath,
-        testSubsidyWasmPath,
-        useWasm,
-      );
-      await proveOnChain("0", testProofsDirPath, subsidyEnabled);
-      await verify(
-        "0",
-        subsidyEnabled,
-        testTallyFilePath,
-        tallyData,
-        maciAddresses.maciAddress,
-        pollAddresses.tally,
-        pollAddresses.subsidy,
-        testSubsidyFilePath,
-      );
+      await mergeMessages(mergeMessagesArgs);
+      await mergeSignups(mergeSignupsArgs);
+      const tallyData = await genProofs(genProofsArgs);
+      await proveOnChain(proveOnChainArgs);
+      await verify({ ...verifyArgs, tallyData });
     });
   });
 
@@ -421,296 +310,175 @@ describe("e2e with Subsidy tests", function test() {
 
     before(async () => {
       // deploy the smart contracts
-      maciAddresses = await deploy(STATE_TREE_DEPTH);
+      maciAddresses = await deploy(deployArgs);
     });
 
     it("should run the first poll", async () => {
       // deploy a poll contract
-      pollAddresses = await deployPoll(
-        pollDuration,
-        maxMessages,
-        maxVoteOptions,
-        INT_STATE_TREE_DEPTH,
-        MSG_BATCH_DEPTH,
-        MSG_TREE_DEPTH,
-        VOTE_OPTION_TREE_DEPTH,
-        coordinatorPubKey,
-        subsidyEnabled,
-      );
+      pollAddresses = await deployPoll(deployPollArgs);
       // signup
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
       for (let i = 0; i < users.length; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        await signup(users[i].pubKey.serialize());
+        await signup({ maciPubKey: users[i].pubKey.serialize() });
       }
       // publish
-      await publish(
-        users[0].pubKey.serialize(),
-        1,
-        0,
-        1,
-        0,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[0].privKey.serialize(),
-      );
+      await publish({
+        pubkey: users[0].pubKey.serialize(),
+        stateIndex: 1,
+        voteOptionIndex: 0,
+        nonce: 1,
+        pollId: 0,
+        newVoteWeight: 9,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[0].privKey.serialize(),
+      });
       // time travel
       await timeTravel(pollDuration, true);
       // generate proofs
-      await mergeMessages(0);
-      await mergeSignups(0);
-      const tallyData = await genProofs(
-        testProofsDirPath,
-        testTallyFilePath,
-        tallyVotesTestZkeyPath,
-        processMessageTestZkeyPath,
-        0,
-        testSubsidyFilePath,
-        subsidyTestZkeyPath,
-        testRapidsnarkPath,
-        testProcessMessagesWitnessPath,
-        testProcessMessagesWitnessDatPath,
-        testTallyVotesWitnessPath,
-        testTallyVotesWitnessDatPath,
-        testSubsidyWitnessPath,
-        testSubsidyWitnessDatPath,
-        coordinatorPrivKey,
-        maciAddresses.maciAddress,
-        undefined,
-        testProcessMessagesWasmPath,
-        testTallyVotesWasmPath,
-        testSubsidyWasmPath,
-        useWasm,
-      );
-      await proveOnChain("0", testProofsDirPath, subsidyEnabled);
-      await verify(
-        "0",
-        subsidyEnabled,
-        testTallyFilePath,
-        tallyData,
-        maciAddresses.maciAddress,
-        pollAddresses.tally,
-        pollAddresses.subsidy,
-        testSubsidyFilePath,
-      );
+      await mergeMessages(mergeMessagesArgs);
+      await mergeSignups(mergeSignupsArgs);
+      await genProofs(genProofsArgs);
+      await proveOnChain(proveOnChainArgs);
+      await verify(verifyArgs);
       cleanSubsidy();
     });
 
     it("should deploy two more polls", async () => {
       // deploy a poll contract
-      pollAddresses = await deployPoll(
-        pollDuration,
-        maxMessages,
-        maxVoteOptions,
-        INT_STATE_TREE_DEPTH,
-        MSG_BATCH_DEPTH,
-        MSG_TREE_DEPTH,
-        VOTE_OPTION_TREE_DEPTH,
-        coordinatorPubKey,
-        subsidyEnabled,
-      );
-      secondPollAddresses = await deployPoll(
-        pollDuration,
-        maxMessages,
-        maxVoteOptions,
-        INT_STATE_TREE_DEPTH,
-        MSG_BATCH_DEPTH,
-        MSG_TREE_DEPTH,
-        VOTE_OPTION_TREE_DEPTH,
-        coordinatorPubKey,
-        subsidyEnabled,
-      );
+      pollAddresses = await deployPoll(deployPollArgs);
+      secondPollAddresses = await deployPoll(deployPollArgs);
     });
 
     it("should publish messages to the second poll", async () => {
-      await publish(
-        users[0].pubKey.serialize(),
-        1,
-        0,
-        1,
-        1,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[0].privKey.serialize(),
-      );
-      await publish(
-        users[1].pubKey.serialize(),
-        2,
-        2,
-        1,
-        1,
-        2,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[1].privKey.serialize(),
-      );
-      await publish(
-        users[2].pubKey.serialize(),
-        3,
-        3,
-        1,
-        1,
-        3,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[2].privKey.serialize(),
-      );
+      await publish({
+        pubkey: users[0].pubKey.serialize(),
+        stateIndex: 1,
+        voteOptionIndex: 0,
+        nonce: 1,
+        pollId: 1,
+        newVoteWeight: 9,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[0].privKey.serialize(),
+      });
+
+      await publish({
+        pubkey: users[1].pubKey.serialize(),
+        stateIndex: 2,
+        voteOptionIndex: 3,
+        nonce: 1,
+        pollId: 1,
+        newVoteWeight: 1,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[1].privKey.serialize(),
+      });
+
+      await publish({
+        pubkey: users[2].pubKey.serialize(),
+        stateIndex: 3,
+        voteOptionIndex: 5,
+        nonce: 1,
+        pollId: 1,
+        newVoteWeight: 3,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[2].privKey.serialize(),
+      });
     });
 
     it("should publish messages to the third poll", async () => {
-      await publish(
-        users[3].pubKey.serialize(),
-        1,
-        1,
-        1,
-        2,
-        9,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[3].privKey.serialize(),
-      );
+      await publish({
+        pubkey: users[3].pubKey.serialize(),
+        stateIndex: 3,
+        voteOptionIndex: 5,
+        nonce: 1,
+        pollId: 2,
+        newVoteWeight: 3,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[3].privKey.serialize(),
+      });
 
-      await publish(
-        users[4].pubKey.serialize(),
-        2,
-        2,
-        1,
-        2,
-        5,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[4].privKey.serialize(),
-      );
+      await publish({
+        pubkey: users[4].pubKey.serialize(),
+        stateIndex: 4,
+        voteOptionIndex: 7,
+        nonce: 1,
+        pollId: 2,
+        newVoteWeight: 2,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[4].privKey.serialize(),
+      });
 
-      await publish(
-        users[5].pubKey.serialize(),
-        5,
-        5,
-        1,
-        2,
-        5,
-        maciAddresses.maciAddress,
-        genRandomSalt().toString(),
-        users[5].privKey.serialize(),
-      );
+      await publish({
+        pubkey: users[5].pubKey.serialize(),
+        stateIndex: 5,
+        voteOptionIndex: 5,
+        nonce: 1,
+        pollId: 2,
+        newVoteWeight: 9,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt().toString(),
+        privateKey: users[5].privKey.serialize(),
+      });
     });
 
     it("should complete the second poll", async () => {
       await timeTravel(pollDuration, true);
-      await mergeMessages(1);
-      await mergeSignups(1);
-      const tallyData = await genProofs(
-        testProofsDirPath,
-        testTallyFilePath,
-        tallyVotesTestZkeyPath,
-        processMessageTestZkeyPath,
-        1,
-        testSubsidyFilePath,
-        subsidyTestZkeyPath,
-        testRapidsnarkPath,
-        testProcessMessagesWitnessPath,
-        testProcessMessagesWitnessDatPath,
-        testTallyVotesWitnessPath,
-        testTallyVotesWitnessDatPath,
-        testSubsidyWitnessPath,
-        testSubsidyWitnessDatPath,
-        coordinatorPrivKey,
-        maciAddresses.maciAddress,
-        undefined,
-        testProcessMessagesWasmPath,
-        testTallyVotesWasmPath,
-        testSubsidyWasmPath,
-        useWasm,
-      );
-      await proveOnChain(
-        "1",
-        testProofsDirPath,
-        subsidyEnabled,
-        maciAddresses.maciAddress,
-        pollAddresses.messageProcessor,
-        pollAddresses.tally,
-        pollAddresses.subsidy,
-      );
-      await verify(
-        "1",
-        subsidyEnabled,
-        testTallyFilePath,
+      await mergeMessages({ pollId: 1 });
+      await mergeSignups({ pollId: 1 });
+      const tallyData = await genProofs({
+        ...genProofsArgs,
+        pollId: 1,
+      });
+      await proveOnChain({
+        ...proveOnChainArgs,
+        pollId: "1",
+      });
+      await verify({
+        ...verifyArgs,
+        pollId: "1",
         tallyData,
-        maciAddresses.maciAddress,
-        pollAddresses.tally,
-        pollAddresses.subsidy,
-        testSubsidyFilePath,
-      );
+        tallyAddress: pollAddresses.tally,
+      });
       cleanSubsidy();
     });
 
     it("should complete the third poll", async () => {
-      await mergeMessages(2);
-      await mergeSignups(2);
-      const tallyData = await genProofs(
-        testProofsDirPath,
-        testTallyFilePath,
-        tallyVotesTestZkeyPath,
-        processMessageTestZkeyPath,
-        2,
-        testSubsidyFilePath,
-        subsidyTestZkeyPath,
-        testRapidsnarkPath,
-        testProcessMessagesWitnessPath,
-        testProcessMessagesWitnessDatPath,
-        testTallyVotesWitnessPath,
-        testTallyVotesWitnessDatPath,
-        testSubsidyWitnessPath,
-        testSubsidyWitnessDatPath,
-        coordinatorPrivKey,
-        maciAddresses.maciAddress,
-        undefined,
-        testProcessMessagesWasmPath,
-        testTallyVotesWasmPath,
-        testSubsidyWasmPath,
-        useWasm,
-      );
-      await proveOnChain(
-        "2",
-        testProofsDirPath,
-        subsidyEnabled,
-        maciAddresses.maciAddress,
-        secondPollAddresses.messageProcessor,
-        secondPollAddresses.tally,
-        secondPollAddresses.subsidy,
-      );
-      await verify(
-        "2",
-        subsidyEnabled,
-        testTallyFilePath,
+      await mergeMessages({ pollId: 2 });
+      await mergeSignups({ pollId: 2 });
+      const tallyData = await genProofs({
+        ...genProofsArgs,
+        pollId: 2,
+      });
+      await proveOnChain({
+        ...proveOnChainArgs,
+        pollId: "2",
+      });
+      await verify({
+        ...verifyArgs,
+        pollId: "2",
         tallyData,
-        maciAddresses.maciAddress,
-        secondPollAddresses.tally,
-        secondPollAddresses.subsidy,
-        testSubsidyFilePath,
-      );
+        tallyAddress: secondPollAddresses.tally,
+      });
     });
   });
 
   describe("checkKeys", () => {
     before(async () => {
       // deploy maci as we need the address
-      await deploy(STATE_TREE_DEPTH);
+      await deploy(deployArgs);
     });
     it("should check if the verifying keys have been set correctly", async () => {
-      await checkVerifyingKeys(
-        STATE_TREE_DEPTH,
-        INT_STATE_TREE_DEPTH,
-        MSG_TREE_DEPTH,
-        VOTE_OPTION_TREE_DEPTH,
-        MSG_BATCH_DEPTH,
-        processMessageTestZkeyPath,
-        tallyVotesTestZkeyPath,
-        vkRegistryContractAddress,
-        subsidyTestZkeyPath,
-      );
+      await checkVerifyingKeys({
+        ...checkVerifyingKeysArgs,
+        vkRegistry: vkRegistryContractAddress,
+        subsidyZkeyPath: subsidyTestZkeyPath,
+      });
     });
   });
 });

--- a/cli/tests/unit/airdrop.test.ts
+++ b/cli/tests/unit/airdrop.test.ts
@@ -1,7 +1,7 @@
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { ZeroAddress } from "ethers";
-import { deployTopupCredit } from "maci-contracts";
+import { deployTopupCredit, getDefaultSigner } from "maci-contracts";
 
 import { airdrop } from "../../ts";
 
@@ -11,19 +11,21 @@ describe("airdrop", () => {
   let topupContractAddress: string | undefined;
 
   before(async () => {
-    const topupContract = await deployTopupCredit();
+    const topupContract = await deployTopupCredit(await getDefaultSigner(), true);
     topupContractAddress = await topupContract.getAddress();
   });
 
   it("should airdrop tokens to the coordinator", async () => {
-    await expect(airdrop(100, topupContractAddress)).to.be.fulfilled;
+    await expect(airdrop({ amount: 100, contractAddress: topupContractAddress })).to.be.fulfilled;
   });
 
   it("should throw when the amount is negative", async () => {
-    await expect(airdrop(-1, topupContractAddress)).to.be.rejectedWith("Invalid amount");
+    await expect(airdrop({ amount: -1, contractAddress: topupContractAddress })).to.be.rejectedWith("Invalid amount");
   });
 
   it("should throw when the ERC20 contract address is invalid", async () => {
-    await expect(airdrop(100, ZeroAddress)).to.be.rejectedWith("Invalid ERC20 contract address");
+    await expect(airdrop({ amount: 100, contractAddress: ZeroAddress })).to.be.rejectedWith(
+      "Invalid ERC20 contract address",
+    );
   });
 });

--- a/cli/tests/unit/topup.test.ts
+++ b/cli/tests/unit/topup.test.ts
@@ -31,14 +31,20 @@ describe("topup", () => {
   });
 
   it("should throw when the state index is invalid", async () => {
-    await expect(topup(100, 0, 0, maciAddress)).to.be.rejectedWith("State index must be greater than 0");
+    await expect(topup({ amount: 100, pollId: 0, stateIndex: 0, maciAddress })).to.be.rejectedWith(
+      "State index must be greater than 0",
+    );
   });
 
   it("should throw when the poll ID is invalid", async () => {
-    await expect(topup(100, 1, -1, maciAddress)).to.be.rejectedWith("Poll ID must be a positive integer");
+    await expect(topup({ amount: 100, pollId: -1, stateIndex: 1, maciAddress })).to.be.rejectedWith(
+      "Poll ID must be a positive integer",
+    );
   });
 
   it("should throw when the amount is invalid", async () => {
-    await expect(topup(0, 1, 0, maciAddress)).to.be.rejectedWith("Topup amount must be greater than 0");
+    await expect(topup({ amount: 0, pollId: 0, stateIndex: 1, maciAddress })).to.be.rejectedWith(
+      "Topup amount must be greater than 0",
+    );
   });
 });

--- a/cli/ts/commands/airdrop.ts
+++ b/cli/ts/commands/airdrop.ts
@@ -1,28 +1,21 @@
 import { BaseContract } from "ethers";
 import { type MACI, type TopupCredit, getDefaultSigner, parseArtifact } from "maci-contracts";
 
-import { banner } from "../utils/banner";
-import { contractExists } from "../utils/contracts";
-import { readContractAddress } from "../utils/storage";
-import { logError, logGreen, success } from "../utils/theme";
+import { type AirdropArgs, logError, logGreen, success, readContractAddress, contractExists, banner } from "../utils";
 
 /**
  * Utility that can be used to get
  * topup credits aidropped
  * to the coordinator
- * @param amount the amount of credits to airdrop
- * @param contractAddress the address of the ERC20 contract
- * @param pollId the id of the poll
- * @param maciAddress the address of the MACI contract
- * @param quiet whether to log the output
+ * @param AirdropArgs - The arguments for the airdrop command
  */
-export const airdrop = async (
-  amount: number,
-  contractAddress?: string,
-  pollId?: number,
-  maciAddress?: string,
+export const airdrop = async ({
+  amount,
+  contractAddress,
+  pollId,
+  maciAddress,
   quiet = true,
-): Promise<void> => {
+}: AirdropArgs): Promise<void> => {
   banner(quiet);
 
   // get the topup credit address from storage

--- a/cli/ts/commands/checkVerifyingKeys.ts
+++ b/cli/ts/commands/checkVerifyingKeys.ts
@@ -7,6 +7,7 @@ import { VerifyingKey } from "maci-domainobjs";
 import fs from "fs";
 
 import {
+  CheckVerifyingKeysArgs,
   banner,
   compareVks,
   contractExists,
@@ -22,29 +23,21 @@ import {
  * Command to confirm that the verifying keys in the contract match the
  * local ones
  * @note see different options for zkey files to use specific circuits https://maci.pse.dev/docs/trusted-setup, https://maci.pse.dev/docs/testing/#pre-compiled-artifacts-for-testing
- * @param stateTreeDepth the depth of the state tree
- * @param intStateTreeDepth the depth of the state subtree
- * @param messageTreeDepth the depth of the message tree
- * @param voteOptionTreeDepth the depth of the vote option tree
- * @param messageBatchDepth the depth of the message batch tree
- * @param processMessagesZkeyPath the path to the process messages zkey
- * @param tallyVotesZkeyPath the path to the tally votes zkey
- * @param quiet whether to log the output
- * @param vkRegistry the address of the VkRegistry contract
- * @returns whether the verifying keys match or not
+ * @param CheckVerifyingKeysArgs - The arguments for the checkVerifyingKeys command
+ * @returns Whether the verifying keys match or not
  */
-export const checkVerifyingKeys = async (
-  stateTreeDepth: number,
-  intStateTreeDepth: number,
-  messageTreeDepth: number,
-  voteOptionTreeDepth: number,
-  messageBatchDepth: number,
-  processMessagesZkeyPath: string,
-  tallyVotesZkeyPath: string,
-  vkRegistry?: string,
-  subsidyZkeyPath?: string,
+export const checkVerifyingKeys = async ({
+  stateTreeDepth,
+  intStateTreeDepth,
+  messageTreeDepth,
+  voteOptionTreeDepth,
+  messageBatchDepth,
+  processMessagesZkeyPath,
+  tallyVotesZkeyPath,
+  vkRegistry,
+  subsidyZkeyPath,
   quiet = true,
-): Promise<boolean> => {
+}: CheckVerifyingKeysArgs): Promise<boolean> => {
   banner(quiet);
   // get the signer
   const signer = await getDefaultSigner();

--- a/cli/ts/commands/deploy.ts
+++ b/cli/ts/commands/deploy.ts
@@ -7,27 +7,30 @@ import {
   getDefaultSigner,
 } from "maci-contracts";
 
-import { logError, logGreen, success, DEFAULT_INITIAL_VOICE_CREDITS, type DeployedContracts } from "../utils";
-import { banner } from "../utils/banner";
-import { readContractAddress, storeContractAddress } from "../utils/storage";
+import {
+  banner,
+  logError,
+  logGreen,
+  success,
+  readContractAddress,
+  storeContractAddress,
+  DEFAULT_INITIAL_VOICE_CREDITS,
+  type DeployedContracts,
+  type DeployArgs,
+} from "../utils";
 
 /**
  * Deploy MACI and related contracts
- * @param stateTreeDepth - the depth of the state tree
- * @param vkRegistryAddress - the address of the vkRegistry contract
- * @param initialVoiceCredits - the initial voice credits to be minted
- * @param initialVoiceCreditsProxyAddress - the address of the initialVoiceCreditsProxy contract
- * @param signupGatekeeperAddress - the address of the signupGatekeeper contract
- * @param quiet - whether to log the output
- * @returns the addresses of the deployed contracts
+ * @param DeployArgs - The arguments for the deploy command
+ * @returns The addresses of the deployed contracts
  */
-export const deploy = async (
-  stateTreeDepth: number,
-  initialVoiceCredits?: number,
-  initialVoiceCreditsProxyAddress?: string,
-  signupGatekeeperAddress?: string,
+export const deploy = async ({
+  stateTreeDepth,
+  initialVoiceCredits,
+  initialVoiceCreditsProxyAddress,
+  signupGatekeeperAddress,
   quiet = true,
-): Promise<DeployedContracts> => {
+}: DeployArgs): Promise<DeployedContracts> => {
   banner(quiet);
 
   if (initialVoiceCreditsProxyAddress && initialVoiceCredits) {

--- a/cli/ts/commands/deployPoll.ts
+++ b/cli/ts/commands/deployPoll.ts
@@ -2,43 +2,37 @@ import { BaseContract } from "ethers";
 import { type MACI, getDefaultSigner, parseArtifact } from "maci-contracts";
 import { PubKey } from "maci-domainobjs";
 
-import type { PollContracts } from "../utils/interfaces";
-
-import { banner } from "../utils/banner";
-import { contractExists } from "../utils/contracts";
-import { readContractAddress, storeContractAddress } from "../utils/storage";
-import { info, logError, logGreen } from "../utils/theme";
+import {
+  banner,
+  contractExists,
+  readContractAddress,
+  storeContractAddress,
+  info,
+  logError,
+  logGreen,
+  type DeployPollArgs,
+  type PollContracts,
+} from "../utils";
 
 /**
  * Deploy a new Poll for the set of MACI's contracts already deployed
- * @param pollDuration - the duration of the poll in seconds
- * @param maxMessages - the maximum number of messages that can be submitted
- * @param maxVoteOptions - the maximum number of vote options
- * @param intStateTreeDepth - the depth of the intermediate state tree
- * @param messageTreeSubDepth - the depth of the message tree sublevels
- * @param messageTreeDepth - the depth of the message tree
- * @param voteOptionTreeDepth - the depth of the vote option tree
- * @param coordinatorPubkey - the coordinator's public key
- * @param subsidyEnabled - whether to deploy subsidy contract
- * @param maciAddress - the MACI contract address
- * @param vkRegistryAddress - the vkRegistry contract address
- * @param quiet - whether to log the output to the console
- * @returns the addresses of the deployed contracts
+ * @param DeployPollArgs - The arguments for the deployPoll command
+ * @returns The addresses of the deployed contracts
  */
-export const deployPoll = async (
-  pollDuration: number,
-  maxMessages: number,
-  maxVoteOptions: number,
-  intStateTreeDepth: number,
-  messageTreeSubDepth: number,
-  messageTreeDepth: number,
-  voteOptionTreeDepth: number,
-  coordinatorPubkey: string,
-  subsidyEnabled: boolean,
-  maciAddress?: string,
-  vkRegistryAddress?: string,
+export const deployPoll = async ({
+  pollDuration,
+  maxMessages,
+  maxVoteOptions,
+  intStateTreeDepth,
+  messageTreeSubDepth,
+  messageTreeDepth,
+  voteOptionTreeDepth,
+  coordinatorPubkey,
+  subsidyEnabled,
+  maciAddress,
+  vkRegistryAddress,
   quiet = true,
-): Promise<PollContracts> => {
+}: DeployPollArgs): Promise<PollContracts> => {
   banner(quiet);
 
   // check if we have a vkRegistry already deployed or passed as arg

--- a/cli/ts/commands/deployVkRegistry.ts
+++ b/cli/ts/commands/deployVkRegistry.ts
@@ -2,10 +2,15 @@ import { deployVkRegistry, getDefaultSigner } from "maci-contracts";
 
 import fs from "fs";
 
-import { banner } from "../utils/banner";
-import { contractAddressesStore, oldContractAddressesStore } from "../utils/constants";
-import { resetContractAddresses, storeContractAddress } from "../utils/storage";
-import { logGreen, success } from "../utils/theme";
+import {
+  banner,
+  contractAddressesStore,
+  logGreen,
+  oldContractAddressesStore,
+  success,
+  storeContractAddress,
+  resetContractAddresses,
+} from "../utils";
 
 /**
  * Deploy the vkRegistry contract

--- a/cli/ts/commands/genKeyPair.ts
+++ b/cli/ts/commands/genKeyPair.ts
@@ -1,7 +1,6 @@
 import { Keypair } from "maci-domainobjs";
 
-import { banner } from "../utils/banner";
-import { logGreen, success } from "../utils/theme";
+import { logGreen, success, banner } from "../utils";
 
 /**
  * Generate a new Maci Key Pair

--- a/cli/ts/commands/genLocalState.ts
+++ b/cli/ts/commands/genLocalState.ts
@@ -14,35 +14,26 @@ import {
   info,
   logGreen,
   success,
+  type GenLocalStateArgs,
 } from "../utils";
 
 /**
  * Generate a local MACI state from the smart contracts events
- * @param outputPath - the path where to write the state
- * @param pollId - the id of the poll
- * @param maciContractAddress - the address of the MACI contract
- * @param coordinatorPrivateKey - the private key of the MACI coordinator
- * @param ethereumProvider - the ethereum provider
- * @param endBlock - the end block number
- * @param startBlock - the start block number
- * @param blockPerBatch - the number of blocks to fetch per batch
- * @param transactionHash - the transaction hash
- * @param sleep - the sleep time between batches
- * @param quiet - whether to log the output
+ * @param GenLocalStateArgs - The arguments for the genLocalState command
  */
-export const genLocalState = async (
-  outputPath: string,
-  pollId: number,
-  maciContractAddress?: string,
-  coordinatorPrivateKey?: string,
-  ethereumProvider?: string,
-  endBlock?: number,
-  startBlock?: number,
-  blockPerBatch?: number,
-  transactionHash?: string,
-  sleep?: number,
+export const genLocalState = async ({
+  outputPath,
+  pollId,
+  maciContractAddress,
+  coordinatorPrivateKey,
+  ethereumProvider,
+  endBlock,
+  startBlock,
+  blockPerBatch,
+  transactionHash,
+  sleep,
   quiet = true,
-): Promise<void> => {
+}: GenLocalStateArgs): Promise<void> => {
   banner(quiet);
   // validation of the maci contract address
   if (!readContractAddress("MACI") && !maciContractAddress) {

--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -15,8 +15,6 @@ import { Keypair, PrivKey } from "maci-domainobjs";
 import fs from "fs";
 import path from "path";
 
-import type { ISnarkJSVerificationKey } from "../utils/interfaces";
-
 import {
   DEFAULT_ETH_PROVIDER,
   asHex,
@@ -30,65 +28,46 @@ import {
   promptSensitiveValue,
   readContractAddress,
   success,
+  type Proof,
+  type TallyData,
+  type GenProofsArgs,
+  type ISnarkJSVerificationKey,
 } from "../utils";
-import { Proof, TallyData } from "../utils/interfaces";
 
 /**
  * Generate proofs for the message processing, tally and subsidy calculations
  * @note see different options for zkey files to use specific circuits https://maci.pse.dev/docs/trusted-setup, https://maci.pse.dev/docs/testing/#pre-compiled-artifacts-for-testing
- * @param outputDir - the directory to store the proofs
- * @param tallyFile - the file to store the tally proof
- * @param tallyZkey - the path to the tally zkey file
- * @param processZkey - the path to the process zkey file
- * @param pollId - the id of the poll
- * @param subsidyFile - the file to store the subsidy proof
- * @param subsidyZkey - the path to the subsidy zkey file
- * @param rapidsnark - the path to the rapidsnark binary
- * @param processWitgen - the path to the process witnessgen binary
- * @param tallyWitgen - the path to the tally witnessgen binary
- * @param subsidyWitgen - the path to the subsidy witnessgen binary
- * @param coordinatorPrivKey - the coordinator's private key
- * @param maciAddress - the address of the MACI contract
- * @param transactionHash - the transaction hash of the first transaction
- * @param processWasm - the path to the process wasm file
- * @param tallyWasm - the path to the tally wasm file
- * @param subsidyWasm - the path to the subsidy wasm file
- * @param useWasm - whether to use wasm or rapidsnark
- * @param stateFile - the file with the serialized maci state
- * @param startBlock - the block number to start fetching logs from
- * @param blocksPerBatch - the number of blocks to fetch logs from
- * @param endBlock - the block number to stop fetching logs from
- * @param quiet - whether to log the output
- * @returns the tally data
+ * @param GenProofsArgs - The arguments for the genProofs command
+ * @returns The tally data
  */
-export const genProofs = async (
-  outputDir: string,
-  tallyFile: string,
-  tallyZkey: string,
-  processZkey: string,
-  pollId: number,
-  subsidyFile?: string,
-  subsidyZkey?: string,
-  rapidsnark?: string,
-  processWitgen?: string,
-  processDatFile?: string,
-  tallyWitgen?: string,
-  tallyDatFile?: string,
-  subsidyWitgen?: string,
-  subsidyDatFile?: string,
-  coordinatorPrivKey?: string,
-  maciAddress?: string,
-  transactionHash?: string,
-  processWasm?: string,
-  tallyWasm?: string,
-  subsidyWasm?: string,
-  useWasm?: boolean,
-  stateFile?: string,
-  startBlock?: number,
-  blocksPerBatch?: number,
-  endBlock?: number,
+export const genProofs = async ({
+  outputDir,
+  tallyFile,
+  tallyZkey,
+  processZkey,
+  pollId,
+  subsidyFile,
+  subsidyZkey,
+  rapidsnark,
+  processWitgen,
+  processDatFile,
+  tallyWitgen,
+  tallyDatFile,
+  subsidyWitgen,
+  subsidyDatFile,
+  coordinatorPrivKey,
+  maciAddress,
+  transactionHash,
+  processWasm,
+  tallyWasm,
+  subsidyWasm,
+  useWasm,
+  stateFile,
+  startBlock,
+  blocksPerBatch,
+  endBlock,
   quiet = true,
-): Promise<TallyData> => {
+}: GenProofsArgs): Promise<TallyData> => {
   banner(quiet);
 
   // if we do not have the output directory just create it

--- a/cli/ts/commands/genPubKey.ts
+++ b/cli/ts/commands/genPubKey.ts
@@ -1,8 +1,7 @@
 import { genPubKey } from "maci-crypto";
 import { PrivKey, PubKey } from "maci-domainobjs";
 
-import { banner } from "../utils/banner";
-import { logError, logGreen, success } from "../utils/theme";
+import { banner, logError, logGreen, success } from "../utils";
 
 /**
  * Generate a new Maci Public key from a private key

--- a/cli/ts/commands/mergeMessages.ts
+++ b/cli/ts/commands/mergeMessages.ts
@@ -12,21 +12,19 @@ import {
   logYellow,
   success,
   readContractAddress,
+  type MergeMessagesArgs,
 } from "../utils";
 
 /**
  * Merge the message queue on chain
- * @param pollId - the id of the poll
- * @param quiet - whether to log the output
- * @param maciContractAddress - the address of the MACI contract
- * @param numQueueOps - the number of queue operations to merge
+ * @param MergeMessagesArgs - The arguments for the mergeMessages command
  */
-export const mergeMessages = async (
-  pollId: number,
-  maciContractAddress?: string,
-  numQueueOps?: string,
+export const mergeMessages = async ({
+  pollId,
   quiet = true,
-): Promise<void> => {
+  maciContractAddress,
+  numQueueOps,
+}: MergeMessagesArgs): Promise<void> => {
   banner(quiet);
   const signer = await getDefaultSigner();
 

--- a/cli/ts/commands/mergeSignups.ts
+++ b/cli/ts/commands/mergeSignups.ts
@@ -12,21 +12,19 @@ import {
   logYellow,
   success,
   readContractAddress,
+  type MergeSignupsArgs,
 } from "../utils";
 
 /**
  * Command to merge the signups of a MACI contract
- * @param pollId - the id of the poll
- * @param maciContractAddress - the address of the MACI contract
- * @param numQueueOps - the number of queue operations to perform
- * @param quiet - whether to log the output
+ * @param MergeSignupsArgs - The arguments for the mergeSignups command
  */
-export const mergeSignups = async (
-  pollId: number,
-  maciContractAddress?: string,
-  numQueueOps?: string,
+export const mergeSignups = async ({
+  pollId,
+  maciContractAddress,
+  numQueueOps,
   quiet = true,
-): Promise<void> => {
+}: MergeSignupsArgs): Promise<void> => {
   banner(quiet);
   const signer = await getDefaultSigner();
 

--- a/cli/ts/commands/proveOnChain.ts
+++ b/cli/ts/commands/proveOnChain.ts
@@ -32,30 +32,24 @@ import {
   logYellow,
   readContractAddress,
   success,
+  type Proof,
+  type ProveOnChainArgs,
 } from "../utils";
-import { Proof } from "../utils/interfaces";
 
 /**
  * Command to prove the result of a poll on-chain
- * @param pollId - the id of the poll
- * @param proofDir - the directory containing the proofs
- * @param subsidyEnabled - whether to deploy subsidy contract
- * @param maciAddress - the address of the MACI contract
- * @param messageProcessorAddress - the address of the MessageProcessor contract
- * @param tallyAddress - the address of the Tally contract
- * @param subsidyAddress - the address of the Subsidy contract
- * @param quiet - whether to log the output
+ * @param ProveOnChainArgs - The arguments for the proveOnChain command
  */
-export const proveOnChain = async (
-  pollId: string,
-  proofDir: string,
-  subsidyEnabled: boolean,
-  maciAddress?: string,
-  messageProcessorAddress?: string,
-  tallyAddress?: string,
-  subsidyAddress?: string,
+export const proveOnChain = async ({
+  pollId,
+  proofDir,
+  subsidyEnabled,
+  maciAddress,
+  messageProcessorAddress,
+  tallyAddress,
+  subsidyAddress,
   quiet = true,
-): Promise<void> => {
+}: ProveOnChainArgs): Promise<void> => {
   banner(quiet);
   const signer = await getDefaultSigner();
 

--- a/cli/ts/commands/publish.ts
+++ b/cli/ts/commands/publish.ts
@@ -3,39 +3,36 @@ import { type MACI, type Poll, getDefaultSigner, parseArtifact } from "maci-cont
 import { genRandomSalt } from "maci-crypto";
 import { Keypair, PCommand, PrivKey, PubKey } from "maci-domainobjs";
 
-import { banner } from "../utils/banner";
-import { contractExists } from "../utils/contracts";
-import { promptSensitiveValue } from "../utils/prompts";
-import { validateSalt } from "../utils/salt";
-import { readContractAddress } from "../utils/storage";
-import { info, logError, logGreen, logYellow } from "../utils/theme";
+import {
+  type PublishArgs,
+  info,
+  logError,
+  logGreen,
+  logYellow,
+  readContractAddress,
+  validateSalt,
+  promptSensitiveValue,
+  contractExists,
+  banner,
+} from "../utils";
 
 /**
  * Publish a new message to a MACI Poll contract
- * @param pubkey - the public key of the user
- * @param stateIndex - the index of the state leaf
- * @param voteOptionIndex - the index of the vote option
- * @param nonce - the nonce of the message
- * @param pollId - the id of the poll
- * @param newVoteWeight - the new vote weight
- * @param maciContractAddress - the address of the MACI contract
- * @param salt - the salt of the message
- * @param privateKey - the private key of the user
- * @param quiet - whether to log the output
- * @returns the ephemeral private key used to encrypt the message
+ * @param PublishArgs - The arguments for the publish command
+ * @returns The ephemeral private key used to encrypt the message
  */
-export const publish = async (
-  pubkey: string,
-  stateIndex: number,
-  voteOptionIndex: number,
-  nonce: number,
-  pollId: number,
-  newVoteWeight: number,
-  maciContractAddress?: string,
-  salt?: string,
-  privateKey?: string,
+export const publish = async ({
+  pubkey,
+  stateIndex,
+  voteOptionIndex,
+  nonce,
+  pollId,
+  newVoteWeight,
+  maciContractAddress,
+  salt,
+  privateKey,
   quiet = true,
-): Promise<string> => {
+}: PublishArgs): Promise<string> => {
   banner(quiet);
 
   // validate that the pub key of the user is valid

--- a/cli/ts/commands/setVerifyingKeys.ts
+++ b/cli/ts/commands/setVerifyingKeys.ts
@@ -6,38 +6,36 @@ import { VerifyingKey } from "maci-domainobjs";
 
 import fs from "fs";
 
-import { compareVks } from "../utils";
-import { banner } from "../utils/banner";
-import { contractExists } from "../utils/contracts";
-import { readContractAddress } from "../utils/storage";
-import { info, logError, logGreen, logYellow, success } from "../utils/theme";
+import {
+  type SetVerifyingKeysArgs,
+  info,
+  logError,
+  logGreen,
+  logYellow,
+  success,
+  readContractAddress,
+  contractExists,
+  banner,
+  compareVks,
+} from "../utils";
 
 /**
  * Function that sets the verifying keys in the VkRegistry contract
  * @note see different options for zkey files to use specific circuits https://maci.pse.dev/docs/trusted-setup, https://maci.pse.dev/docs/testing/#pre-compiled-artifacts-for-testing
- * @param stateTreeDepth - the depth of the state tree
- * @param intStateTreeDepth - the depth of the state subtree
- * @param messageTreeDepth - the depth of the message tree
- * @param voteOptionTreeDepth - the depth of the vote option tree
- * @param messageBatchDepth - the depth of the message batch tree
- * @param processMessagesZkeyPath - the path to the process messages zkey
- * @param tallyVotesZkeyPath - the path to the tally votes zkey
- * @param vkRegistry - the address of the vkRegistry contract
- * @param subsidyZkeyPath - the path to the subsidy zkey
- * @param quiet - whether to log the output
+ * @param SetVerifyingKeysArgs - The arguments for the setVerifyingKeys command
  */
-export const setVerifyingKeys = async (
-  stateTreeDepth: number,
-  intStateTreeDepth: number,
-  messageTreeDepth: number,
-  voteOptionTreeDepth: number,
-  messageBatchDepth: number,
-  processMessagesZkeyPath: string,
-  tallyVotesZkeyPath: string,
-  vkRegistry?: string,
-  subsidyZkeyPath?: string,
+export const setVerifyingKeys = async ({
+  stateTreeDepth,
+  intStateTreeDepth,
+  messageTreeDepth,
+  voteOptionTreeDepth,
+  messageBatchDepth,
+  processMessagesZkeyPath,
+  tallyVotesZkeyPath,
+  vkRegistry,
+  subsidyZkeyPath,
   quiet = true,
-): Promise<void> => {
+}: SetVerifyingKeysArgs): Promise<void> => {
   banner(quiet);
   // we must either have the contract as param or stored to file
   if (!readContractAddress("VkRegistry") && !vkRegistry) {

--- a/cli/ts/commands/showContracts.ts
+++ b/cli/ts/commands/showContracts.ts
@@ -1,8 +1,6 @@
 import fs from "fs";
 
-import { banner } from "../utils/banner";
-import { contractAddressesStore } from "../utils/constants";
-import { logGreen, info, logError } from "../utils/theme";
+import { banner, contractAddressesStore, logGreen, info, logError } from "../utils";
 
 /**
  * Utility to print all contracts that have been deployed using maci-cli

--- a/cli/ts/commands/signup.ts
+++ b/cli/ts/commands/signup.ts
@@ -2,28 +2,32 @@ import { BaseContract } from "ethers";
 import { type MACI, getDefaultSigner, parseArtifact } from "maci-contracts";
 import { PubKey } from "maci-domainobjs";
 
-import { banner } from "../utils";
-import { contractExists } from "../utils/contracts";
-import { DEFAULT_IVCP_DATA, DEFAULT_SG_DATA } from "../utils/defaults";
-import { readContractAddress } from "../utils/storage";
-import { info, logError, logGreen, logYellow, success } from "../utils/theme";
+import {
+  type SignupArgs,
+  banner,
+  contractExists,
+  DEFAULT_IVCP_DATA,
+  DEFAULT_SG_DATA,
+  readContractAddress,
+  info,
+  logError,
+  logGreen,
+  logYellow,
+  success,
+} from "../utils";
 
 /**
  * Signup a user to the MACI contract
- * @param maciPubKey - the public key of the user
- * @param maciAddress - the address of the MACI contract
- * @param sgDataArg - the signup gateway data
- * @param ivcpDataArg - the initial voice credit proxy data
- * @param quiet - whether to log the output
- * @returns the state index of the user
+ * @param SignupArgs - The arguments for the signup command
+ * @returns The state index of the user
  */
-export const signup = async (
-  maciPubKey: string,
-  maciAddress?: string,
-  sgDataArg?: string,
-  ivcpDataArg?: string,
+export const signup = async ({
+  maciPubKey,
+  maciAddress,
+  sgDataArg,
+  ivcpDataArg,
   quiet = true,
-): Promise<string> => {
+}: SignupArgs): Promise<string> => {
   banner(quiet);
 
   const signer = await getDefaultSigner();

--- a/cli/ts/commands/timeTravel.ts
+++ b/cli/ts/commands/timeTravel.ts
@@ -2,8 +2,7 @@ import { getDefaultSigner } from "maci-contracts";
 
 import type { JsonRpcProvider } from "ethers";
 
-import { banner } from "../utils/banner";
-import { logError, logGreen, success } from "../utils/theme";
+import { banner, logError, logGreen, success } from "../utils";
 
 /**
  * Utility to travel in time when using a local blockchain

--- a/cli/ts/commands/topup.ts
+++ b/cli/ts/commands/topup.ts
@@ -1,26 +1,13 @@
 import { BaseContract } from "ethers";
 import { type MACI, type Poll, getDefaultSigner, parseArtifact } from "maci-contracts";
 
-import { contractExists } from "../utils/contracts";
-import { banner } from "../utils/index";
-import { readContractAddress } from "../utils/storage";
-import { logError } from "../utils/theme";
+import { type TopupArgs, logError, readContractAddress, contractExists, banner } from "../utils";
 
 /**
  * Publish a topup message
- * @param amount - the amount to topup
- * @param stateIndex - the state index of the user
- * @param pollId - the poll ID
- * @param maciAddress - the address of the MACI contract
- * @param quiet - whether to log the output
+ * @param TopupArgs - The arguments for the topup command
  */
-export const topup = async (
-  amount: number,
-  stateIndex: number,
-  pollId: number,
-  maciAddress?: string,
-  quiet = true,
-): Promise<void> => {
+export const topup = async ({ amount, stateIndex, pollId, maciAddress, quiet = true }: TopupArgs): Promise<void> => {
   banner(quiet);
   const signer = await getDefaultSigner();
 

--- a/cli/ts/commands/verify.ts
+++ b/cli/ts/commands/verify.ts
@@ -4,33 +4,37 @@ import { hash2, hash3, genTreeCommitment } from "maci-crypto";
 
 import fs from "fs";
 
-import type { SubsidyData, TallyData } from "../utils/interfaces";
-
-import { banner, contractExists, info, logError, logGreen, logYellow, readContractAddress, success } from "../utils";
-import { verifyPerVOSpentVoiceCredits, verifyTallyResults } from "../utils/verifiers";
+import {
+  type SubsidyData,
+  type TallyData,
+  type VerifyArgs,
+  banner,
+  contractExists,
+  info,
+  logError,
+  logGreen,
+  logYellow,
+  verifyPerVOSpentVoiceCredits,
+  verifyTallyResults,
+  readContractAddress,
+  success,
+} from "../utils";
 
 /**
  * Verify the results of a poll and optionally the subsidy results on-chain
- * @param pollId - the id of the poll
- * @param subsidyEnabled - whether to deploy subsidy contract
- * @param tallyFile - the path to the tally file with results, per vote option spent credits, spent voice credits total
- * @param maciAddress - the address of the MACI contract
- * @param tallyAddress - the address of the Tally contract
- * @param subsidyAddress - the address of the Subsidy contract
- * @param subsidyFile - the path to the subsidy file
- * @param quiet - whether to log the output
+ * @param VerifyArgs - The arguments for the verify command
  */
-export const verify = async (
-  pollId: string,
-  subsidyEnabled: boolean,
-  tallyFile?: string,
-  tallyData?: TallyData,
-  maciAddress?: string,
-  tallyAddress?: string,
-  subsidyAddress?: string,
-  subsidyFile?: string,
+export const verify = async ({
+  pollId,
+  subsidyEnabled,
+  tallyFile,
+  tallyData,
+  maciAddress,
+  tallyAddress,
+  subsidyAddress,
+  subsidyFile,
   quiet = true,
-): Promise<void> => {
+}: VerifyArgs): Promise<void> => {
   banner(quiet);
   const signer = await getDefaultSigner();
 

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -50,13 +50,13 @@ program
   .requiredOption("-s, --stateTreeDepth <stateTreeDepth>", "the state tree depth", parseInt)
   .action(async (cmdOptions) => {
     try {
-      await deploy(
-        cmdOptions.stateTreeDepth,
-        cmdOptions.initialVoiceCredits,
-        cmdOptions.initialVoiceCreditsProxyAddress,
-        cmdOptions.signupGatekeeperAddress,
-        cmdOptions.quiet,
-      );
+      await deploy({
+        stateTreeDepth: cmdOptions.stateTreeDepth,
+        initialVoiceCredits: cmdOptions.initialVoiceCredits,
+        initialVoiceCreditsProxyAddress: cmdOptions.initialVoiceCreditsProxyAddress,
+        signupGatekeeperAddress: cmdOptions.signupGatekeeperAddress,
+        quiet: cmdOptions.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -86,18 +86,18 @@ program
   )
   .action(async (cmdOptions) => {
     try {
-      await checkVerifyingKeys(
-        cmdOptions.stateTreeDepth,
-        cmdOptions.intStateTreeDepth,
-        cmdOptions.msgTreeDepth,
-        cmdOptions.voteOptionTreeDepth,
-        cmdOptions.msgBatchDepth,
-        cmdOptions.processMessagesZkey,
-        cmdOptions.tallyVotesZkey,
-        cmdOptions.vkContract,
-        cmdOptions.subsidyZkey,
-        cmdOptions.quiet,
-      );
+      await checkVerifyingKeys({
+        stateTreeDepth: cmdOptions.stateTreeDepth,
+        intStateTreeDepth: cmdOptions.intStateTreeDepth,
+        messageTreeDepth: cmdOptions.msgTreeDepth,
+        voteOptionTreeDepth: cmdOptions.voteOptionTreeDepth,
+        messageBatchDepth: cmdOptions.msgBatchDepth,
+        processMessagesZkeyPath: cmdOptions.processMessagesZkey,
+        tallyVotesZkeyPath: cmdOptions.tallyVotesZkey,
+        vkRegistry: cmdOptions.vkContract,
+        subsidyZkeyPath: cmdOptions.subsidyZkey,
+        quiet: cmdOptions.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -130,7 +130,13 @@ program
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
     try {
-      await airdrop(cmdObj.amount, cmdObj.contract, cmdObj.pollId, cmdObj.tokenAddress, cmdObj.quiet);
+      await airdrop({
+        amount: cmdObj.amount,
+        maciAddress: cmdObj.contract,
+        pollId: cmdObj.pollId,
+        contractAddress: cmdObj.tokenAddress,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -182,20 +188,20 @@ program
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
     try {
-      await deployPoll(
-        cmdObj.duration,
-        cmdObj.maxMessages,
-        cmdObj.maxVoteOptions,
-        cmdObj.intStateTreeDepth,
-        cmdObj.msgBatchDepth,
-        cmdObj.msgTreeDepth,
-        cmdObj.voteOptionTreeDepth,
-        cmdObj.pubkey,
-        cmdObj.subsidyEnabled,
-        cmdObj.maciAddress,
-        cmdObj.vkRegistryAddress,
-        cmdObj.quiet,
-      );
+      await deployPoll({
+        pollDuration: cmdObj.duration,
+        maxMessages: cmdObj.maxMessages,
+        maxVoteOptions: cmdObj.maxVoteOptions,
+        intStateTreeDepth: cmdObj.intStateTreeDepth,
+        messageTreeSubDepth: cmdObj.msgBatchDepth,
+        messageTreeDepth: cmdObj.msgTreeDepth,
+        voteOptionTreeDepth: cmdObj.voteOptionTreeDepth,
+        coordinatorPubkey: cmdObj.pubkey,
+        subsidyEnabled: cmdObj.subsidyEnabled,
+        maciAddress: cmdObj.maciAddress,
+        vkRegistryAddress: cmdObj.vkRegistryAddress,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -225,18 +231,18 @@ program
   )
   .action(async (cmdObj) => {
     try {
-      await setVerifyingKeys(
-        cmdObj.stateTreeDepth,
-        cmdObj.intStateTreeDepth,
-        cmdObj.msgTreeDepth,
-        cmdObj.voteOptionTreeDepth,
-        cmdObj.msgBatchDepth,
-        cmdObj.processMessagesZkey,
-        cmdObj.tallyVotesZkey,
-        cmdObj.vkRegistry,
-        cmdObj.subsidyZkey,
-        cmdObj.quiet,
-      );
+      await setVerifyingKeys({
+        stateTreeDepth: cmdObj.stateTreeDepth,
+        intStateTreeDepth: cmdObj.intStateTreeDepth,
+        messageTreeDepth: cmdObj.msgTreeDepth,
+        voteOptionTreeDepth: cmdObj.voteOptionTreeDepth,
+        messageBatchDepth: cmdObj.msgBatchDepth,
+        processMessagesZkeyPath: cmdObj.processMessagesZkey,
+        tallyVotesZkeyPath: cmdObj.tallyVotesZkey,
+        vkRegistry: cmdObj.vkRegistry,
+        subsidyZkeyPath: cmdObj.subsidyZkey,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -260,18 +266,18 @@ program
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
     try {
-      await publish(
-        cmdObj.pubkey,
-        cmdObj.stateIndex,
-        cmdObj.voteOptionIndex,
-        cmdObj.nonce,
-        cmdObj.pollId,
-        cmdObj.newVoteWeight,
-        cmdObj.contract,
-        cmdObj.salt,
-        cmdObj.privkey,
-        cmdObj.quiet,
-      );
+      await publish({
+        pubkey: cmdObj.pubkey,
+        stateIndex: cmdObj.stateIndex,
+        voteOptionIndex: cmdObj.voteOptionIndex,
+        nonce: cmdObj.nonce,
+        pollId: cmdObj.pollId,
+        newVoteWeight: cmdObj.newVoteWeight,
+        maciContractAddress: cmdObj.contract,
+        salt: cmdObj.salt,
+        privateKey: cmdObj.privkey,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -286,7 +292,12 @@ program
   .option("-n, --num-queue-ops <numQueueOps>", "the number of queue operations", parseInt)
   .action(async (cmdObj) => {
     try {
-      await mergeMessages(cmdObj.pollId, cmdObj.maciContractAddress, cmdObj.numQueueOps?.toString(), cmdObj.quiet);
+      await mergeMessages({
+        pollId: cmdObj.pollId,
+        maciContractAddress: cmdObj.maciContractAddress,
+        numQueueOps: cmdObj.numQueueOps?.toString(),
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -301,7 +312,12 @@ program
   .option("-n, --num-queue-ops <numQueueOps>", "the number of queue operations", parseInt)
   .action(async (cmdObj) => {
     try {
-      await mergeSignups(cmdObj.pollId, cmdObj.maciContractAddress, cmdObj.numQueueOps?.toString(), cmdObj.quiet);
+      await mergeSignups({
+        pollId: cmdObj.pollId,
+        maciContractAddress: cmdObj.maciContractAddress,
+        numQueueOps: cmdObj.numQueueOps?.toString(),
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -330,7 +346,13 @@ program
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
     try {
-      await signup(cmdObj.pubkey, cmdObj.maciAddress, cmdObj.sgData, cmdObj.ivcpData, cmdObj.quiet);
+      await signup({
+        maciPubKey: cmdObj.pubkey,
+        maciAddress: cmdObj.maciAddress,
+        sgDataArg: cmdObj.sgData,
+        ivcpDataArg: cmdObj.ivcpData,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -346,7 +368,13 @@ program
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
     try {
-      await topup(cmdObj.amount, cmdObj.stateIndex, cmdObj.pollId, cmdObj.maciAddress, cmdObj.quiet);
+      await topup({
+        amount: cmdObj.amount,
+        stateIndex: cmdObj.stateIndex,
+        pollId: cmdObj.pollId,
+        maciAddress: cmdObj.maciAddress,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -387,17 +415,16 @@ program
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
     try {
-      await verify(
-        cmdObj.pollId.toString(),
-        cmdObj.subsidyEnabled,
-        cmdObj.tallyFile,
-        undefined,
-        cmdObj.contract,
-        cmdObj.tallyContract,
-        cmdObj.subsidyContract,
-        cmdObj.subsidyFile,
-        cmdObj.quiet,
-      );
+      await verify({
+        pollId: cmdObj.pollId.toString(),
+        subsidyEnabled: cmdObj.subsidyEnabled,
+        tallyFile: cmdObj.tallyFile,
+        maciAddress: cmdObj.contract,
+        tallyAddress: cmdObj.tallyContract,
+        subsidyAddress: cmdObj.subsidyContract,
+        subsidyFile: cmdObj.subsidyFile,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -437,34 +464,34 @@ program
   .option("-bb, --blocks-per-batch <blockPerBatch>", "the number of blocks to process per batch", parseInt)
   .action(async (cmdObj) => {
     try {
-      await genProofs(
-        cmdObj.output,
-        cmdObj.tallyFile,
-        cmdObj.tallyZkey,
-        cmdObj.processZkey,
-        cmdObj.pollId,
-        cmdObj.subsidyFile,
-        cmdObj.subsidyZkey,
-        cmdObj.rapidsnark,
-        cmdObj.processWitnessgen,
-        cmdObj.processWitnessdat,
-        cmdObj.tallyWitnessgen,
-        cmdObj.tallyWitnessdat,
-        cmdObj.subsidyWitnessgen,
-        cmdObj.subsidyWitnessdat,
-        cmdObj.privkey,
-        cmdObj.contract,
-        cmdObj.transactionHash,
-        cmdObj.processWasm,
-        cmdObj.tallyWasm,
-        cmdObj.subsidyWasm,
-        cmdObj.wasm,
-        cmdObj.stateFile,
-        cmdObj.startBlock,
-        cmdObj.endBlock,
-        cmdObj.blocksPerBatch,
-        cmdObj.quiet,
-      );
+      await genProofs({
+        outputDir: cmdObj.output,
+        tallyFile: cmdObj.tallyFile,
+        tallyZkey: cmdObj.tallyZkey,
+        processZkey: cmdObj.processZkey,
+        pollId: cmdObj.pollId,
+        subsidyFile: cmdObj.subsidyFile,
+        subsidyZkey: cmdObj.subsidyZkey,
+        rapidsnark: cmdObj.rapidsnark,
+        processWitgen: cmdObj.processWitnessgen,
+        processDatFile: cmdObj.processWitnessdat,
+        tallyWitgen: cmdObj.tallyWitnessgen,
+        tallyDatFile: cmdObj.tallyWitnessdat,
+        subsidyWitgen: cmdObj.subsidyWitnessgen,
+        subsidyDatFile: cmdObj.subsidyWitnessdat,
+        coordinatorPrivKey: cmdObj.privkey,
+        maciAddress: cmdObj.contract,
+        transactionHash: cmdObj.transactionHash,
+        processWasm: cmdObj.processWasm,
+        tallyWasm: cmdObj.tallyWasm,
+        subsidyWasm: cmdObj.subsidyWasm,
+        useWasm: cmdObj.wasm,
+        stateFile: cmdObj.stateFile,
+        startBlock: cmdObj.startBlock,
+        endBlock: cmdObj.endBlock,
+        blocksPerBatch: cmdObj.blocksPerBatch,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -485,19 +512,19 @@ program
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
     try {
-      await genLocalState(
-        cmdObj.output.toString(),
-        cmdObj.pollId,
-        cmdObj.contract,
-        cmdObj.privkey,
-        cmdObj.rpcProvider,
-        cmdObj.endBlock,
-        cmdObj.startBlock,
-        cmdObj.blocksPerBatch,
-        cmdObj.transactionHash,
-        cmdObj.sleep,
-        cmdObj.quiet,
-      );
+      await genLocalState({
+        outputPath: cmdObj.output.toString(),
+        pollId: cmdObj.pollId,
+        maciContractAddress: cmdObj.contract,
+        coordinatorPrivateKey: cmdObj.privkey,
+        ethereumProvider: cmdObj.rpcProvider,
+        endBlock: cmdObj.endBlock,
+        startBlock: cmdObj.startBlock,
+        blockPerBatch: cmdObj.blocksPerBatch,
+        transactionHash: cmdObj.transactionHash,
+        sleep: cmdObj.sleep,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -521,16 +548,16 @@ program
   .requiredOption("-f, --proof-dir <proofDir>", "the proof output directory from the genProofs subcommand")
   .action(async (cmdObj) => {
     try {
-      await proveOnChain(
-        cmdObj.pollId.toString(),
-        cmdObj.proofDir,
-        cmdObj.subsidyEnabled,
-        cmdObj.contract,
-        cmdObj.messageProcessorAddress,
-        cmdObj.tallyContract,
-        cmdObj.subsidyContract,
-        cmdObj.quiet,
-      );
+      await proveOnChain({
+        pollId: cmdObj.pollId.toString(),
+        proofDir: cmdObj.proofDir,
+        subsidyEnabled: cmdObj.subsidyEnabled,
+        maciAddress: cmdObj.contract,
+        messageProcessorAddress: cmdObj.messageProcessorAddress,
+        tallyAddress: cmdObj.tallyContract,
+        subsidyAddress: cmdObj.subsidyContract,
+        quiet: cmdObj.quiet,
+      });
     } catch (error) {
       program.error((error as Error).message, { exitCode: 1 });
     }
@@ -563,4 +590,20 @@ export {
   verify,
 } from "./commands";
 
-export type { DeployedContracts, PollContracts, TallyData } from "./utils";
+export type {
+  DeployedContracts,
+  PollContracts,
+  TallyData,
+  DeployPollArgs,
+  GenLocalStateArgs,
+  GenProofsArgs,
+  PublishArgs,
+  SignupArgs,
+  MergeMessagesArgs,
+  MergeSignupsArgs,
+  AirdropArgs,
+  TopupArgs,
+  VerifyArgs,
+  ProveOnChainArgs,
+  DeployArgs,
+} from "./utils";

--- a/cli/ts/utils/index.ts
+++ b/cli/ts/utils/index.ts
@@ -14,7 +14,28 @@ export {
   DEFAULT_IVCP_DATA,
   DEFAULT_SR_QUEUE_OPS,
 } from "./defaults";
-export type { DeployedContracts, PollContracts, TallyData } from "./interfaces";
+export type {
+  AirdropArgs,
+  CheckVerifyingKeysArgs,
+  DeployArgs,
+  DeployedContracts,
+  GenLocalStateArgs,
+  GenProofsArgs,
+  Proof,
+  ISnarkJSVerificationKey,
+  SignupArgs,
+  SetVerifyingKeysArgs,
+  MergeMessagesArgs,
+  MergeSignupsArgs,
+  ProveOnChainArgs,
+  PublishArgs,
+  DeployPollArgs,
+  PollContracts,
+  TallyData,
+  TopupArgs,
+  VerifyArgs,
+  SubsidyData,
+} from "./interfaces";
 export { compareVks } from "./vks";
 export { delay } from "./time";
 export {
@@ -27,3 +48,5 @@ export {
 export { logRed, logGreen, logYellow, logMagenta, logError, info, success, warning, error } from "./theme";
 export { promptSensitiveValue } from "./prompts";
 export { asHex } from "./formatting";
+export { validateSalt } from "./salt";
+export { verifyPerVOSpentVoiceCredits, verifyTallyResults } from "./verifiers";

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -140,3 +140,694 @@ export interface ISnarkJSVerificationKey {
   vk_alphabeta_12: BigNumberish[][][];
   IC: BigNumberish[][];
 }
+
+/**
+ * Interface for the arguments to the airdrop command
+ */
+export interface AirdropArgs {
+  /**
+   * The amount of credits to airdrop
+   */
+  amount: number;
+
+  /**
+   * The address of the ERC20 contract
+   */
+  contractAddress?: string;
+
+  /**
+   * The id of the poll
+   */
+  pollId?: number;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the checkVerifyingKeys command
+ */
+export interface CheckVerifyingKeysArgs {
+  /**
+   * The depth of the state tree
+   */
+  stateTreeDepth: number;
+
+  /**
+   * The depth of the state subtree
+   */
+  intStateTreeDepth: number;
+
+  /**
+   * The depth of the message tree
+   */
+  messageTreeDepth: number;
+
+  /**
+   * The depth of the vote option tree
+   */
+  voteOptionTreeDepth: number;
+
+  /**
+   * The depth of the message batch tree
+   */
+  messageBatchDepth: number;
+
+  /**
+   * The path to the process messages zkey
+   */
+  processMessagesZkeyPath: string;
+
+  /**
+   * The path to the tally votes zkey
+   */
+  tallyVotesZkeyPath: string;
+
+  /**
+   * The address of the VkRegistry contract
+   */
+  vkRegistry?: string;
+
+  /**
+   * The path to the subsidy zkey
+   */
+  subsidyZkeyPath?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the deploy command
+ */
+export interface DeployArgs {
+  /**
+   * The depth of the state tree
+   */
+  stateTreeDepth: number;
+
+  /**
+   * The initial voice credits to be minted
+   */
+  initialVoiceCredits?: number;
+
+  /**
+   * The address of the initialVoiceCreditsProxy contract
+   */
+  initialVoiceCreditsProxyAddress?: string;
+
+  /**
+   * The address of the signupGatekeeper contract
+   */
+  signupGatekeeperAddress?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the deployPoll command
+ */
+export interface DeployPollArgs {
+  /**
+   * The duration of the poll in seconds
+   */
+  pollDuration: number;
+
+  /**
+   * The maximum number of messages that can be submitted
+   */
+  maxMessages: number;
+
+  /**
+   * The maximum number of vote options
+   */
+  maxVoteOptions: number;
+
+  /**
+   * The depth of the intermediate state tree
+   */
+  intStateTreeDepth: number;
+
+  /**
+   * The depth of the message tree sublevels
+   */
+  messageTreeSubDepth: number;
+
+  /**
+   * The depth of the message tree
+   */
+  messageTreeDepth: number;
+
+  /**
+   * The depth of the vote option tree
+   */
+  voteOptionTreeDepth: number;
+
+  /**
+   * The coordinator's public key
+   */
+  coordinatorPubkey: string;
+
+  /**
+   * Whether to deploy subsidy contract
+   */
+  subsidyEnabled: boolean;
+
+  /**
+   * The MACI contract address
+   */
+  maciAddress?: string;
+
+  /**
+   * The vkRegistry contract address
+   */
+  vkRegistryAddress?: string;
+
+  /**
+   * Whether to log the output to the console
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the genLocalState command
+ * Generate a local MACI state from the smart contracts events
+ */
+export interface GenLocalStateArgs {
+  /**
+   * The path where to write the state
+   */
+  outputPath: string;
+
+  /**
+   * The id of the poll
+   */
+  pollId: number;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciContractAddress?: string;
+
+  /**
+   * The private key of the MACI coordinator
+   */
+  coordinatorPrivateKey?: string;
+
+  /**
+   * The ethereum provider
+   */
+  ethereumProvider?: string;
+
+  /**
+   * The end block number
+   */
+  endBlock?: number;
+
+  /**
+   * The start block number
+   */
+  startBlock?: number;
+
+  /**
+   * The number of blocks to fetch per batch
+   */
+  blockPerBatch?: number;
+
+  /**
+   * The transaction hash
+   */
+  transactionHash?: string;
+
+  /**
+   * The sleep time between batches
+   */
+  sleep?: number;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the genProof command
+ */
+export interface GenProofsArgs {
+  /**
+   * The directory to store the proofs
+   */
+  outputDir: string;
+
+  /**
+   * The file to store the tally proof
+   */
+  tallyFile: string;
+
+  /**
+   * The path to the tally zkey file
+   */
+  tallyZkey: string;
+
+  /**
+   * The path to the process zkey file
+   */
+  processZkey: string;
+
+  /**
+   * The id of the poll
+   */
+  pollId: number;
+
+  /**
+   * The file to store the subsidy proof
+   */
+  subsidyFile?: string;
+
+  /**
+   * The path to the subsidy zkey file
+   */
+  subsidyZkey?: string;
+
+  /**
+   * The path to the rapidsnark binary
+   */
+  rapidsnark?: string;
+
+  /**
+   * The path to the process witnessgen binary
+   */
+  processWitgen?: string;
+
+  /**
+   * The path to the process dat file
+   */
+  processDatFile?: string;
+
+  /**
+   * The path to the tally witnessgen binary
+   */
+  tallyWitgen?: string;
+
+  /**
+   * The path to the tally dat file
+   */
+  tallyDatFile?: string;
+
+  /**
+   * The path to the subsidy witnessgen binary
+   */
+  subsidyWitgen?: string;
+
+  /**
+   * The path to the subsidy dat file
+   */
+  subsidyDatFile?: string;
+
+  /**
+   * The coordinator's private key
+   */
+  coordinatorPrivKey?: string;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress?: string;
+
+  /**
+   * The transaction hash of the first transaction
+   */
+  transactionHash?: string;
+
+  /**
+   * The path to the process wasm file
+   */
+  processWasm?: string;
+
+  /**
+   * The path to the tally wasm file
+   */
+  tallyWasm?: string;
+
+  /**
+   * The path to the subsidy wasm file
+   */
+  subsidyWasm?: string;
+
+  /**
+   * Whether to use wasm or rapidsnark
+   */
+  useWasm?: boolean;
+
+  /**
+   * The file with the serialized maci state
+   */
+  stateFile?: string;
+
+  /**
+   * The block number to start fetching logs from
+   */
+  startBlock?: number;
+
+  /**
+   * The number of blocks to fetch logs from
+   */
+  blocksPerBatch?: number;
+
+  /**
+   * The block number to stop fetching logs from
+   */
+  endBlock?: number;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the mergeMessages command
+ */
+export interface MergeMessagesArgs {
+  /**
+   * The id of the poll
+   */
+  pollId: number;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciContractAddress?: string;
+
+  /**
+   * The number of queue operations to merge
+   */
+  numQueueOps?: string;
+}
+
+/**
+ * Interface for the arguments to the mergeSignups command
+ */
+export interface MergeSignupsArgs {
+  /**
+   * The id of the poll
+   */
+  pollId: number;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciContractAddress?: string;
+
+  /**
+   * The number of queue operations to perform
+   */
+  numQueueOps?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the ProveOnChainArgs command
+ */
+export interface ProveOnChainArgs {
+  /**
+   * The id of the poll
+   */
+  pollId: string;
+
+  /**
+   * The directory containing the proofs
+   */
+  proofDir: string;
+
+  /**
+   * Whether to deploy subsidy contract
+   */
+  subsidyEnabled: boolean;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress?: string;
+
+  /**
+   * The address of the MessageProcessor contract
+   */
+  messageProcessorAddress?: string;
+
+  /**
+   * The address of the Tally contract
+   */
+  tallyAddress?: string;
+
+  /**
+   * The address of the Subsidy contract
+   */
+  subsidyAddress?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the publish command
+ */
+export interface PublishArgs {
+  /**
+   * The public key of the user
+   */
+  pubkey: string;
+
+  /**
+   * The index of the state leaf
+   */
+  stateIndex: number;
+
+  /**
+   * The index of the vote option
+   */
+  voteOptionIndex: number;
+
+  /**
+   * The nonce of the message
+   */
+  nonce: number;
+
+  /**
+   * The id of the poll
+   */
+  pollId: number;
+
+  /**
+   * The new vote weight
+   */
+  newVoteWeight: number;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciContractAddress?: string;
+
+  /**
+   * The salt of the message
+   */
+  salt?: string;
+
+  /**
+   * The private key of the user
+   */
+  privateKey?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the setVerifyingKeys command
+ */
+export interface SetVerifyingKeysArgs {
+  /**
+   * The depth of the state tree
+   */
+  stateTreeDepth: number;
+
+  /**
+   * The depth of the state subtree
+   */
+  intStateTreeDepth: number;
+
+  /**
+   * The depth of the message tree
+   */
+  messageTreeDepth: number;
+
+  /**
+   * The depth of the vote option tree
+   */
+  voteOptionTreeDepth: number;
+
+  /**
+   * The depth of the message batch tree
+   */
+  messageBatchDepth: number;
+
+  /**
+   * The path to the process messages zkey
+   */
+  processMessagesZkeyPath: string;
+
+  /**
+   * The path to the tally votes zkey
+   */
+  tallyVotesZkeyPath: string;
+
+  /**
+   * The address of the vkRegistry contract
+   */
+  vkRegistry?: string;
+
+  /**
+   * The path to the subsidy zkey
+   */
+  subsidyZkeyPath?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the signup command
+ */
+export interface SignupArgs {
+  /**
+   * The public key of the user
+   */
+  maciPubKey: string;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress?: string;
+
+  /**
+   * The signup gateway data
+   */
+  sgDataArg?: string;
+
+  /**
+   * The initial voice credit proxy data
+   */
+  ivcpDataArg?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the topup command
+ */
+export interface TopupArgs {
+  /**
+   * The amount to topup
+   */
+  amount: number;
+
+  /**
+   * The state index of the user
+   */
+  stateIndex: number;
+
+  /**
+   * The poll ID
+   */
+  pollId: number;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}
+
+/**
+ * Interface for the arguments to the verifyProof command
+ */
+export interface VerifyArgs {
+  /**
+   * The id of the poll
+   */
+  pollId: string;
+
+  /**
+   * Whether to deploy subsidy contract
+   */
+  subsidyEnabled: boolean;
+
+  /**
+   * The path to the tally file with results, per vote option spent credits, spent voice credits total
+   */
+  tallyFile?: string;
+
+  /**
+   * The tally data
+   */
+  tallyData?: TallyData;
+
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress?: string;
+
+  /**
+   * The address of the Tally contract
+   */
+  tallyAddress?: string;
+
+  /**
+   * The address of the Subsidy contract
+   */
+  subsidyAddress?: string;
+
+  /**
+   * The path to the subsidy file
+   */
+  subsidyFile?: string;
+
+  /**
+   * Whether to log the output
+   */
+  quiet?: boolean;
+}

--- a/cli/ts/utils/verifiers.ts
+++ b/cli/ts/utils/verifiers.ts
@@ -11,7 +11,6 @@ import type { Tally } from "maci-contracts";
  * @param voteOptionTreeDepth The vote option tree depth
  * @param newSpentVoiceCreditsCommitment The total spent voice credits commitment
  * @param newResultsCommitment The tally result commitment
- *
  * @returns list of the indexes of the tally result that failed on-chain verification
  */
 export const verifyPerVOSpentVoiceCredits = async (

--- a/integrationTests/package.json
+++ b/integrationTests/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "types": "tsc -p tsconfig.json --noEmit",
     "test": "ts-mocha --exit ./ts/__tests__/**.test.ts",
-    "test:suites": "NODE_OPTIONS=--max-old-space-size=4096 ts-mocha --exit  ./ts/__tests__/suites.test.ts",
+    "test:integration": "NODE_OPTIONS=--max-old-space-size=4096 ts-mocha --exit  ./ts/__tests__/integration.test.ts",
     "test:maciKeys": "ts-mocha --exit ./ts/__tests__/maci-keys.test.ts",
     "download-zkeys": "./scripts/download_zkeys.sh"
   },


### PR DESCRIPTION
# Description

Cleanup cli commands by using object args, as well as amend tests to reflect this change

## Related issue(s)

fix #1035 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
