### PR TITLE
fix(fetch): fix bugs related to logs fetching

### DIFF
--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -259,9 +259,10 @@ export const genProofs = async (
   } else {
     // build an off-chain representation of the MACI contract using data in the contract storage
     let fromBlock = startBlock ? Number(startBlock) : 0;
-    fromBlock = transactionHash
-      ? await signer.provider!.getTransaction(transactionHash).then((tx) => tx?.blockNumber ?? 0)
-      : 0;
+    if (transactionHash) {
+      const tx = await signer.provider!.getTransaction(transactionHash);
+      fromBlock = tx?.blockNumber ?? 0;
+    }
 
     logYellow(quiet, info(`starting to fetch logs from block ${fromBlock}`));
     maciState = await genMaciStateFromContract(

--- a/contracts/ts/genMaciState.ts
+++ b/contracts/ts/genMaciState.ts
@@ -58,9 +58,11 @@ export const genMaciStateFromContract = async (
   // if no last block is set then we fetch until the current block number
   const lastBlock = endBlock || (await provider.getBlockNumber());
 
-  // Fetch event logs in batches
-  for (let i = fromBlock; i < lastBlock; i += blocksPerRequest + 1) {
-    const toBlock = i + blocksPerRequest >= lastBlock ? undefined : i + blocksPerRequest;
+  // Fetch event logs in batches (lastBlock inclusive)
+  for (let i = fromBlock; i <= lastBlock; i += blocksPerRequest + 1) {
+    // the last block batch will be either current iteration block + blockPerRequest
+    // or the end block if it is set
+    const toBlock = i + blocksPerRequest >= lastBlock ? lastBlock : i + blocksPerRequest;
 
     const [tmpSignUpLogs, tmpDeployPollLogs] =
       // eslint-disable-next-line no-await-in-loop
@@ -178,8 +180,8 @@ export const genMaciStateFromContract = async (
   let mergeMessageAqSubRootsLogs: Log[] = [];
   let mergeMessageAqLogs: Log[] = [];
 
-  for (let i = fromBlock; i < lastBlock; i += blocksPerRequest + 1) {
-    const toBlock = i + blocksPerRequest >= lastBlock ? undefined : i + blocksPerRequest;
+  for (let i = fromBlock; i <= lastBlock; i += blocksPerRequest + 1) {
+    const toBlock = i + blocksPerRequest >= lastBlock ? lastBlock : i + blocksPerRequest;
 
     const [
       tmpPublishMessageLogs,


### PR DESCRIPTION
# Description

Ensure the start block is not overriden by the tx hash check. Also ensure we fetch logs at least for 1 block if fromBlock is equal to lastBlock

## Related issue(s)

fix #1043 fix #1044

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
