### PR TITLE
docs: clarify installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 Minimal Anti-Collusion Infrastructure (MACI) is an on-chain voting protocol which protects privacy and minimizes the risk of collusion and bribery.
 
-MACI blog, resources, and documentation for developers and integrators can be found here:
-https://maci.pse.dev/
+**MACI blog, resources, and documentation for developers and integrators can be found here:
+https://maci.pse.dev/**
 
 We welcome contributions to this project. Please join our
 [Discord server](https://discord.com/invite/sF5CT5rzrR) (in the `#🗳️-maci` channel) to discuss.
@@ -37,7 +37,9 @@ To contribute to MACI, create feature/fix branches, then open PRs into `dev`. [L
 
 ### Local development
 
-This repository is organised as Lerna submodules. Each submodule contains its
+For installation and local development instructions, please see our [installation docs](https://maci.pse.dev/docs/installation/).
+
+This repository is organized as Lerna submodules. Each submodule contains its
 own unit tests.
 
 - `audit`: Documentation surrounding the audit performed on v1


### PR DESCRIPTION
# Description

Small README tweaks to clarify that users should refer to our documentation

## Related issue(s)

N/A, feedback from Discord

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://github.com/privacy-scaling-explorations/maci/blob/dev/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/maci/blob/dev/CODE_OF_CONDUCT.md).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
