### PR TITLE
fix(build): fix bug that prevented c witness from being compiled

### DIFF
--- a/circuits/ts/compile.ts
+++ b/circuits/ts/compile.ts
@@ -60,8 +60,7 @@ export const compileCircuits = async (cWitness?: boolean, outputPath?: string): 
     if (cWitness) {
       try {
         // build
-        execFileSync("cd", [`${outPath}/${circuit.name}_cpp`]);
-        execFileSync("make");
+        execFileSync("bash", ["-c", `cd ${outPath}/${circuit.name}_cpp && make`]);
       } catch (error) {
         throw new Error(`Failed to compile the c witness for ${circuit.name}`);
       }


### PR DESCRIPTION
# Description

Currently, compiling the c witness generator will fail because execFileSync commands share no context, thus the second command will still run in the original directory, not the one where the first command moved to.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
