### PR TITLE
fix(message-batch-index): remove redundant check

### DIFF
--- a/cli/ts/commands/proveOnChain.ts
+++ b/cli/ts/commands/proveOnChain.ts
@@ -234,11 +234,7 @@ export const proveOnChain = async ({
     if (numberBatchesProcessed === 0) {
       const r = numMessages % messageBatchSize;
 
-      if (r === 0) {
-        currentMessageBatchIndex = Math.floor(numMessages / messageBatchSize) * messageBatchSize;
-      } else {
-        currentMessageBatchIndex = numMessages;
-      }
+      currentMessageBatchIndex = numMessages;
 
       if (currentMessageBatchIndex > 0) {
         if (r === 0) {

--- a/contracts/contracts/MessageProcessor.sol
+++ b/contracts/contracts/MessageProcessor.sol
@@ -94,11 +94,7 @@ contract MessageProcessor is Ownable, SnarkCommon, Hasher, CommonUtilities, IMes
       (, uint256 numMessages) = poll.numSignUpsAndMessages();
       uint256 r = numMessages % messageBatchSize;
 
-      if (r == 0) {
-        currentMessageBatchIndex = (numMessages / messageBatchSize) * messageBatchSize;
-      } else {
-        currentMessageBatchIndex = numMessages;
-      }
+      currentMessageBatchIndex = numMessages;
 
       if (currentMessageBatchIndex > 0) {
         if (r == 0) {


### PR DESCRIPTION
# Description

Remove redundant check from message processor circuit and proveOnChain cli command. 

Core:  https://github.com/privacy-scaling-explorations/maci/blob/dev/core/ts/Poll.ts#L436-L451

Redundant check: 
https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/MessageProcessor.sol#L97-L101

```
if (r == 0) -> (numMessages / messageBatchSize) * messageBatchSize would just be numMessages
```

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
