### PR TITLE
fix(cli): remove hardcoded gas limit from signup and publish

### DIFF
--- a/cli/ts/commands/publish.ts
+++ b/cli/ts/commands/publish.ts
@@ -135,9 +135,7 @@ export const publish = async ({
 
   try {
     // submit the message onchain as well as the encryption public key
-    const tx = await pollContract.publishMessage(message.asContractParam(), encKeypair.pubKey.asContractParam(), {
-      gasLimit: 10000000,
-    });
+    const tx = await pollContract.publishMessage(message.asContractParam(), encKeypair.pubKey.asContractParam());
     const receipt = await tx.wait();
 
     if (receipt?.status !== 1) {

--- a/cli/ts/commands/signup.ts
+++ b/cli/ts/commands/signup.ts
@@ -69,7 +69,7 @@ export const signup = async ({
   let stateIndex = "";
   try {
     // sign up to the MACI contract
-    const tx = await maciContract.signUp(userMaciPubKey.asContractParam(), sgData, ivcpData, { gasLimit: 1000000 });
+    const tx = await maciContract.signUp(userMaciPubKey.asContractParam(), sgData, ivcpData);
     const receipt = await tx.wait();
 
     logYellow(quiet, info(`Transaction hash: ${tx.hash}`));


### PR DESCRIPTION
# Description

hardcoded gas limit might prevent transaction from succeeding on certain networks

## Related issue(s)

fix #1086

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
