### PR TITLE
fix(cli): remove redundant local check for poll address

### DIFF
--- a/cli/ts/commands/genLocalState.ts
+++ b/cli/ts/commands/genLocalState.ts
@@ -47,13 +47,6 @@ export const genLocalState = async ({
     logError("MACI contract does not exist");
   }
 
-  if (!readContractAddress(`Poll-${pollId}`)) {
-    logError(`There is no poll with id ${pollId}`);
-  }
-  if (!(await contractExists(signer.provider!, readContractAddress(`Poll-${pollId}`)))) {
-    logError(`Poll-${pollId} contract's is not deployed on this network`);
-  }
-
   // if no private key is passed we ask it securely
   const coordPrivKey = coordinatorPrivateKey || (await promptSensitiveValue("Insert your MACI private key"));
   if (!PrivKey.isValidSerializedPrivKey(coordPrivKey)) {


### PR DESCRIPTION
# Description

In genLocalState, we check that a poll contract is present in a local address store file. This is not necessary as given a pollId and a maci contract address, the address of the poll can be found on chain.

## Related issue(s)

fix #1084

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
