### PR TITLE
refactor(contracts): remove maxValues from Maci.deployPoll() and instead calculate

### DIFF
--- a/cli/tests/constants.ts
+++ b/cli/tests/constants.ts
@@ -97,8 +97,6 @@ export const deployArgs: DeployArgs = {
 
 export const deployPollArgs: DeployPollArgs = {
   pollDuration,
-  maxMessages,
-  maxVoteOptions,
   intStateTreeDepth: INT_STATE_TREE_DEPTH,
   messageTreeSubDepth: MSG_BATCH_DEPTH,
   messageTreeDepth: MSG_TREE_DEPTH,

--- a/cli/ts/commands/deployPoll.ts
+++ b/cli/ts/commands/deployPoll.ts
@@ -21,8 +21,6 @@ import {
  */
 export const deployPoll = async ({
   pollDuration,
-  maxMessages,
-  maxVoteOptions,
   intStateTreeDepth,
   messageTreeSubDepth,
   messageTreeDepth,
@@ -56,14 +54,6 @@ export const deployPoll = async ({
   // required arg -> poll duration
   if (pollDuration <= 0) {
     logError("Duration cannot be <= 0");
-  }
-  // require arg -> max messages
-  if (maxMessages <= 0) {
-    logError("Max messages cannot be <= 0");
-  }
-  // required arg -> max vote options
-  if (maxVoteOptions <= 0) {
-    logError("Max vote options cannot be <= 0");
   }
 
   // required arg -> int state tree depth
@@ -111,7 +101,6 @@ export const deployPoll = async ({
     // deploy the poll contract via the maci contract
     const tx = await maciContract.deployPoll(
       pollDuration,
-      { maxMessages, maxVoteOptions },
       {
         intStateTreeDepth,
         messageTreeSubDepth,

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -178,8 +178,6 @@ program
   .description("deploy a new poll")
   .option("-vk, --vkRegistryAddress <vkRegistryAddress>", "the vk registry contract address")
   .requiredOption("-t, --duration <pollDuration>", "the poll duration", parseInt)
-  .requiredOption("-g, --max-messages <maxMessages>", "the max messages", parseInt)
-  .requiredOption("-mv, --max-vote-options <maxVoteOptions>", "the max vote options", parseInt)
   .requiredOption("-i, --int-state-tree-depth <intStateTreeDepth>", "the int state tree depth", parseInt)
   .requiredOption("-b, --msg-batch-depth <messageTreeSubDepth>", "the message tree sub depth", parseInt)
   .requiredOption("-m, --msg-tree-depth <messageTreeDepth>", "the message tree depth", parseInt)
@@ -198,8 +196,6 @@ program
     try {
       await deployPoll({
         pollDuration: cmdObj.duration,
-        maxMessages: cmdObj.maxMessages,
-        maxVoteOptions: cmdObj.maxVoteOptions,
         intStateTreeDepth: cmdObj.intStateTreeDepth,
         messageTreeSubDepth: cmdObj.msgBatchDepth,
         messageTreeDepth: cmdObj.msgTreeDepth,

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -286,16 +286,6 @@ export interface DeployPollArgs {
   pollDuration: number;
 
   /**
-   * The maximum number of messages that can be submitted
-   */
-  maxMessages: number;
-
-  /**
-   * The maximum number of vote options
-   */
-  maxVoteOptions: number;
-
-  /**
    * The depth of the intermediate state tree
    */
   intStateTreeDepth: number;

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -54,8 +54,6 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
   /// @notice Depths of the merkle trees
   TreeDepths public treeDepths;
 
-  /// @notice Batch sizes for processing
-  BatchSizes public batchSizes;
   /// @notice The contracts used by the Poll
   ExtContracts public extContracts;
 
@@ -79,14 +77,12 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
   /// @param _duration The duration of the voting period, in seconds
   /// @param _maxValues The maximum number of messages and vote options
   /// @param _treeDepths The depths of the merkle trees
-  /// @param _batchSizes The batch sizes for processing
   /// @param _coordinatorPubKey The coordinator's public key
   /// @param _extContracts The external contracts
   constructor(
     uint256 _duration,
     MaxValues memory _maxValues,
     TreeDepths memory _treeDepths,
-    BatchSizes memory _batchSizes,
     PubKey memory _coordinatorPubKey,
     ExtContracts memory _extContracts
   ) payable {
@@ -96,7 +92,6 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
     coordinatorPubKeyHash = hashLeftRight(_coordinatorPubKey.x, _coordinatorPubKey.y);
     duration = _duration;
     maxValues = _maxValues;
-    batchSizes = _batchSizes;
     treeDepths = _treeDepths;
     // Record the current timestamp
     deployTime = block.timestamp;

--- a/contracts/contracts/PollFactory.sol
+++ b/contracts/contracts/PollFactory.sol
@@ -29,7 +29,6 @@ contract PollFactory is Params, DomainObjs, IPollFactory {
     uint256 _duration,
     MaxValues calldata _maxValues,
     TreeDepths calldata _treeDepths,
-    BatchSizes calldata _batchSizes,
     PubKey calldata _coordinatorPubKey,
     IMACI _maci,
     TopupCredit _topupCredit,
@@ -39,13 +38,7 @@ contract PollFactory is Params, DomainObjs, IPollFactory {
     /// maxVoteOptions must be less than 2 ** 50 due to circuit limitations;
     /// it will be packed as a 50-bit value along with other values as one
     /// of the inputs (aka packedVal)
-    if (
-      _maxValues.maxMessages > TREE_ARITY ** uint256(_treeDepths.messageTreeDepth) ||
-      _maxValues.maxMessages < _batchSizes.messageBatchSize ||
-      _maxValues.maxMessages % _batchSizes.messageBatchSize != 0 ||
-      _maxValues.maxVoteOptions > TREE_ARITY ** uint256(_treeDepths.voteOptionTreeDepth) ||
-      _maxValues.maxVoteOptions >= (2 ** 50)
-    ) {
+    if (_maxValues.maxVoteOptions >= (2 ** 50)) {
       revert InvalidMaxValues();
     }
 
@@ -56,7 +49,7 @@ contract PollFactory is Params, DomainObjs, IPollFactory {
     ExtContracts memory extContracts = ExtContracts({ maci: _maci, messageAq: messageAq, topupCredit: _topupCredit });
 
     // deploy the poll
-    Poll poll = new Poll(_duration, _maxValues, _treeDepths, _batchSizes, _coordinatorPubKey, extContracts);
+    Poll poll = new Poll(_duration, _maxValues, _treeDepths, _coordinatorPubKey, extContracts);
 
     // Make the Poll contract own the messageAq contract, so only it can
     // run enqueue/merge

--- a/contracts/contracts/Subsidy.sol
+++ b/contracts/contracts/Subsidy.sol
@@ -25,7 +25,7 @@ contract Subsidy is Ownable, CommonUtilities, Hasher, SnarkCommon {
   uint256 public sbCommitment;
   uint256 public subsidyCommitment;
 
-  uint8 internal constant TREE_ARITY = 5;
+  uint256 private constant TREE_ARITY = 5;
 
   IVerifier public immutable verifier;
   IVkRegistry public immutable vkRegistry;
@@ -103,7 +103,7 @@ contract Subsidy is Ownable, CommonUtilities, Hasher, SnarkCommon {
 
     (uint8 intStateTreeDepth, , , ) = poll.treeDepths();
 
-    uint256 subsidyBatchSize = uint256(TREE_ARITY) ** intStateTreeDepth;
+    uint256 subsidyBatchSize = TREE_ARITY ** intStateTreeDepth;
 
     (uint256 numSignUps, ) = poll.numSignUpsAndMessages();
 

--- a/contracts/contracts/Tally.sol
+++ b/contracts/contracts/Tally.sol
@@ -15,7 +15,7 @@ import { CommonUtilities } from "./utilities/CommonUtilities.sol";
 /// @notice The Tally contract is used during votes tallying
 /// and by users to verify the tally results.
 contract Tally is Ownable, SnarkCommon, CommonUtilities, Hasher {
-  uint8 private constant TREE_ARITY = 5;
+  uint256 private constant TREE_ARITY = 5;
 
   /// @notice The commitment to the tally results. Its initial value is 0, but after
   /// the tally of each batch is proven on-chain via a zk-SNARK, it should be
@@ -127,8 +127,11 @@ contract Tally is Ownable, SnarkCommon, CommonUtilities, Hasher {
       tallyBatchNum++;
     }
 
-    (, uint256 tallyBatchSize, ) = poll.batchSizes();
+    // get the batch size and start index
+    (uint8 intStateTreeDepth, , , ) = poll.treeDepths();
+    uint256 tallyBatchSize = TREE_ARITY ** intStateTreeDepth;
     uint256 batchStartIndex = cachedBatchNum * tallyBatchSize;
+
     (uint256 numSignUps, ) = poll.numSignUpsAndMessages();
 
     // Require that there are untalied ballots left

--- a/contracts/contracts/interfaces/IPoll.sol
+++ b/contracts/contracts/interfaces/IPoll.sol
@@ -68,12 +68,6 @@ interface IPoll {
     view
     returns (uint8 intStateTreeDepth, uint8 messageTreeSubDepth, uint8 messageTreeDepth, uint8 voteOptionTreeDepth);
 
-  /// @notice Get the batch sizes for processing
-  /// @return messageBatchSize The batch size for message processing
-  /// @return tallyBatchSize The batch size for tally processing
-  /// @return subsidyBatchSize The batch size for subsidy processing
-  function batchSizes() external view returns (uint24 messageBatchSize, uint24 tallyBatchSize, uint24 subsidyBatchSize);
-
   /// @notice Get the max values for the poll
   /// @return maxMessages The maximum number of messages
   /// @return maxVoteOptions The maximum number of vote options

--- a/contracts/contracts/interfaces/IPollFactory.sol
+++ b/contracts/contracts/interfaces/IPollFactory.sol
@@ -13,7 +13,6 @@ interface IPollFactory {
   /// @param _duration The duration of the poll
   /// @param _maxValues The max values for the poll
   /// @param _treeDepths The depths of the merkle trees
-  /// @param _batchSizes The batch sizes for processing
   /// @param _coordinatorPubKey The coordinator's public key
   /// @param _maci The MACI contract interface reference
   /// @param _topupCredit The TopupCredit contract
@@ -23,7 +22,6 @@ interface IPollFactory {
     uint256 _duration,
     Params.MaxValues memory _maxValues,
     Params.TreeDepths memory _treeDepths,
-    Params.BatchSizes memory _batchSizes,
     DomainObjs.PubKey memory _coordinatorPubKey,
     IMACI _maci,
     TopupCredit _topupCredit,

--- a/contracts/contracts/utilities/Params.sol
+++ b/contracts/contracts/utilities/Params.sol
@@ -19,13 +19,6 @@ contract Params {
     uint8 voteOptionTreeDepth;
   }
 
-  /// @notice A struct holding the batch sizes for processing
-  struct BatchSizes {
-    uint24 messageBatchSize;
-    uint24 tallyBatchSize;
-    uint24 subsidyBatchSize;
-  }
-
   /// @notice A struct holding the max values for the poll
   struct MaxValues {
     uint256 maxMessages;

--- a/contracts/tests/MACI.test.ts
+++ b/contracts/tests/MACI.test.ts
@@ -160,7 +160,6 @@ describe("MACI", () => {
       // Create the poll and get the poll ID from the tx event logs
       const tx = await maciContract.deployPoll(
         duration,
-        maxValues,
         treeDepths,
         coordinator.pubKey.asContractParam() as { x: BigNumberish; y: BigNumberish },
         verifierContract,
@@ -207,7 +206,6 @@ describe("MACI", () => {
       await expect(
         maciContract.deployPoll(
           duration,
-          maxValues,
           treeDepths,
           coordinator.pubKey.asContractParam(),
           verifierContract,

--- a/contracts/tests/MessageProcessor.test.ts
+++ b/contracts/tests/MessageProcessor.test.ts
@@ -58,7 +58,6 @@ describe("MessageProcessor", () => {
     // deploy on chain poll
     const tx = await maciContract.deployPoll(
       duration,
-      maxValues,
       treeDepths,
       coordinator.pubKey.asContractParam(),
       verifierContract,
@@ -159,7 +158,15 @@ describe("MessageProcessor", () => {
         0,
         poll.messages.length,
       );
-      const onChainPackedVals = BigInt(await mpContract.genProcessMessagesPackedVals(0, users.length));
+      const onChainPackedVals = BigInt(
+        await mpContract.genProcessMessagesPackedVals(
+          0,
+          users.length,
+          poll.messages.length,
+          treeDepths.messageTreeSubDepth,
+          treeDepths.voteOptionTreeDepth,
+        ),
+      );
       expect(packedVals.toString()).to.eq(onChainPackedVals.toString());
     });
 

--- a/contracts/tests/Poll.test.ts
+++ b/contracts/tests/Poll.test.ts
@@ -17,7 +17,6 @@ import {
   initialVoiceCreditBalance,
   maxValues,
   messageBatchSize,
-  tallyBatchSize,
   treeDepths,
 } from "./constants";
 import { timeTravel, deployTestContracts } from "./utils";
@@ -49,7 +48,6 @@ describe("Poll", () => {
       // deploy on chain poll
       const tx = await maciContract.deployPoll(
         duration,
-        maxValues,
         treeDepths,
         coordinator.pubKey.asContractParam(),
         verifierContract,
@@ -127,12 +125,6 @@ describe("Poll", () => {
       expect(td[1].toString()).to.eq(treeDepths.messageTreeSubDepth.toString());
       expect(td[2].toString()).to.eq(treeDepths.messageTreeDepth.toString());
       expect(td[3].toString()).to.eq(treeDepths.voteOptionTreeDepth.toString());
-    });
-
-    it("should have the correct batch values set", async () => {
-      const batchSizes = await pollContract.batchSizes();
-      expect(batchSizes[0].toString()).to.eq(messageBatchSize.toString());
-      expect(batchSizes[1].toString()).to.eq(tallyBatchSize.toString());
     });
 
     it("should have numMessages set to 1 (blank message)", async () => {

--- a/contracts/tests/PollFactory.test.ts
+++ b/contracts/tests/PollFactory.test.ts
@@ -5,7 +5,7 @@ import { Keypair } from "maci-domainobjs";
 import { deployPollFactory, getDefaultSigner } from "../ts";
 import { PollFactory } from "../typechain-types";
 
-import { maxValues, messageBatchSize, tallyBatchSize, treeDepths } from "./constants";
+import { maxValues, treeDepths } from "./constants";
 
 describe("pollFactory", () => {
   let pollFactory: PollFactory;
@@ -24,11 +24,6 @@ describe("pollFactory", () => {
         "100",
         maxValues,
         treeDepths,
-        {
-          messageBatchSize,
-          tallyBatchSize,
-          subsidyBatchSize: tallyBatchSize,
-        },
         coordinatorPubKey.asContractParam(),
         ZeroAddress,
         ZeroAddress,
@@ -43,15 +38,10 @@ describe("pollFactory", () => {
         pollFactory.deploy(
           "100",
           {
-            maxMessages: maxValues.maxMessages * 10000,
-            maxVoteOptions: maxValues.maxVoteOptions,
+            maxMessages: maxValues.maxMessages,
+            maxVoteOptions: 2 ** 50,
           },
           treeDepths,
-          {
-            messageBatchSize,
-            tallyBatchSize,
-            subsidyBatchSize: tallyBatchSize,
-          },
           coordinatorPubKey.asContractParam(),
           ZeroAddress,
           ZeroAddress,

--- a/contracts/tests/Subsidy.test.ts
+++ b/contracts/tests/Subsidy.test.ts
@@ -55,7 +55,6 @@ describe("Subsidy", () => {
     // deploy on chain poll
     const tx = await maciContract.deployPoll(
       duration,
-      maxValues,
       treeDepths,
       coordinator.pubKey.asContractParam(),
       verifierContract,

--- a/contracts/tests/Tally.test.ts
+++ b/contracts/tests/Tally.test.ts
@@ -63,7 +63,6 @@ describe("TallyVotes", () => {
     // deploy on chain poll
     const tx = await maciContract.deployPoll(
       duration,
-      maxValues,
       treeDepths,
       coordinator.pubKey.asContractParam(),
       verifierContract,

--- a/contracts/tests/constants.ts
+++ b/contracts/tests/constants.ts
@@ -4,11 +4,11 @@ import { VerifyingKey } from "maci-domainobjs";
 
 export const duration = 20;
 
-export const messageBatchSize = 25;
 export const STATE_TREE_DEPTH = 10;
 export const STATE_TREE_ARITY = 5;
-export const MESSAGE_TREE_DEPTH = 4;
-export const MESSAGE_TREE_SUBDEPTH = 2;
+export const MESSAGE_TREE_DEPTH = 2;
+export const MESSAGE_TREE_SUBDEPTH = 1;
+export const messageBatchSize = STATE_TREE_ARITY ** MESSAGE_TREE_SUBDEPTH;
 
 export const testProcessVk = new VerifyingKey(
   new G1Point(BigInt(0), BigInt(1)),
@@ -28,7 +28,7 @@ export const testTallyVk = new VerifyingKey(
 
 export const initialVoiceCreditBalance = 100;
 export const maxValues: MaxValues = {
-  maxMessages: 25,
+  maxMessages: STATE_TREE_ARITY ** MESSAGE_TREE_DEPTH,
   maxVoteOptions: 25,
 };
 

--- a/contracts/ts/genMaciState.ts
+++ b/contracts/ts/genMaciState.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { type Provider, type Log, Interface, BaseContract } from "ethers";
-import { MaciState } from "maci-core";
+import { MaciState, STATE_TREE_ARITY } from "maci-core";
 import { type Keypair, PubKey, Message } from "maci-domainobjs";
 
 import assert from "assert";
@@ -154,7 +154,6 @@ export const genMaciStateFromContract = async (
   const duration = Number(dd[1]);
   const onChainMaxValues = await pollContract.maxValues();
   const onChainTreeDepths = await pollContract.treeDepths();
-  const onChainBatchSizes = await pollContract.batchSizes();
 
   const maxValues = {
     maxMessages: Number(onChainMaxValues.maxMessages),
@@ -167,9 +166,9 @@ export const genMaciStateFromContract = async (
     voteOptionTreeDepth: Number(onChainTreeDepths.voteOptionTreeDepth),
   };
   const batchSizes = {
-    tallyBatchSize: Number(onChainBatchSizes.tallyBatchSize),
-    subsidyBatchSize: Number(onChainBatchSizes.subsidyBatchSize),
-    messageBatchSize: Number(onChainBatchSizes.messageBatchSize),
+    tallyBatchSize: STATE_TREE_ARITY ** Number(onChainTreeDepths.intStateTreeDepth),
+    subsidyBatchSize: STATE_TREE_ARITY ** Number(onChainTreeDepths.intStateTreeDepth),
+    messageBatchSize: STATE_TREE_ARITY ** Number(onChainTreeDepths.messageTreeSubDepth),
   };
 
   // fetch poll contract logs

--- a/integrationTests/ts/__tests__/integration.test.ts
+++ b/integrationTests/ts/__tests__/integration.test.ts
@@ -106,8 +106,7 @@ describe("Integration tests", function test() {
     // 4. create a poll
     pollContracts = await deployPoll({
       pollDuration: duration,
-      maxMessages: maxValues.maxMessages,
-      maxVoteOptions: maxValues.maxVoteOptions,
+
       intStateTreeDepth: INT_STATE_TREE_DEPTH,
       messageTreeSubDepth: MSG_BATCH_DEPTH,
       messageTreeDepth: MSG_TREE_DEPTH,

--- a/integrationTests/ts/__tests__/maci-keys.test.ts
+++ b/integrationTests/ts/__tests__/maci-keys.test.ts
@@ -10,8 +10,6 @@ import {
   VOTE_OPTION_TREE_DEPTH,
   duration,
   initialVoiceCredits,
-  maxMessages,
-  maxVoteOptions,
   messageBatchDepth,
   messageTreeDepth,
 } from "./utils/constants";
@@ -84,10 +82,6 @@ describe("integration tests private/public/keypair", () => {
       // deploy a poll
       await maci.deployPoll(
         BigInt(duration),
-        {
-          maxMessages,
-          maxVoteOptions,
-        },
         {
           intStateTreeDepth: INT_STATE_TREE_DEPTH,
           messageTreeDepth,


### PR DESCRIPTION
# Description

Simplify logic and save gas by computing maxValues and batchSizes within MACI vs passing as parameter to deployPoll.
Also cache variables fetched from the poll contract, and pass around the various functions inside MessageProcessor.

Benefits: 

* Reduction of gas consumption to deploy Poll and various contracts.
* large gas saving in the `processMessages` function

## Related issue(s)

fix #1066

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
