### PR TITLE
fix: dark mode search result

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -44,6 +44,7 @@
   --ifm-navbar-background-color: #0b0b0b;
   --ifm-font-color-base: #cdcdcd;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --ifm-color-white: #0b0b0b;
 }
 
 h1 {


### PR DESCRIPTION
# Description

as described in #1071 .

## Related issue(s)

fix #1071.

## Additional Note ##

actually I should modify `--docsearch-hit-active-color` as black-like color, but it refers to `ifm-color-white` in the **dark** mode, I tried to modify it directly but failed, so can only modify the `ifm-color-white`. 
It's so weird, maybe just a temporal solution.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
