### PR TITLE
fix(crypto): get rid of potential prototype polution

### DIFF
--- a/circuits/ts/__tests__/CeremonyParams.test.ts
+++ b/circuits/ts/__tests__/CeremonyParams.test.ts
@@ -166,7 +166,7 @@ describe("Ceremony param tests", () => {
         accumulatorQueue.merge(params.messageTreeDepth);
 
         expect(poll.messageTree.root.toString()).to.be.eq(
-          accumulatorQueue.mainRoots[params.messageTreeDepth].toString(),
+          accumulatorQueue.getMainRoots()[params.messageTreeDepth].toString(),
         );
       });
 
@@ -316,7 +316,7 @@ describe("Ceremony param tests", () => {
           accumulatorQueue.merge(params.messageTreeDepth);
 
           expect(poll.messageTree.root.toString()).to.be.eq(
-            accumulatorQueue.mainRoots[params.messageTreeDepth].toString(),
+            accumulatorQueue.getMainRoots()[params.messageTreeDepth].toString(),
           );
           // Process messages
           poll.processMessages(pollId);

--- a/circuits/ts/__tests__/ProcessMessages.test.ts
+++ b/circuits/ts/__tests__/ProcessMessages.test.ts
@@ -141,7 +141,7 @@ describe("ProcessMessage circuit", function test() {
       accumulatorQueue.merge(treeDepths.messageTreeDepth);
 
       expect(poll.messageTree.root.toString()).to.be.eq(
-        accumulatorQueue.mainRoots[treeDepths.messageTreeDepth].toString(),
+        accumulatorQueue.getMainRoots()[treeDepths.messageTreeDepth].toString(),
       );
     });
 

--- a/circuits/ts/__tests__/TallyVotes.test.ts
+++ b/circuits/ts/__tests__/TallyVotes.test.ts
@@ -112,7 +112,7 @@ describe("TallyVotes circuit", function test() {
       accumulatorQueue.merge(treeDepths.messageTreeDepth);
 
       expect(poll.messageTree.root.toString()).to.be.eq(
-        accumulatorQueue.mainRoots[treeDepths.messageTreeDepth].toString(),
+        accumulatorQueue.getMainRoots()[treeDepths.messageTreeDepth].toString(),
       );
       // Process messages
       poll.processMessages(pollId);

--- a/contracts/tests/AccQueue.test.ts
+++ b/contracts/tests/AccQueue.test.ts
@@ -373,7 +373,7 @@ describe("AccQueues", () => {
       }
 
       aq.mergeSubRoots(0);
-      const expectedSmallSRTroot = aq.smallSRTroot;
+      const expectedSmallSRTroot = aq.getSmallSRTroot();
 
       await expect(aqContract.getSmallSRTroot()).to.be.revertedWithCustomError(aqContract, "SubTreesNotMerged");
 
@@ -387,7 +387,7 @@ describe("AccQueues", () => {
       aq.merge(MAIN_DEPTH);
       await (await aqContract.merge(MAIN_DEPTH)).wait();
 
-      const expectedMainRoot = aq.mainRoots[MAIN_DEPTH];
+      const expectedMainRoot = aq.getMainRoots()[MAIN_DEPTH];
       const contractMainRoot = await aqContract.getMainRoot(MAIN_DEPTH);
 
       expect(expectedMainRoot.toString()).to.eq(contractMainRoot.toString());
@@ -422,7 +422,7 @@ describe("AccQueues", () => {
       }
 
       aq.mergeSubRoots(0);
-      const expectedSmallSRTroot = aq.smallSRTroot;
+      const expectedSmallSRTroot = aq.getSmallSRTroot();
 
       await expect(aqContract.getSmallSRTroot()).to.be.revertedWithCustomError(aqContract, "SubTreesNotMerged");
 
@@ -436,7 +436,7 @@ describe("AccQueues", () => {
       aq.merge(MAIN_DEPTH);
       await (await aqContract.merge(MAIN_DEPTH)).wait();
 
-      const expectedMainRoot = aq.mainRoots[MAIN_DEPTH];
+      const expectedMainRoot = aq.getMainRoots()[MAIN_DEPTH];
       const contractMainRoot = await aqContract.getMainRoot(MAIN_DEPTH);
 
       expect(expectedMainRoot.toString()).to.eq(contractMainRoot.toString());

--- a/contracts/tests/AccQueueBenchmark.test.ts
+++ b/contracts/tests/AccQueueBenchmark.test.ts
@@ -77,7 +77,7 @@ const testMerge = async (
     }
   }
 
-  const expectedSmallSRTroot = aq.smallSRTroot;
+  const expectedSmallSRTroot = aq.getSmallSRTroot();
 
   const contractSmallSRTroot = await contract.getSmallSRTroot();
 
@@ -90,7 +90,7 @@ const testMerge = async (
   expect(receipt?.gasUsed.toString()).to.not.eq("");
   expect(receipt?.gasUsed.toString()).to.not.eq("0");
 
-  const expectedMainRoot = aq.mainRoots[MAIN_DEPTH];
+  const expectedMainRoot = aq.getMainRoots()[MAIN_DEPTH];
   const contractMainRoot = await contract.getMainRoot(MAIN_DEPTH);
 
   expect(expectedMainRoot.toString()).to.eq(contractMainRoot.toString());

--- a/crypto/ts/__tests__/utils.ts
+++ b/crypto/ts/__tests__/utils.ts
@@ -75,14 +75,14 @@ export const testMergeShortest = (SUB_DEPTH: number, HASH_LENGTH: number, ZERO: 
 
   // Merge all but one subroot in aq2
   aq2.mergeSubRoots(2);
-  expect(aq.smallSRTroot.toString()).not.to.eq(aq2.smallSRTroot.toString());
+  expect(aq.getSmallSRTroot().toString()).not.to.eq(aq2.getSmallSRTroot().toString());
   aq2.mergeSubRoots(2);
-  expect(aq.smallSRTroot.toString()).not.to.eq(aq2.smallSRTroot.toString());
+  expect(aq.getSmallSRTroot().toString()).not.to.eq(aq2.getSmallSRTroot().toString());
 
   // Merge the last subroot in aq2
   aq2.mergeSubRoots(1);
 
-  expect(aq.smallSRTroot.toString()).to.eq(aq2.smallSRTroot.toString());
+  expect(aq.getSmallSRTroot().toString()).to.eq(aq2.getSmallSRTroot().toString());
 };
 
 /**
@@ -98,7 +98,7 @@ export const testMergeShortestOne = (SUB_DEPTH: number, HASH_LENGTH: number, ZER
 
   aq.mergeSubRoots(0);
 
-  expect(aq.smallSRTroot.toString()).to.eq(smallTree.root.toString());
+  expect(aq.getSmallSRTroot().toString()).to.eq(smallTree.root.toString());
   expect(aq.getSubRoot(0).toString()).to.eq(smallTree.root.toString());
 };
 
@@ -121,12 +121,12 @@ export const testMergeExhaustive = (SUB_DEPTH: number, HASH_LENGTH: number, ZERO
     aq.mergeSubRoots(0);
 
     const depth = calcDepthFromNumLeaves(HASH_LENGTH, numSubtrees);
-    const smallTree = new IncrementalQuinTree(depth, aq.zeros[aq.subDepth], HASH_LENGTH, aq.hashFunc);
+    const smallTree = new IncrementalQuinTree(depth, aq.getZeros()[aq.getSubDepth()], HASH_LENGTH, aq.hashFunc);
 
-    aq.subRoots.forEach((subRoot) => {
+    aq.getSubRoots().forEach((subRoot) => {
       smallTree.insert(subRoot);
     });
 
-    expect(aq.smallSRTroot.toString()).to.eq(smallTree.root.toString());
+    expect(aq.getSmallSRTroot().toString()).to.eq(smallTree.root.toString());
   }
 };

--- a/crypto/ts/types.ts
+++ b/crypto/ts/types.ts
@@ -27,7 +27,7 @@ export type PathElements = bigint[][];
  * A acc queue
  */
 export interface Queue {
-  levels: bigint[][];
+  levels: Map<number, Map<number, bigint>>;
   indices: number[];
 }
 


### PR DESCRIPTION
# Description

Use map instead of 2d array as internal data structure for AccQueue and make class props access stricter.

## Additional Notes

N/A

## Related issue(s)

Closes #1030 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
