### PR TITLE
fix(contracts): save numSignups after merging maciStateAq inside the Poll contract

### DIFF
--- a/circuits/ts/__tests__/CeremonyParams.test.ts
+++ b/circuits/ts/__tests__/CeremonyParams.test.ts
@@ -116,6 +116,9 @@ describe("Ceremony param tests", () => {
 
         poll = maciState.polls.get(pollId)!;
 
+        // update the state
+        poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
         // First command (valid)
         const command = new PCommand(
           stateIndex, // BigInt(1),
@@ -181,7 +184,7 @@ describe("Ceremony param tests", () => {
           ballotTree.insert(emptyBallotHash);
         });
 
-        const currentStateRoot = maciState.stateTree.root;
+        const currentStateRoot = poll.stateTree?.root;
         const currentBallotRoot = ballotTree.root;
 
         const inputs = poll.processMessages(pollId) as unknown as IProcessMessagesInputs;
@@ -195,7 +198,7 @@ describe("Ceremony param tests", () => {
         const newStateRoot = poll.stateTree?.root;
         const newBallotRoot = poll.ballotTree?.root;
 
-        expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot.toString());
+        expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot?.toString());
         expect(newBallotRoot?.toString()).not.to.be.eq(currentBallotRoot.toString());
 
         const packedVals = packProcessMessageSmallVals(
@@ -285,6 +288,9 @@ describe("Ceremony param tests", () => {
           );
 
           poll = maciState.polls.get(pollId)!;
+
+          // update the state
+          poll.updatePoll(BigInt(maciState.stateLeaves.length));
 
           // First command (valid)
           const command = new PCommand(

--- a/circuits/ts/__tests__/ProcessMessages.test.ts
+++ b/circuits/ts/__tests__/ProcessMessages.test.ts
@@ -91,6 +91,7 @@ describe("ProcessMessage circuit", function test() {
       );
 
       poll = maciState.polls.get(pollId)!;
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
 
       // First command (valid)
       const command = new PCommand(
@@ -157,7 +158,7 @@ describe("ProcessMessage circuit", function test() {
         ballotTree.insert(emptyBallotHash);
       });
 
-      const currentStateRoot = maciState.stateTree.root;
+      const currentStateRoot = poll.stateTree?.root;
       const currentBallotRoot = ballotTree.root;
 
       const inputs = poll.processMessages(pollId) as unknown as IProcessMessagesInputs;
@@ -171,7 +172,7 @@ describe("ProcessMessage circuit", function test() {
       const newStateRoot = poll.stateTree?.root;
       const newBallotRoot = poll.ballotTree?.root;
 
-      expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot.toString());
+      expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot?.toString());
       expect(newBallotRoot?.toString()).not.to.be.eq(currentBallotRoot.toString());
 
       const packedVals = packProcessMessageSmallVals(
@@ -231,6 +232,8 @@ describe("ProcessMessage circuit", function test() {
 
       poll = maciState.polls.get(pollId)!;
 
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
       const command = new PCommand(
         BigInt(1),
         userKeypair.pubKey,
@@ -277,7 +280,7 @@ describe("ProcessMessage circuit", function test() {
         ballotTree.insert(emptyBallotHash);
       });
 
-      const currentStateRoot = maciState.stateTree.root;
+      const currentStateRoot = poll.stateTree?.root;
       const currentBallotRoot = ballotTree.root;
 
       const inputs = poll.processMessages(pollId) as unknown as IProcessMessagesInputs;
@@ -290,7 +293,7 @@ describe("ProcessMessage circuit", function test() {
       const newStateRoot = poll.stateTree?.root;
       const newBallotRoot = poll.ballotTree?.root;
 
-      expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot.toString());
+      expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot?.toString());
       expect(newBallotRoot?.toString()).not.to.be.eq(currentBallotRoot.toString());
     });
   });
@@ -326,6 +329,8 @@ describe("ProcessMessage circuit", function test() {
       );
 
       poll = maciState.polls.get(pollId)!;
+
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
 
       // Vote for option 0
       const command = new PCommand(
@@ -417,6 +422,8 @@ describe("ProcessMessage circuit", function test() {
 
         const selectedPoll = state.polls.get(id);
 
+        selectedPoll?.updatePoll(BigInt(state.stateLeaves.length));
+
         // Second batch is not a full batch
         const numMessages = messageBatchSize * NUM_BATCHES - 1;
         for (let i = 0; i < numMessages; i += 1) {
@@ -471,6 +478,7 @@ describe("ProcessMessage circuit", function test() {
       );
 
       poll = maciState.polls.get(pollId)!;
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
     });
 
     it("should work when publishing 2 vote messages and a topup (the second vote uses more than initial voice credit balance)", async () => {

--- a/circuits/ts/__tests__/TallyVotes.test.ts
+++ b/circuits/ts/__tests__/TallyVotes.test.ts
@@ -81,6 +81,7 @@ describe("TallyVotes circuit", function test() {
       );
 
       poll = maciState.polls.get(pollId)!;
+      poll.updatePoll(stateIndex);
 
       // First command (valid)
       const command = new PCommand(
@@ -161,6 +162,7 @@ describe("TallyVotes circuit", function test() {
       );
 
       const poll = maciState.polls.get(pollId)!;
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
 
       const numMessages = messageBatchSize * NUM_BATCHES;
       for (let i = 0; i < numMessages; i += 1) {

--- a/contracts/tests/MACI.test.ts
+++ b/contracts/tests/MACI.test.ts
@@ -265,14 +265,15 @@ describe("MACI", () => {
 
     it("should have the correct state root on chain after merging the acc queue", async () => {
       const onChainStateRoot = await stateAqContract.getMainRoot(STATE_TREE_DEPTH);
-      expect(onChainStateRoot.toString()).to.eq(maciState.stateTree.root.toString());
+      maciState.polls.get(pollId)?.updatePoll(await pollContract.numSignups());
+      expect(onChainStateRoot.toString()).to.eq(maciState.polls.get(pollId)?.stateTree?.root.toString());
     });
   });
 
   describe("getStateAqRoot", () => {
     it("should return the correct state root", async () => {
       const onChainStateRoot = await maciContract.getStateAqRoot();
-      expect(onChainStateRoot.toString()).to.eq(maciState.stateTree.root.toString());
+      expect(onChainStateRoot.toString()).to.eq(maciState.polls.get(pollId)?.stateTree?.root.toString());
     });
   });
 

--- a/contracts/tests/MessageProcessor.test.ts
+++ b/contracts/tests/MessageProcessor.test.ts
@@ -112,6 +112,9 @@ describe("MessageProcessor", () => {
 
     poll.publishMessage(message, padKey);
 
+    // update the poll state
+    poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
     generatedInputs = poll.processMessages(pollId);
 
     // set the verification keys on the vk smart contract

--- a/contracts/tests/Subsidy.test.ts
+++ b/contracts/tests/Subsidy.test.ts
@@ -116,6 +116,9 @@ describe("Subsidy", () => {
 
     poll.publishMessage(message, padKey);
 
+    // update the poll state
+    poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
     // process messages locally
     generatedInputs = poll.processMessages(pollId);
 

--- a/contracts/tests/Tally.test.ts
+++ b/contracts/tests/Tally.test.ts
@@ -119,6 +119,9 @@ describe("TallyVotes", () => {
 
     poll.publishMessage(message, padKey);
 
+    // update the poll state
+    poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
     // process messages locally
     generatedInputs = poll.processMessages(pollId);
 

--- a/contracts/ts/genMaciState.ts
+++ b/contracts/ts/genMaciState.ts
@@ -346,11 +346,13 @@ export const genMaciStateFromContract = async (
 
   const poll = maciState.polls.get(pollId);
 
+  // ensure all messages were recorded
   assert(Number(numSignUpsAndMessages[1]) === poll?.messages.length);
-  assert(Number(numSignUpsAndMessages[0]) === maciState.numSignUps);
+  // set the number of signups
+  poll.updatePoll(numSignUpsAndMessages[0]);
 
   // we need to ensure that the stateRoot is correct
-  assert(maciState.stateTree.root.toString() === (await maciContract.getStateAqRoot()).toString());
+  assert(poll.stateTree?.root.toString() === (await pollContract.mergedStateRoot()).toString());
 
   maciState.polls.set(pollId, poll);
 

--- a/core/package.json
+++ b/core/package.json
@@ -52,9 +52,10 @@
       "**/*.js",
       "**/*.d.ts"
     ],
-    "branches": ">50%",
-    "lines": ">50%",
-    "functions": ">50%",
-    "statements": ">50%"
+    "branches": ">90%",
+    "lines": ">90%",
+    "functions": ">90%",
+    "statements": ">90%",
+    "check-coverage": true
   }
 }

--- a/core/ts/__benchmarks__/index.ts
+++ b/core/ts/__benchmarks__/index.ts
@@ -42,6 +42,8 @@ export default function runCore(): void {
       );
       const poll = maciState.polls.get(pollId)!;
 
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
       // 24 valid votes
       for (let i = 0; i < MESSAGE_BATCH_SIZE - 1; i += 1) {
         const userKeypair = users[i];

--- a/core/ts/__tests__/utils/utils.ts
+++ b/core/ts/__tests__/utils/utils.ts
@@ -140,6 +140,7 @@ export class TestHarness {
    * This should be called after all votes have been cast.
    */
   finalizePoll = (): void => {
+    this.poll.updatePoll(BigInt(this.maciState.stateLeaves.length));
     this.poll.processMessages(this.pollId);
     this.poll.tallyVotes();
   };

--- a/core/ts/utils/types.ts
+++ b/core/ts/utils/types.ts
@@ -116,6 +116,7 @@ export interface IJsonPoll {
   stateLeaves: IJsonStateLeaf[];
   results: string[];
   numBatchesProcessed: number;
+  numSignups: string;
 }
 
 /**


### PR DESCRIPTION
# Description

prevent new signups from changing the record of users being signed for a specific poll. Instead store this value in the Poll contract after the stateAq is merged. This way, even if a user signs up after the logs are fetched and the state is reproduced offchain, the proof validation will not fail because of a numSignups mismatch.

## Additional Notes

Changes:

* when calling `mergeMaciStateAq` on the Poll contract, we now save the number of signups on a state variable
* the `numSignUpsAndMessages` function now returns the value from the Poll state and not from the MACI contract so if there's any new signup, this does not affect proof verification later on
* removed the state tree from MaciState. Instead, `MaciState.ts` will store the state leaves only. 
* amended the `copyStateFromMaci` function in `Poll.ts` to accept `numSignups` . This function is now called `updatePoll` and copies over `numSignups` leaves from `MaciState.ts` and creates its own state tree. 
* amended `genMaciStateFromContract` to call `updatePoll` with the number of signups taken directly from the on chain Poll contract. It also checks that the local state root matches the one saved on the Poll contract.
* amended tests where we mock calling `updatePoll` with the number of leaves 

Benefits:

* We remove one operation of copying over the stateAq for a poll, and instead fill the tree within the poll (should give a little speed boost) 
* Make it easier to then allow multiple concurrent polls as each would store independent data for finalization and not interfere with each other
* fixing the issue

## Related issue(s)

fix #1091

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
