### PR TITLE
chore(core): add quiet flag to process messages to log errors

### DIFF
--- a/cli/testScript.sh
+++ b/cli/testScript.sh
@@ -13,7 +13,7 @@ node build/ts/index.js setVerifyingKeys \
 node build/ts/index.js create -s 10
 node build/ts/index.js deployPoll \
     --pubkey macipk.ea638a3366ed91f2e955110888573861f7c0fc0bb5fb8b8dca9cd7a08d7d6b93 \
-    -t 30 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 -se false
+    -t 30 -i 1 -m 2 -b 1 -v 2 -se false
 node build/ts/index.js signup \
     --pubkey macipk.e743ffb5298ef0f5c1f63b6464a48fea19ea7ee5a885c67ae1b24a1d04f03f07 
 node build/ts/index.js publish \
@@ -44,7 +44,8 @@ node build/ts/index.js genProofs \
     --output proofs/ \
     -tw ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test_js/TallyVotes_10-1-2_test.wasm \
     -pw ./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test_js/ProcessMessages_10-2-1-2_test.wasm \
-    -w true 
+    -w true \
+    -q false 
 node build/ts/index.js proveOnChain \
     --poll-id 0 \
     --proof-dir proofs/ \

--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -283,7 +283,7 @@ export const genProofs = async ({
   // while we have unprocessed messages, process them
   while (poll.hasUnprocessedMessages()) {
     // process messages in batches
-    const circuitInputs = poll.processMessages(pollId) as unknown as CircuitInputs;
+    const circuitInputs = poll.processMessages(pollId, quiet) as unknown as CircuitInputs;
     try {
       // generate the proof for this batch
       // eslint-disable-next-line no-await-in-loop

--- a/core/ts/Poll.ts
+++ b/core/ts/Poll.ts
@@ -430,7 +430,7 @@ export class Poll implements IPoll {
    *        process
    * @returns stringified circuit inputs
    */
-  processMessages = (pollId: bigint): IProcessMessagesCircuitInputs => {
+  processMessages = (pollId: bigint, quiet = true): IProcessMessagesCircuitInputs => {
     assert(this.hasUnprocessedMessages(), "No more messages to process");
 
     const batchSize = this.batchSizes.messageBatchSize;
@@ -544,6 +544,12 @@ export class Poll implements IPoll {
               // otherwise we continue processing but add the default blank data instead of
               // this invalid message
               if (e instanceof ProcessMessageError) {
+                // if logging is enabled, print the error
+                if (!quiet) {
+                  // eslint-disable-next-line no-console
+                  console.log(`Error at message index ${idx} - ${e.message}`);
+                }
+
                 // Since the command is invalid, use a blank state leaf
                 currentStateLeaves.unshift(this.stateLeaves[0].copy());
                 currentStateLeavesPathElements.unshift(this.stateTree!.genProof(0).pathElements);
@@ -599,8 +605,10 @@ export class Poll implements IPoll {
               // add to the first position the path elements of the vote weight tree
               currentVoteWeightsPathElements.unshift(vt.genProof(0).pathElements);
             } catch (e) {
-              // eslint-disable-next-line no-console
-              console.log("Error processing topup message: ", (e as Error).message);
+              if (!quiet) {
+                // eslint-disable-next-line no-console
+                console.log("Error processing topup message: ", (e as Error).message);
+              }
               throw e;
             }
             break;


### PR DESCRIPTION
# Description

Allow to log errors in message processing by accepting a flag into core.processMessages

## Related issue(s)

fix #1135

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
