### PR TITLE
feat(cli): add relevant information in tally.json to simplify verify interface

### DIFF
--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -68,6 +68,7 @@ export const genProofs = async ({
   blocksPerBatch,
   endBlock,
   signer,
+  tallyAddress,
   useQuadraticVoting = true,
   quiet = true,
 }: GenProofsArgs): Promise<TallyData> => {
@@ -487,10 +488,16 @@ export const genProofs = async ({
     newPerVOSpentVoiceCreditsCommitment,
   ]);
 
+  // get the tally contract address
+  const tallyContractAddress = tallyAddress || readContractAddress(`Tally-${pollId}`, network?.name);
+
   // create the tally file data to store for verification later
   const tallyFileData: TallyData = {
-    maci: maciAddress!,
+    maci: maciContractAddress,
     pollId: pollId.toString(),
+    network: network?.name,
+    chainId: network?.chainId.toString(),
+    tallyAddress: tallyContractAddress,
     newTallyCommitment: asHex(tallyCircuitInputs!.newTallyCommitment as BigNumberish),
     results: {
       tally: poll.tallyResult.map((x) => x.toString()),

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -443,6 +443,7 @@ program
     "-t, --tally-file <tallyFile>",
     "the tally file with results, per vote option spent credits, spent voice credits total",
   )
+  .option("-ta, --tally-address <tallyAddress>", "the tally contract address")
   .option("-s, --subsidy-file <subsidyFile>", "the subsidy file")
   .option("-r, --rapidsnark <rapidsnark>", "the path to the rapidsnark binary")
   .option("-wp, --process-witnessgen <processWitnessgen>", "the path to the process witness generation binary")
@@ -495,6 +496,7 @@ program
         startBlock: cmdObj.startBlock,
         endBlock: cmdObj.endBlock,
         blocksPerBatch: cmdObj.blocksPerBatch,
+        tallyAddress: cmdObj.tallyAddress,
         useQuadraticVoting: cmdObj.useQuadraticVoting,
         quiet: cmdObj.quiet,
       });

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -40,6 +40,22 @@ export interface TallyData {
   pollId: string;
 
   /**
+   * The name of the network for which these proofs
+   * are valid for
+   */
+  network?: string;
+
+  /**
+   * The chain ID for which these proofs are valid for
+   */
+  chainId?: string;
+
+  /**
+   * The address of the Tally contract.
+   */
+  tallyAddress: string;
+
+  /**
    * The new tally commitment.
    */
   newTallyCommitment: string;
@@ -562,6 +578,11 @@ export interface GenProofsArgs {
    * Whether to use quadratic voting or not
    */
   useQuadraticVoting?: boolean;
+
+  /**
+   * The address of the Tally contract
+   */
+  tallyAddress?: string;
 }
 
 /**


### PR DESCRIPTION
# Description

Simplify the verify command interface by favoring data fetching from the tally data or tally file.
Also add chain id and network name to better identify tally results across chains.

## Related issue(s)

fix #1065 
fix #1085 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
