### PR TITLE
refactor(contracts): optimize publishMessage by using calldata and removing arg change

### DIFF
--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -154,6 +154,7 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
 
     /// @notice topupCredit is a trusted token contract which reverts if the transfer fails
     extContracts.topupCredit.transferFrom(msg.sender, address(this), amount);
+
     uint256[2] memory dat;
     dat[0] = stateIndex;
     dat[1] = amount;
@@ -164,7 +165,7 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
   }
 
   /// @inheritdoc IPoll
-  function publishMessage(Message memory _message, PubKey calldata _encPubKey) public isWithinVotingDeadline {
+  function publishMessage(Message calldata _message, PubKey calldata _encPubKey) public isWithinVotingDeadline {
     // we check that we do not exceed the max number of messages
     if (numMessages == maxValues.maxMessages) revert TooManyMessages();
 
@@ -178,8 +179,6 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
       numMessages++;
     }
 
-    // force the message to have type 1 just to be safe
-    _message.msgType = 1;
     uint256 messageLeaf = hashMessageAndEncPubKey(_message, _encPubKey);
     extContracts.messageAq.enqueue(messageLeaf);
 

--- a/contracts/contracts/interfaces/IPoll.sol
+++ b/contracts/contracts/interfaces/IPoll.sol
@@ -25,7 +25,7 @@ interface IPoll {
   /// @param _encPubKey An epheremal public key which can be combined with the
   /// coordinator's private key to generate an ECDH shared key with which
   /// to encrypt the message.
-  function publishMessage(DomainObjs.Message memory _message, DomainObjs.PubKey memory _encPubKey) external;
+  function publishMessage(DomainObjs.Message calldata _message, DomainObjs.PubKey calldata _encPubKey) external;
 
   /// @notice The first step of merging the MACI state AccQueue. This allows the
   /// ProcessMessages circuit to access the latest state tree and ballots via


### PR DESCRIPTION
# Description

Remove redundant operation to set msgType to 1. Also use calldata vs memory as we are not modifying the user param anymore.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
