### PR TITLE
refactor(contracts): optimize utilities.padAndHashMessage

### DIFF
--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -133,9 +133,8 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
     }
 
     // init messageAq here by inserting placeholderLeaf
-    uint256[2] memory dat;
-    dat[0] = NOTHING_UP_MY_SLEEVE;
-    dat[1] = 0;
+    uint256[2] memory dat = [NOTHING_UP_MY_SLEEVE, 0];
+
     (Message memory _message, PubKey memory _padKey, uint256 placeholderLeaf) = padAndHashMessage(dat, 1);
     extContracts.messageAq.enqueue(placeholderLeaf);
 
@@ -155,10 +154,9 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
     /// @notice topupCredit is a trusted token contract which reverts if the transfer fails
     extContracts.topupCredit.transferFrom(msg.sender, address(this), amount);
 
-    uint256[2] memory dat;
-    dat[0] = stateIndex;
-    dat[1] = amount;
+    uint256[2] memory dat = [stateIndex, amount];
     (Message memory _message, , uint256 messageLeaf) = padAndHashMessage(dat, 2);
+
     extContracts.messageAq.enqueue(messageLeaf);
 
     emit TopupMessage(_message);

--- a/contracts/contracts/utilities/Utilities.sol
+++ b/contracts/contracts/utilities/Utilities.sol
@@ -36,15 +36,9 @@ contract Utilities is SnarkConstants, DomainObjs, Hasher {
     uint256[2] memory dataToPad,
     uint256 msgType
   ) public pure returns (Message memory message, PubKey memory padKey, uint256 msgHash) {
-    uint256[10] memory dat;
-    dat[0] = dataToPad[0];
-    dat[1] = dataToPad[1];
-    for (uint256 i = 2; i < 10; ) {
-      dat[i] = 0;
-      unchecked {
-        ++i;
-      }
-    }
+    // add data and pad it
+    uint256[10] memory dat = [dataToPad[0], dataToPad[1], 0, 0, 0, 0, 0, 0, 0, 0];
+
     padKey = PubKey(PAD_PUBKEY_X, PAD_PUBKEY_Y);
     message = Message({ msgType: msgType, data: dat });
     msgHash = hashMessageAndEncPubKey(message, padKey);


### PR DESCRIPTION
# Description

optimize utilities.padAndHashMessage by using inline initialization of array vs using for loop to pad it.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
