### PR TITLE
refactor(core): remove redundant code which could slow down processing

### DIFF
--- a/core/ts/Poll.ts
+++ b/core/ts/Poll.ts
@@ -557,7 +557,7 @@ export class Poll implements IPoll {
                 // Since the command is invalid, use a blank state leaf
                 currentStateLeaves.unshift(this.stateLeaves[0].copy());
                 currentStateLeavesPathElements.unshift(this.stateTree!.genProof(0).pathElements);
-                // since the command is invliad we use the blank ballot
+                // since the command is invalid we use the blank ballot
                 currentBallots.unshift(this.ballots[0].copy());
                 currentBallotsPathElements.unshift(this.ballotTree!.genProof(0).pathElements);
 
@@ -710,14 +710,6 @@ export class Poll implements IPoll {
     }
     // we only take the messages we need for this batch
     msgs = msgs.slice(index, index + messageBatchSize);
-
-    // fill the commands array with a copy of the commands we have
-    let commands = this.commands.map((x) => x.copy());
-    while (commands.length % messageBatchSize > 0) {
-      commands.push(commands[commands.length - 1]);
-    }
-    // we only take the commands we need for this batch
-    commands = commands.slice(index, index + messageBatchSize);
 
     while (this.messageTree.nextIndex < index + messageBatchSize) {
       this.messageTree.insert(this.messageTree.zeroValue);


### PR DESCRIPTION
# Description

Remove redundant code in `genProcessMessagesCircuitInputsPartial`, looping over a potentially large array to create an array copy that is not used

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
