### PR TITLE
fix(circuits): enforce use of stateIndex from message

### DIFF
--- a/circuits/circom/messageValidator.circom
+++ b/circuits/circom/messageValidator.circom
@@ -20,6 +20,7 @@ template MessageValidator() {
     validStateLeafIndex.in[0] <== stateTreeIndex;
     validStateLeafIndex.in[1] <== numSignUps;
 
+    // @todo check if we need this if we do the check inside processOne 
     // b) Whether the max vote option tree index is correct
     signal input voteOptionIndex;
     signal input maxVoteOptions;

--- a/circuits/circom/processMessages.circom
+++ b/circuits/circom/processMessages.circom
@@ -613,8 +613,16 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
     isMessageValid.in[0] <== bothValid;
     isMessageValid.in[1] <== transformer.isValid + enoughVoiceCredits.out;
 
+    // check that the vote option index is < maxVoteOptions (0-indexed)
+    component validVoteOptionIndex = SafeLessThan(N_BITS);
+    validVoteOptionIndex.in[0] <== cmdVoteOptionIndex;
+    validVoteOptionIndex.in[1] <== maxVoteOptions;
+
+    // @note pick the correct vote option index based on whether the index is < max vote options 
+    // @todo can probably add one output to messageValidator and take from there
+    // or maybe we can remove altogther from messageValidator so we don't double check this
     component cmdVoteOptionIndexMux = Mux1();
-    cmdVoteOptionIndexMux.s <== isMessageValid.out;
+    cmdVoteOptionIndexMux.s <== validVoteOptionIndex.out;
     cmdVoteOptionIndexMux.c[0] <== 0;
     cmdVoteOptionIndexMux.c[1] <== cmdVoteOptionIndex;
 

--- a/circuits/circom/processMessagesNonQv.circom
+++ b/circuits/circom/processMessagesNonQv.circom
@@ -535,8 +535,16 @@ template ProcessOneNonQv(stateTreeDepth, voteOptionTreeDepth) {
     isMessageValid.in[0] <== bothValid;
     isMessageValid.in[1] <== transformer.isValid + enoughVoiceCredits.out;
 
+    // check that the vote option index is < maxVoteOptions (0-indexed)
+    component validVoteOptionIndex = SafeLessThan(N_BITS);
+    validVoteOptionIndex.in[0] <== cmdVoteOptionIndex;
+    validVoteOptionIndex.in[1] <== maxVoteOptions;
+
+    // @note pick the correct vote option index based on whether the index is < max vote options 
+    // @todo can probably add one output to messageValidator and take from there
+    // or maybe we can remove altogther from messageValidator so we don't double check this
     component cmdVoteOptionIndexMux = Mux1();
-    cmdVoteOptionIndexMux.s <== isMessageValid.out;
+    cmdVoteOptionIndexMux.s <== validVoteOptionIndex.out;
     cmdVoteOptionIndexMux.c[0] <== 0;
     cmdVoteOptionIndexMux.c[1] <== cmdVoteOptionIndex;
 

--- a/circuits/circom/stateLeafAndBallotTransformer.circom
+++ b/circuits/circom/stateLeafAndBallotTransformer.circom
@@ -86,7 +86,7 @@ template StateLeafAndBallotTransformer() {
     messageValidator.voteWeight <== cmdNewVoteWeight;
 
     // if the message is valid then we swap out the public key
-    // we have to do this in two Mux one for pucKey[0]
+    // we have to do this in two Mux one for pubKey[0]
     // and one for pubKey[1]
     component newSlPubKey0Mux = Mux1();
     newSlPubKey0Mux.s <== messageValidator.isValid;

--- a/circuits/circom/stateLeafAndBallotTransformerNonQv.circom
+++ b/circuits/circom/stateLeafAndBallotTransformerNonQv.circom
@@ -86,7 +86,7 @@ template StateLeafAndBallotTransformerNonQv() {
     messageValidator.voteWeight <== cmdNewVoteWeight;
 
     // if the message is valid then we swap out the public key
-    // we have to do this in two Mux one for pucKey[0]
+    // we have to do this in two Mux one for pubKey[0]
     // and one for pubKey[1]
     component newSlPubKey0Mux = Mux1();
     newSlPubKey0Mux.s <== messageValidator.isValid;

--- a/circuits/ts/__tests__/ProcessMessages.test.ts
+++ b/circuits/ts/__tests__/ProcessMessages.test.ts
@@ -575,7 +575,7 @@ describe("ProcessMessage circuit", function test() {
 
         // Second batch is not a full batch
         const numMessages = messageBatchSize * NUM_BATCHES - 1;
-        for (let i = 0; i < 6; i += 1) {
+        for (let i = 0; i < numMessages; i += 1) {
           const command = new PCommand(
             BigInt(index),
             userKeypair.pubKey,
@@ -672,6 +672,392 @@ describe("ProcessMessage circuit", function test() {
       const inputs = poll.processMessages(pollId) as unknown as IProcessMessagesInputs;
       const witness = await circuit.calculateWitness(inputs);
       await circuit.expectConstraintPass(witness);
+    });
+  });
+
+  describe("1 user, 2 messages", () => {
+    const maciState = new MaciState(STATE_TREE_DEPTH);
+    const voteOptionIndex = 1n;
+    let stateIndex: bigint;
+    let pollId: bigint;
+    let poll: Poll;
+    const messages: Message[] = [];
+    const commands: PCommand[] = [];
+
+    before(() => {
+      // Sign up and publish
+      const userKeypair = new Keypair(new PrivKey(BigInt(1)));
+      stateIndex = BigInt(
+        maciState.signUp(userKeypair.pubKey, voiceCreditBalance, BigInt(Math.floor(Date.now() / 1000))),
+      );
+
+      pollId = maciState.deployPoll(
+        BigInt(Math.floor(Date.now() / 1000) + duration),
+        maxValues,
+        treeDepths,
+        messageBatchSize,
+        coordinatorKeypair,
+      );
+
+      poll = maciState.polls.get(pollId)!;
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
+      const nothing = new Message(1n, [
+        8370432830353022751713833565135785980866757267633941821328460903436894336785n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+      ]);
+
+      const encP = new PubKey([
+        10457101036533406547632367118273992217979173478358440826365724437999023779287n,
+        19824078218392094440610104313265183977899662750282163392862422243483260492317n,
+      ]);
+
+      poll.publishMessage(nothing, encP);
+
+      // First command (valid)
+      const command = new PCommand(
+        stateIndex, // BigInt(1),
+        userKeypair.pubKey,
+        1n, // voteOptionIndex,
+        2n, // vote weight
+        2n, // nonce
+        pollId,
+      );
+
+      const signature = command.sign(userKeypair.privKey);
+
+      const ecdhKeypair = new Keypair();
+      const sharedKey = Keypair.genEcdhSharedKey(ecdhKeypair.privKey, coordinatorKeypair.pubKey);
+      const message = command.encrypt(signature, sharedKey);
+      messages.push(message);
+      commands.push(command);
+
+      poll.publishMessage(message, ecdhKeypair.pubKey);
+
+      // Second command (valid)
+      const command2 = new PCommand(
+        stateIndex,
+        userKeypair.pubKey,
+        voteOptionIndex, // voteOptionIndex,
+        9n, // vote weight 9 ** 2 = 81
+        1n, // nonce
+        pollId,
+      );
+      const signature2 = command2.sign(userKeypair.privKey);
+
+      const ecdhKeypair2 = new Keypair();
+      const sharedKey2 = Keypair.genEcdhSharedKey(ecdhKeypair2.privKey, coordinatorKeypair.pubKey);
+      const message2 = command2.encrypt(signature2, sharedKey2);
+      messages.push(message2);
+      commands.push(command2);
+      poll.publishMessage(message2, ecdhKeypair2.pubKey);
+    });
+
+    it("should produce the correct state root and ballot root", async () => {
+      // The current roots
+      const emptyBallot = new Ballot(poll.maxValues.maxVoteOptions, poll.treeDepths.voteOptionTreeDepth);
+      const emptyBallotHash = emptyBallot.hash();
+      const ballotTree = new IncrementalQuinTree(STATE_TREE_DEPTH, emptyBallot.hash(), STATE_TREE_ARITY, hash5);
+
+      ballotTree.insert(emptyBallot.hash());
+
+      poll.stateLeaves.forEach(() => {
+        ballotTree.insert(emptyBallotHash);
+      });
+
+      const currentStateRoot = poll.stateTree?.root;
+      const currentBallotRoot = ballotTree.root;
+
+      const inputs = poll.processMessages(pollId) as unknown as IProcessMessagesInputs;
+
+      // Calculate the witness
+      const witness = await circuit.calculateWitness(inputs);
+      await circuit.expectConstraintPass(witness);
+
+      // The new roots, which should differ, since at least one of the
+      // messages modified a Ballot or State Leaf
+      const newStateRoot = poll.stateTree?.root;
+      const newBallotRoot = poll.ballotTree?.root;
+
+      expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot?.toString());
+      expect(newBallotRoot?.toString()).not.to.be.eq(currentBallotRoot.toString());
+    });
+  });
+
+  describe("1 user, 2 messages in different batches", () => {
+    const maciState = new MaciState(STATE_TREE_DEPTH);
+    const voteOptionIndex = 1n;
+    let stateIndex: bigint;
+    let pollId: bigint;
+    let poll: Poll;
+    const messages: Message[] = [];
+    const commands: PCommand[] = [];
+
+    before(() => {
+      // Sign up and publish
+      const userKeypair = new Keypair(new PrivKey(BigInt(1)));
+      stateIndex = BigInt(
+        maciState.signUp(userKeypair.pubKey, voiceCreditBalance, BigInt(Math.floor(Date.now() / 1000))),
+      );
+
+      pollId = maciState.deployPoll(
+        BigInt(Math.floor(Date.now() / 1000) + duration),
+        maxValues,
+        treeDepths,
+        messageBatchSize,
+        coordinatorKeypair,
+      );
+
+      poll = maciState.polls.get(pollId)!;
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
+      const nothing = new Message(1n, [
+        8370432830353022751713833565135785980866757267633941821328460903436894336785n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+      ]);
+
+      const encP = new PubKey([
+        10457101036533406547632367118273992217979173478358440826365724437999023779287n,
+        19824078218392094440610104313265183977899662750282163392862422243483260492317n,
+      ]);
+
+      poll.publishMessage(nothing, encP);
+
+      // First command (valid)
+      const command = new PCommand(
+        stateIndex, // BigInt(1),
+        userKeypair.pubKey,
+        1n, // voteOptionIndex,
+        2n, // vote weight
+        2n, // nonce
+        pollId,
+      );
+
+      const signature = command.sign(userKeypair.privKey);
+
+      const ecdhKeypair = new Keypair();
+      const sharedKey = Keypair.genEcdhSharedKey(ecdhKeypair.privKey, coordinatorKeypair.pubKey);
+      const message = command.encrypt(signature, sharedKey);
+      messages.push(message);
+      commands.push(command);
+
+      poll.publishMessage(message, ecdhKeypair.pubKey);
+
+      // fill the batch with nothing messages
+      for (let i = 0; i < messageBatchSize - 1; i += 1) {
+        poll.publishMessage(nothing, encP);
+      }
+
+      // Second command (valid) in second batch (which is first due to reverse processing)
+      const command2 = new PCommand(
+        stateIndex,
+        userKeypair.pubKey,
+        voteOptionIndex, // voteOptionIndex,
+        9n, // vote weight 9 ** 2 = 81
+        1n, // nonce
+        pollId,
+      );
+      const signature2 = command2.sign(userKeypair.privKey);
+
+      const ecdhKeypair2 = new Keypair();
+      const sharedKey2 = Keypair.genEcdhSharedKey(ecdhKeypair2.privKey, coordinatorKeypair.pubKey);
+      const message2 = command2.encrypt(signature2, sharedKey2);
+      messages.push(message2);
+      commands.push(command2);
+      poll.publishMessage(message2, ecdhKeypair2.pubKey);
+    });
+
+    it("should produce the correct state root and ballot root", async () => {
+      // The current roots
+      const emptyBallot = new Ballot(poll.maxValues.maxVoteOptions, poll.treeDepths.voteOptionTreeDepth);
+      const emptyBallotHash = emptyBallot.hash();
+      const ballotTree = new IncrementalQuinTree(STATE_TREE_DEPTH, emptyBallot.hash(), STATE_TREE_ARITY, hash5);
+
+      ballotTree.insert(emptyBallot.hash());
+
+      poll.stateLeaves.forEach(() => {
+        ballotTree.insert(emptyBallotHash);
+      });
+
+      while (poll.hasUnprocessedMessages()) {
+        const currentStateRoot = poll.stateTree?.root;
+        const currentBallotRoot = ballotTree.root;
+        const inputs = poll.processMessages(pollId) as unknown as IProcessMessagesInputs;
+
+        // Calculate the witness
+        // eslint-disable-next-line no-await-in-loop
+        const witness = await circuit.calculateWitness(inputs);
+        // eslint-disable-next-line no-await-in-loop
+        await circuit.expectConstraintPass(witness);
+
+        // The new roots, which should differ, since at least one of the
+        // messages modified a Ballot or State Leaf
+        const newStateRoot = poll.stateTree?.root;
+        const newBallotRoot = poll.ballotTree?.root;
+
+        expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot?.toString());
+        expect(newBallotRoot?.toString()).not.to.be.eq(currentBallotRoot.toString());
+      }
+    });
+  });
+
+  describe("1 user, 3 messages in different batches", () => {
+    const maciState = new MaciState(STATE_TREE_DEPTH);
+    const voteOptionIndex = 1n;
+    let stateIndex: bigint;
+    let pollId: bigint;
+    let poll: Poll;
+    const messages: Message[] = [];
+    const commands: PCommand[] = [];
+
+    before(() => {
+      // Sign up and publish
+      const userKeypair = new Keypair(new PrivKey(BigInt(1)));
+      stateIndex = BigInt(
+        maciState.signUp(userKeypair.pubKey, voiceCreditBalance, BigInt(Math.floor(Date.now() / 1000))),
+      );
+
+      pollId = maciState.deployPoll(
+        BigInt(Math.floor(Date.now() / 1000) + duration),
+        maxValues,
+        treeDepths,
+        messageBatchSize,
+        coordinatorKeypair,
+      );
+
+      poll = maciState.polls.get(pollId)!;
+      poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
+      const nothing = new Message(1n, [
+        8370432830353022751713833565135785980866757267633941821328460903436894336785n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+        0n,
+      ]);
+
+      const encP = new PubKey([
+        10457101036533406547632367118273992217979173478358440826365724437999023779287n,
+        19824078218392094440610104313265183977899662750282163392862422243483260492317n,
+      ]);
+
+      poll.publishMessage(nothing, encP);
+
+      const commandFinal = new PCommand(
+        stateIndex, // BigInt(1),
+        userKeypair.pubKey,
+        1n, // voteOptionIndex,
+        1n, // vote weight
+        3n, // nonce
+        pollId,
+      );
+
+      const signatureFinal = commandFinal.sign(userKeypair.privKey);
+
+      const ecdhKeypairFinal = new Keypair();
+      const sharedKeyFinal = Keypair.genEcdhSharedKey(ecdhKeypairFinal.privKey, coordinatorKeypair.pubKey);
+      const messageFinal = commandFinal.encrypt(signatureFinal, sharedKeyFinal);
+      messages.push(messageFinal);
+      commands.push(commandFinal);
+
+      poll.publishMessage(messageFinal, ecdhKeypairFinal.pubKey);
+
+      // First command (valid)
+      const command = new PCommand(
+        stateIndex, // BigInt(1),
+        userKeypair.pubKey,
+        1n, // voteOptionIndex,
+        2n, // vote weight
+        2n, // nonce
+        pollId,
+      );
+
+      const signature = command.sign(userKeypair.privKey);
+
+      const ecdhKeypair = new Keypair();
+      const sharedKey = Keypair.genEcdhSharedKey(ecdhKeypair.privKey, coordinatorKeypair.pubKey);
+      const message = command.encrypt(signature, sharedKey);
+      messages.push(message);
+      commands.push(command);
+
+      poll.publishMessage(message, ecdhKeypair.pubKey);
+
+      // fill the batch with nothing messages
+      for (let i = 0; i < messageBatchSize - 1; i += 1) {
+        poll.publishMessage(nothing, encP);
+      }
+
+      // Second command (valid) in second batch (which is first due to reverse processing)
+      const command2 = new PCommand(
+        stateIndex,
+        userKeypair.pubKey,
+        voteOptionIndex, // voteOptionIndex,
+        9n, // vote weight 9 ** 2 = 81
+        1n, // nonce
+        pollId,
+      );
+      const signature2 = command2.sign(userKeypair.privKey);
+
+      const ecdhKeypair2 = new Keypair();
+      const sharedKey2 = Keypair.genEcdhSharedKey(ecdhKeypair2.privKey, coordinatorKeypair.pubKey);
+      const message2 = command2.encrypt(signature2, sharedKey2);
+      messages.push(message2);
+      commands.push(command2);
+      poll.publishMessage(message2, ecdhKeypair2.pubKey);
+    });
+
+    it("should produce the correct state root and ballot root", async () => {
+      // The current roots
+      const emptyBallot = new Ballot(poll.maxValues.maxVoteOptions, poll.treeDepths.voteOptionTreeDepth);
+      const emptyBallotHash = emptyBallot.hash();
+      const ballotTree = new IncrementalQuinTree(STATE_TREE_DEPTH, emptyBallot.hash(), STATE_TREE_ARITY, hash5);
+
+      ballotTree.insert(emptyBallot.hash());
+
+      poll.stateLeaves.forEach(() => {
+        ballotTree.insert(emptyBallotHash);
+      });
+
+      while (poll.hasUnprocessedMessages()) {
+        const currentStateRoot = poll.stateTree?.root;
+        const currentBallotRoot = ballotTree.root;
+        const inputs = poll.processMessages(pollId) as unknown as IProcessMessagesInputs;
+
+        // Calculate the witness
+        // eslint-disable-next-line no-await-in-loop
+        const witness = await circuit.calculateWitness(inputs);
+        // eslint-disable-next-line no-await-in-loop
+        await circuit.expectConstraintPass(witness);
+
+        // The new roots, which should differ, since at least one of the
+        // messages modified a Ballot or State Leaf
+        const newStateRoot = poll.stateTree?.root;
+        const newBallotRoot = poll.ballotTree?.root;
+
+        expect(newStateRoot?.toString()).not.to.be.eq(currentStateRoot?.toString());
+        expect(newBallotRoot?.toString()).not.to.be.eq(currentBallotRoot.toString());
+      }
     });
   });
 });

--- a/cli/tests/e2e/e2e.test.ts
+++ b/cli/tests/e2e/e2e.test.ts
@@ -54,7 +54,7 @@ import { cleanVanilla, isArm } from "../utils";
 /**
  Test scenarios:
     1 signup, 1 message
-    4 signups, 6 messages
+    4 signups, 8 messages
     5 signups, 1 message
     8 signups, 10 messages
     4 signups, 4 messages
@@ -195,7 +195,7 @@ describe("e2e tests", function test() {
     });
   });
 
-  describe("4 signups, 6 messages", () => {
+  describe("4 signups, 8 messages", () => {
     after(() => {
       cleanVanilla();
     });
@@ -217,7 +217,31 @@ describe("e2e tests", function test() {
       }
     });
 
-    it("should publish six messages", async () => {
+    it("should publish eight messages", async () => {
+      await publish({
+        pubkey: users[0].pubKey.serialize(),
+        stateIndex: 1n,
+        voteOptionIndex: 0n,
+        nonce: 2n,
+        pollId: 0n,
+        newVoteWeight: 4n,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt(),
+        privateKey: users[0].privKey.serialize(),
+        signer,
+      });
+      await publish({
+        pubkey: users[0].pubKey.serialize(),
+        stateIndex: 1n,
+        voteOptionIndex: 0n,
+        nonce: 2n,
+        pollId: 0n,
+        newVoteWeight: 3n,
+        maciContractAddress: maciAddresses.maciAddress,
+        salt: genRandomSalt(),
+        privateKey: users[0].privKey.serialize(),
+        signer,
+      });
       await publish({
         pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
@@ -233,7 +257,7 @@ describe("e2e tests", function test() {
       await publish({
         pubkey: users[1].pubKey.serialize(),
         stateIndex: 2n,
-        voteOptionIndex: 0n,
+        voteOptionIndex: 2n,
         nonce: 1n,
         pollId: 0n,
         newVoteWeight: 9n,
@@ -245,7 +269,7 @@ describe("e2e tests", function test() {
       await publish({
         pubkey: users[2].pubKey.serialize(),
         stateIndex: 3n,
-        voteOptionIndex: 0n,
+        voteOptionIndex: 2n,
         nonce: 1n,
         pollId: 0n,
         newVoteWeight: 9n,
@@ -257,10 +281,10 @@ describe("e2e tests", function test() {
       await publish({
         pubkey: users[3].pubKey.serialize(),
         stateIndex: 4n,
-        voteOptionIndex: 0n,
-        nonce: 1n,
+        voteOptionIndex: 2n,
+        nonce: 3n,
         pollId: 0n,
-        newVoteWeight: 9n,
+        newVoteWeight: 3n,
         maciContractAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
         privateKey: users[3].privKey.serialize(),
@@ -269,10 +293,10 @@ describe("e2e tests", function test() {
       await publish({
         pubkey: users[3].pubKey.serialize(),
         stateIndex: 4n,
-        voteOptionIndex: 0n,
-        nonce: 1n,
+        voteOptionIndex: 2n,
+        nonce: 2n,
         pollId: 0n,
-        newVoteWeight: 9n,
+        newVoteWeight: 2n,
         maciContractAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
         privateKey: users[3].privKey.serialize(),
@@ -281,7 +305,7 @@ describe("e2e tests", function test() {
       await publish({
         pubkey: users[3].pubKey.serialize(),
         stateIndex: 4n,
-        voteOptionIndex: 0n,
+        voteOptionIndex: 1n,
         nonce: 1n,
         pollId: 0n,
         newVoteWeight: 9n,

--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -279,6 +279,7 @@ export const genProofs = async ({
   while (poll.hasUnprocessedMessages()) {
     // process messages in batches
     const circuitInputs = poll.processMessages(pollId, useQuadraticVoting, quiet) as unknown as CircuitInputs;
+
     try {
       // generate the proof for this batch
       // eslint-disable-next-line no-await-in-loop
@@ -290,11 +291,12 @@ export const genProofs = async ({
         witnessExePath: processWitgen,
         wasmPath: processWasm,
       });
+
       // verify it
       // eslint-disable-next-line no-await-in-loop
       const isValid = await verifyProof(r.publicSignals, r.proof, processVk);
       if (!isValid) {
-        logError("Error: generated an invalid proof");
+        throw new Error("Generated an invalid proof");
       }
 
       const thisProof = {

--- a/crypto/ts/index.ts
+++ b/crypto/ts/index.ts
@@ -23,7 +23,7 @@ export { G1Point, G2Point, genRandomBabyJubValue } from "./babyjub";
 
 export { sha256Hash, hashLeftRight, hashN, hash2, hash3, hash4, hash5, hash13, hashOne } from "./hashing";
 
-export { poseidonDecrypt, poseidonEncrypt } from "@zk-kit/poseidon-cipher";
+export { poseidonDecrypt, poseidonDecryptWithoutCheck, poseidonEncrypt } from "@zk-kit/poseidon-cipher";
 
 export { verifySignature, signMessage as sign } from "@zk-kit/eddsa-poseidon";
 

--- a/domainobjs/ts/commands/PCommand.ts
+++ b/domainobjs/ts/commands/PCommand.ts
@@ -9,6 +9,7 @@ import {
   type Ciphertext,
   type EcdhSharedKey,
   type Point,
+  poseidonDecryptWithoutCheck,
 } from "maci-crypto";
 
 import assert from "assert";
@@ -172,11 +173,16 @@ export class PCommand implements ICommand {
 
   /**
    * Decrypts a Message to produce a Command.
+   * @dev You can force decrypt the message by setting `force` to true.
+   * This is useful in case you don't want an invalid message to throw an error.
    * @param {Message} message - the message to decrypt
    * @param {EcdhSharedKey} sharedKey - the shared key to use for decryption
+   * @param {boolean} force - whether to force decryption or not
    */
-  static decrypt = (message: Message, sharedKey: EcdhSharedKey): IDecryptMessage => {
-    const decrypted = poseidonDecrypt(message.data, sharedKey, BigInt(0), 7);
+  static decrypt = (message: Message, sharedKey: EcdhSharedKey, force = false): IDecryptMessage => {
+    const decrypted = force
+      ? poseidonDecryptWithoutCheck(message.data, sharedKey, BigInt(0), 7)
+      : poseidonDecrypt(message.data, sharedKey, BigInt(0), 7);
 
     const p = BigInt(decrypted[0].toString());
 


### PR DESCRIPTION
# Description

Prevent passing unmatched state leaves to censor votes by the coordinator. Instead, ensure that the state leaf sent for each message, is the state leaf at position message.stateIndex within the stateTree. Also, force decryption on the TS message processing, to ensure that a malicious user might not send an invalid message which when decrypted by the circuit (using decryptWithoutCheck and thus possibily failing decryption) would result in a valid stateIndex, causing a DoS on the coordinator which would not be able to generate a proof.

Also, the padding messages are not anymore the last message sent (this.messages[this.messages.length - 1]), but actually an empty command with a state index 0 so that when processed in the circuit, it will have no effect.

cc @kcharbo3 

## Related issue(s)

re #1133 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
