### PR TITLE
refactor(nonqv): optimize tally votes non qv circuit and contracts

### DIFF
--- a/circuits/ts/__tests__/TallyVotes.test.ts
+++ b/circuits/ts/__tests__/TallyVotes.test.ts
@@ -214,13 +214,14 @@ describe("TallyVotes circuit", function test() {
     });
 
     it("should produce the correct result commitments", async () => {
-      const generatedInputs = poll.tallyVotes() as unknown as ITallyVotesInputs;
-      const witness = await circuit.calculateWitness(generatedInputs);
-      await circuit.expectConstraintPass(witness);
+      const generatedInputs = poll.tallyVotesNonQv() as unknown as ITallyVotesInputs;
+
+      const witness = await circuitNonQv.calculateWitness(generatedInputs);
+      await circuitNonQv.expectConstraintPass(witness);
     });
 
     it("should produce the correct result if the inital tally is not zero", async () => {
-      const generatedInputs = poll.tallyVotes(false) as unknown as ITallyVotesInputs;
+      const generatedInputs = poll.tallyVotesNonQv() as unknown as ITallyVotesInputs;
 
       // Start the tally from non-zero value
       let randIdx = generateRandomIndex(Object.keys(generatedInputs).length);

--- a/cli/tests/e2e/e2e.nonQv.test.ts
+++ b/cli/tests/e2e/e2e.nonQv.test.ts
@@ -47,7 +47,7 @@ import { cleanVanilla, isArm } from "../utils";
  Test scenarios:
     1 signup, 1 message with quadratic voting disabled
  */
-describe("e2e tests", function test() {
+describe("e2e tests with non quadratic voting", function test() {
   const useWasm = isArm();
   this.timeout(900000);
 
@@ -69,6 +69,7 @@ describe("e2e tests", function test() {
     processWasm: testProcessMessagesNonQvWasmPath,
     tallyWasm: testTallyVotesNonQvWasmPath,
     useWasm,
+    useQuadraticVoting: false,
   };
 
   // before all tests we deploy the vk registry contract and set the verifying keys
@@ -90,7 +91,7 @@ describe("e2e tests", function test() {
 
     before(async () => {
       // deploy the smart contracts
-      maciAddresses = await deploy({ ...deployArgs, signer });
+      maciAddresses = await deploy({ ...deployArgs, signer, useQv: false });
       // deploy a poll contract
       await deployPoll({ ...deployPollArgs, signer });
     });

--- a/cli/tests/e2e/keyChange.test.ts
+++ b/cli/tests/e2e/keyChange.test.ts
@@ -147,7 +147,7 @@ describe("keyChange tests", function test() {
     it("should confirm the tally is correct", () => {
       const tallyData = JSON.parse(fs.readFileSync(testTallyFilePath).toString()) as TallyData;
       expect(tallyData.results.tally[0]).to.equal(expectedTally.toString());
-      expect(tallyData.perVOSpentVoiceCredits.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
+      expect(tallyData.perVOSpentVoiceCredits?.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
     });
   });
 
@@ -215,7 +215,7 @@ describe("keyChange tests", function test() {
     it("should confirm the tally is correct", () => {
       const tallyData = JSON.parse(fs.readFileSync(testTallyFilePath).toString()) as TallyData;
       expect(tallyData.results.tally[0]).to.equal(expectedTally.toString());
-      expect(tallyData.perVOSpentVoiceCredits.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
+      expect(tallyData.perVOSpentVoiceCredits?.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
     });
   });
 
@@ -283,7 +283,7 @@ describe("keyChange tests", function test() {
     it("should confirm the tally is correct", () => {
       const tallyData = JSON.parse(fs.readFileSync(testTallyFilePath).toString()) as TallyData;
       expect(tallyData.results.tally[2]).to.equal(expectedTally.toString());
-      expect(tallyData.perVOSpentVoiceCredits.tally[2]).to.equal(expectedPerVoteOptionTally.toString());
+      expect(tallyData.perVOSpentVoiceCredits?.tally[2]).to.equal(expectedPerVoteOptionTally.toString());
     });
   });
 });

--- a/cli/ts/commands/deploy.ts
+++ b/cli/ts/commands/deploy.ts
@@ -32,6 +32,7 @@ export const deploy = async ({
   poseidonT4Address,
   poseidonT5Address,
   poseidonT6Address,
+  useQv = true,
   signer,
   quiet = true,
 }: DeployArgs): Promise<DeployedContracts> => {
@@ -95,6 +96,7 @@ export const deploy = async ({
     signer,
     stateTreeDepth,
     quiet: true,
+    useQv,
   });
 
   const [maciContractAddress, stateAqContractAddress, pollFactoryContractAddress] = await Promise.all([

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -57,6 +57,7 @@ program
   .option("-g, --signupGatekeeperAddress <signupGatekeeperAddress>", "the signup gatekeeper contract address")
   .option("-q, --quiet <quiet>", "whether to print values to the console", (value) => value === "true", false)
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
+  .option("-uq, --use-quadratic-voting", "whether to use quadratic voting", (value) => value === "true", true)
   .requiredOption("-s, --stateTreeDepth <stateTreeDepth>", "the state tree depth", parseInt)
   .action(async (cmdOptions) => {
     try {
@@ -71,6 +72,7 @@ program
         poseidonT4Address: cmdOptions.poseidonT4Address,
         poseidonT5Address: cmdOptions.poseidonT5Address,
         poseidonT6Address: cmdOptions.poseidonT6Address,
+        useQv: cmdOptions.useQuadraticVoting,
         quiet: cmdOptions.quiet,
         signer,
       });

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -51,6 +51,11 @@ export interface TallyData {
   chainId?: string;
 
   /**
+   * Whether the poll is using quadratic voting or not.
+   */
+  isQuadratic: boolean;
+
+  /**
    * The address of the Tally contract.
    */
   tallyAddress: string;
@@ -103,7 +108,7 @@ export interface TallyData {
   /**
    * The per VO spent voice credits.
    */
-  perVOSpentVoiceCredits: {
+  perVOSpentVoiceCredits?: {
     /**
      * The tally of the per VO spent voice credits.
      */
@@ -307,6 +312,11 @@ export interface DeployArgs {
    * Whether to log the output
    */
   quiet?: boolean;
+
+  /**
+   * Whether to use quadratic voting or not
+   */
+  useQv?: boolean;
 }
 
 /**

--- a/contracts/contracts/TallyNonQv.sol
+++ b/contracts/contracts/TallyNonQv.sol
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import { IMACI } from "./interfaces/IMACI.sol";
+import { Hasher } from "./crypto/Hasher.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IPoll } from "./interfaces/IPoll.sol";
+import { IMessageProcessor } from "./interfaces/IMessageProcessor.sol";
+import { SnarkCommon } from "./crypto/SnarkCommon.sol";
+import { IVerifier } from "./interfaces/IVerifier.sol";
+import { IVkRegistry } from "./interfaces/IVkRegistry.sol";
+import { CommonUtilities } from "./utilities/CommonUtilities.sol";
+
+/// @title TallyNonQv
+/// @notice The TallyNonQv contract is used during votes tallying
+/// and by users to verify the tally results.
+contract TallyNonQv is Ownable, SnarkCommon, CommonUtilities, Hasher {
+  uint256 private constant TREE_ARITY = 5;
+
+  /// @notice The commitment to the tally results. Its initial value is 0, but after
+  /// the tally of each batch is proven on-chain via a zk-SNARK, it should be
+  /// updated to:
+  ///
+  /// hash2(
+  ///   hashLeftRight(merkle root of current results, salt0)
+  ///   hashLeftRight(number of spent voice credits, salt1),
+  /// )
+  ///
+  /// Where each salt is unique and the merkle roots are of arrays of leaves
+  /// TREE_ARITY ** voteOptionTreeDepth long.
+  uint256 public tallyCommitment;
+
+  uint256 public tallyBatchNum;
+
+  // The final commitment to the state and ballot roots
+  uint256 public sbCommitment;
+
+  IVerifier public immutable verifier;
+  IVkRegistry public immutable vkRegistry;
+  IPoll public immutable poll;
+  IMessageProcessor public immutable messageProcessor;
+
+  /// @notice custom errors
+  error ProcessingNotComplete();
+  error InvalidTallyVotesProof();
+  error AllBallotsTallied();
+  error NumSignUpsTooLarge();
+  error BatchStartIndexTooLarge();
+  error TallyBatchSizeTooLarge();
+
+  /// @notice Create a new Tally contract
+  /// @param _verifier The Verifier contract
+  /// @param _vkRegistry The VkRegistry contract
+  /// @param _poll The Poll contract
+  /// @param _mp The MessageProcessor contract
+  constructor(address _verifier, address _vkRegistry, address _poll, address _mp) payable {
+    verifier = IVerifier(_verifier);
+    vkRegistry = IVkRegistry(_vkRegistry);
+    poll = IPoll(_poll);
+    messageProcessor = IMessageProcessor(_mp);
+  }
+
+  /// @notice Pack the batch start index and number of signups into a 100-bit value.
+  /// @param _numSignUps: number of signups
+  /// @param _batchStartIndex: the start index of given batch
+  /// @param _tallyBatchSize: size of batch
+  /// @return result an uint256 representing the 3 inputs packed together
+  function genTallyVotesPackedVals(
+    uint256 _numSignUps,
+    uint256 _batchStartIndex,
+    uint256 _tallyBatchSize
+  ) public pure returns (uint256 result) {
+    if (_numSignUps >= 2 ** 50) revert NumSignUpsTooLarge();
+    if (_batchStartIndex >= 2 ** 50) revert BatchStartIndexTooLarge();
+    if (_tallyBatchSize >= 2 ** 50) revert TallyBatchSizeTooLarge();
+
+    result = (_batchStartIndex / _tallyBatchSize) + (_numSignUps << uint256(50));
+  }
+
+  /// @notice Check if all ballots are tallied
+  /// @return tallied whether all ballots are tallied
+  function isTallied() external view returns (bool tallied) {
+    (uint8 intStateTreeDepth, , , ) = poll.treeDepths();
+    (uint256 numSignUps, ) = poll.numSignUpsAndMessages();
+
+    // Require that there are untallied ballots left
+    tallied = tallyBatchNum * (TREE_ARITY ** intStateTreeDepth) >= numSignUps;
+  }
+
+  /// @notice generate hash of public inputs for tally circuit
+  /// @param _numSignUps: number of signups
+  /// @param _batchStartIndex: the start index of given batch
+  /// @param _tallyBatchSize: size of batch
+  /// @param _newTallyCommitment: the new tally commitment to be updated
+  /// @return inputHash hash of public inputs
+  function genTallyVotesPublicInputHash(
+    uint256 _numSignUps,
+    uint256 _batchStartIndex,
+    uint256 _tallyBatchSize,
+    uint256 _newTallyCommitment
+  ) public view returns (uint256 inputHash) {
+    uint256 packedVals = genTallyVotesPackedVals(_numSignUps, _batchStartIndex, _tallyBatchSize);
+    uint256[] memory input = new uint256[](4);
+    input[0] = packedVals;
+    input[1] = sbCommitment;
+    input[2] = tallyCommitment;
+    input[3] = _newTallyCommitment;
+    inputHash = sha256Hash(input);
+  }
+
+  /// @notice Update the state and ballot root commitment
+  function updateSbCommitment() public onlyOwner {
+    // Require that all messages have been processed
+    if (!messageProcessor.processingComplete()) {
+      revert ProcessingNotComplete();
+    }
+
+    if (sbCommitment == 0) {
+      sbCommitment = messageProcessor.sbCommitment();
+    }
+  }
+
+  /// @notice Verify the result of a tally batch
+  /// @param _newTallyCommitment the new tally commitment to be verified
+  /// @param _proof the proof generated after tallying this batch
+  function tallyVotes(uint256 _newTallyCommitment, uint256[8] calldata _proof) public onlyOwner {
+    _votingPeriodOver(poll);
+    updateSbCommitment();
+
+    // get the batch size and start index
+    (uint8 intStateTreeDepth, , , ) = poll.treeDepths();
+    uint256 tallyBatchSize = TREE_ARITY ** intStateTreeDepth;
+    uint256 batchStartIndex = tallyBatchNum * tallyBatchSize;
+
+    // save some gas because we won't overflow uint256
+    unchecked {
+      tallyBatchNum++;
+    }
+
+    (uint256 numSignUps, ) = poll.numSignUpsAndMessages();
+
+    // Require that there are untallied ballots left
+    if (batchStartIndex >= numSignUps) {
+      revert AllBallotsTallied();
+    }
+
+    bool isValid = verifyTallyProof(_proof, numSignUps, batchStartIndex, tallyBatchSize, _newTallyCommitment);
+
+    if (!isValid) {
+      revert InvalidTallyVotesProof();
+    }
+
+    // Update the tally commitment and the tally batch num
+    tallyCommitment = _newTallyCommitment;
+  }
+
+  /// @notice Verify the tally proof using the verifying key
+  /// @param _proof the proof generated after processing all messages
+  /// @param _numSignUps number of signups for a given poll
+  /// @param _batchStartIndex the number of batches multiplied by the size of the batch
+  /// @param _tallyBatchSize batch size for the tally
+  /// @param _newTallyCommitment the tally commitment to be verified at a given batch index
+  /// @return isValid whether the proof is valid
+  function verifyTallyProof(
+    uint256[8] calldata _proof,
+    uint256 _numSignUps,
+    uint256 _batchStartIndex,
+    uint256 _tallyBatchSize,
+    uint256 _newTallyCommitment
+  ) public view returns (bool isValid) {
+    (uint8 intStateTreeDepth, , , uint8 voteOptionTreeDepth) = poll.treeDepths();
+
+    (IMACI maci, , ) = poll.extContracts();
+
+    // Get the verifying key
+    VerifyingKey memory vk = vkRegistry.getTallyVk(maci.stateTreeDepth(), intStateTreeDepth, voteOptionTreeDepth);
+
+    // Get the public inputs
+    uint256 publicInputHash = genTallyVotesPublicInputHash(
+      _numSignUps,
+      _batchStartIndex,
+      _tallyBatchSize,
+      _newTallyCommitment
+    );
+
+    // Verify the proof
+    isValid = verifier.verify(_proof, vk, publicInputHash);
+  }
+
+  /// @notice Compute the merkle root from the path elements
+  /// and a leaf
+  /// @param _depth the depth of the merkle tree
+  /// @param _index the index of the leaf
+  /// @param _leaf the leaf
+  /// @param _pathElements the path elements to reconstruct the merkle root
+  /// @return current The merkle root
+  function computeMerkleRootFromPath(
+    uint8 _depth,
+    uint256 _index,
+    uint256 _leaf,
+    uint256[][] calldata _pathElements
+  ) internal pure returns (uint256 current) {
+    uint256 pos = _index % TREE_ARITY;
+    current = _leaf;
+    uint8 k;
+
+    uint256[TREE_ARITY] memory level;
+
+    for (uint8 i = 0; i < _depth; ++i) {
+      for (uint8 j = 0; j < TREE_ARITY; ++j) {
+        if (j == pos) {
+          level[j] = current;
+        } else {
+          if (j > pos) {
+            k = j - 1;
+          } else {
+            k = j;
+          }
+          level[j] = _pathElements[i][k];
+        }
+      }
+
+      _index /= TREE_ARITY;
+      pos = _index % TREE_ARITY;
+      current = hash5(level);
+    }
+  }
+
+  /// @notice Verify the number of spent voice credits from the tally.json
+  /// @param _totalSpent spent field retrieved in the totalSpentVoiceCredits object
+  /// @param _totalSpentSalt the corresponding salt in the totalSpentVoiceCredit object
+  /// @param _resultCommitment hashLeftRight(merkle root of the results.tally, results.salt) in tally.json file
+  /// @return isValid Whether the provided values are valid
+  function verifySpentVoiceCredits(
+    uint256 _totalSpent,
+    uint256 _totalSpentSalt,
+    uint256 _resultCommitment
+  ) public view returns (bool isValid) {
+    uint256[2] memory tally;
+    tally[0] = _resultCommitment;
+    tally[1] = hashLeftRight(_totalSpent, _totalSpentSalt);
+
+    isValid = hash2(tally) == tallyCommitment;
+  }
+
+  /// @notice Verify the result generated from the tally.json
+  /// @param _voteOptionIndex the index of the vote option to verify the correctness of the tally
+  /// @param _tallyResult Flattened array of the tally
+  /// @param _tallyResultProof Corresponding proof of the tally result
+  /// @param _tallyResultSalt the respective salt in the results object in the tally.json
+  /// @param _voteOptionTreeDepth depth of the vote option tree
+  /// @param _spentVoiceCreditsHash hashLeftRight(number of spent voice credits, spent salt)
+  /// @return isValid Whether the provided proof is valid
+  function verifyTallyResult(
+    uint256 _voteOptionIndex,
+    uint256 _tallyResult,
+    uint256[][] calldata _tallyResultProof,
+    uint256 _tallyResultSalt,
+    uint8 _voteOptionTreeDepth,
+    uint256 _spentVoiceCreditsHash
+  ) public view returns (bool isValid) {
+    uint256 computedRoot = computeMerkleRootFromPath(
+      _voteOptionTreeDepth,
+      _voteOptionIndex,
+      _tallyResult,
+      _tallyResultProof
+    );
+
+    uint256[2] memory tally = [hashLeftRight(computedRoot, _tallyResultSalt), _spentVoiceCreditsHash];
+
+    isValid = hash2(tally) == tallyCommitment;
+  }
+}

--- a/contracts/contracts/TallyNonQvFactory.sol
+++ b/contracts/contracts/TallyNonQvFactory.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import { TallyNonQv } from "./TallyNonQv.sol";
+import { ITallySubsidyFactory } from "./interfaces/ITallySubsidyFactory.sol";
+
+/// @title TallyNonQvFactory
+/// @notice A factory contract which deploys TallyNonQv contracts.
+contract TallyNonQvFactory is ITallySubsidyFactory {
+  /// @inheritdoc ITallySubsidyFactory
+  function deploy(
+    address _verifier,
+    address _vkRegistry,
+    address _poll,
+    address _messageProcessor,
+    address _owner
+  ) public returns (address tallyAddr) {
+    // deploy Tally for this Poll
+    TallyNonQv tally = new TallyNonQv(_verifier, _vkRegistry, _poll, _messageProcessor);
+    tally.transferOwnership(_owner);
+    tallyAddr = address(tally);
+  }
+}

--- a/contracts/deploy-config-example.json
+++ b/contracts/deploy-config-example.json
@@ -29,7 +29,8 @@
     "Poll": {
       "pollDuration": 30,
       "coordinatorPubkey": "macipk.ea638a3366ed91f2e955110888573861f7c0fc0bb5fb8b8dca9cd7a08d7d6b93",
-      "subsidyEnabled": false
+      "subsidyEnabled": false,
+      "useQuadraticVoting": true
     }
   }
 }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -37,6 +37,7 @@
     "test:poll": "pnpm run test ./tests/Poll.test.ts",
     "test:messageProcessor": "pnpm run test ./tests/MessageProcessor.test.ts",
     "test:tally": "pnpm run test ./tests/Tally.test.ts",
+    "test:tallyNonQv": "pnpm run test ./tests/TallyNonQv.test.ts",
     "test:hasher": "pnpm run test ./tests/Hasher.test.ts",
     "test:utilities": "pnpm run test ./tests/Utilities.test.ts",
     "test:signupGatekeeper": "pnpm run test ./tests/SignUpGatekeeper.test.ts",

--- a/contracts/tasks/deploy/maci/08-tallyFactory.ts
+++ b/contracts/tasks/deploy/maci/08-tallyFactory.ts
@@ -25,8 +25,10 @@ deployment
     const poseidonT5ContractAddress = storage.mustGetAddress(EContracts.PoseidonT5, hre.network.name);
     const poseidonT6ContractAddress = storage.mustGetAddress(EContracts.PoseidonT6, hre.network.name);
 
+    const useQuadraticVoting = deployment.getDeployConfigField<boolean>(EContracts.Poll, "useQuadraticVoting");
+
     const linkedTallyFactoryContract = await deployment.linkPoseidonLibraries(
-      EContracts.TallyFactory,
+      useQuadraticVoting ? EContracts.TallyFactory : EContracts.TallyNonQvFactory,
       poseidonT3ContractAddress,
       poseidonT4ContractAddress,
       poseidonT5ContractAddress,

--- a/contracts/tasks/deploy/poll/01-poll.ts
+++ b/contracts/tasks/deploy/poll/01-poll.ts
@@ -54,6 +54,8 @@ deployment.deployTask("poll:deploy-poll", "Deploy poll").setAction(async (_, hre
   const messageTreeDepth = deployment.getDeployConfigField<number>(EContracts.VkRegistry, "messageTreeDepth");
   const voteOptionTreeDepth = deployment.getDeployConfigField<number>(EContracts.VkRegistry, "voteOptionTreeDepth");
   const subsidyEnabled = deployment.getDeployConfigField<boolean | null>(EContracts.Poll, "subsidyEnabled") ?? false;
+  const useQuadraticVoting =
+    deployment.getDeployConfigField<boolean | null>(EContracts.Poll, "useQuadraticVoting") ?? false;
   const unserializedKey = PubKey.deserialize(coordinatorPubkey);
 
   const [pollContractAddress, messageProcessorContractAddress, tallyContractAddress, subsidyContractAddress] =
@@ -100,7 +102,7 @@ deployment.deployTask("poll:deploy-poll", "Deploy poll").setAction(async (_, hre
   });
 
   const tallyContract = await deployment.getContract({
-    name: EContracts.Tally,
+    name: useQuadraticVoting ? EContracts.Tally : EContracts.TallyNonQv,
     address: tallyContractAddress,
   });
 
@@ -133,7 +135,7 @@ deployment.deployTask("poll:deploy-poll", "Deploy poll").setAction(async (_, hre
     }),
 
     storage.register({
-      id: EContracts.Tally,
+      id: useQuadraticVoting ? EContracts.Tally : EContracts.TallyNonQv,
       key: `poll-${pollId}`,
       contract: tallyContract,
       args: [verifierContractAddress, vkRegistryContractAddress, pollContractAddress, messageProcessorContractAddress],

--- a/contracts/tasks/helpers/Deployment.ts
+++ b/contracts/tasks/helpers/Deployment.ts
@@ -7,13 +7,13 @@ import FileSync from "lowdb/adapters/FileSync";
 
 import { exit } from "process";
 
-import type { EContracts, IDeployParams, IDeployStep, IDeployStepCatalog, IGetContractParams } from "./types";
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import type { ConfigurableTaskDefinition, HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
 
 import { parseArtifact } from "../../ts/abi";
 
 import { ContractStorage } from "./ContractStorage";
+import { EContracts, IDeployParams, IDeployStep, IDeployStepCatalog, IGetContractParams } from "./types";
 
 /**
  * Internal deploy config structure type.

--- a/contracts/tasks/helpers/Prover.ts
+++ b/contracts/tasks/helpers/Prover.ts
@@ -10,6 +10,7 @@ import type {
   Poll,
   Subsidy,
   Tally,
+  TallyNonQv,
   Verifier,
   VkRegistry,
 } from "../../typechain-types";
@@ -57,7 +58,7 @@ export class Prover {
   /**
    * Tally contract typechain wrapper
    */
-  private tallyContract: Tally;
+  private tallyContract: Tally | TallyNonQv;
 
   /**
    * Subsidy contract typechain wrapper

--- a/contracts/tasks/helpers/types.ts
+++ b/contracts/tasks/helpers/types.ts
@@ -5,6 +5,7 @@ import type {
   Poll,
   Subsidy,
   Tally,
+  TallyNonQv,
   Verifier,
   VkRegistry,
 } from "../../typechain-types";
@@ -346,7 +347,7 @@ export interface IProverParams {
   /**
    * Tally contract typechain wrapper
    */
-  tallyContract: Tally;
+  tallyContract: Tally | TallyNonQv;
 
   /**
    * Subsidy contract typechain wrapper
@@ -505,6 +506,7 @@ export enum EContracts {
   PollFactory = "PollFactory",
   MessageProcessorFactory = "MessageProcessorFactory",
   TallyFactory = "TallyFactory",
+  TallyNonQvFactory = "TallyNonQvFactory",
   SubsidyFactory = "SubsidyFactory",
   PoseidonT3 = "PoseidonT3",
   PoseidonT4 = "PoseidonT4",
@@ -513,6 +515,7 @@ export enum EContracts {
   VkRegistry = "VkRegistry",
   Poll = "Poll",
   Tally = "Tally",
+  TallyNonQv = "TallyNonQv",
   MessageProcessor = "MessageProcessor",
   Subsidy = "Subsidy",
   AccQueue = "AccQueue",
@@ -579,4 +582,105 @@ export interface ITreeMergeParams {
    * Message AccQueue contract
    */
   messageAccQueueContract: AccQueue;
+}
+
+/**
+ * Interface for the tally file data.
+ */
+export interface TallyData {
+  /**
+   * The MACI address.
+   */
+  maci: string;
+
+  /**
+   * The ID of the poll.
+   */
+  pollId: string;
+
+  /**
+   * The name of the network for which these proofs
+   * are valid for
+   */
+  network?: string;
+
+  /**
+   * The chain ID for which these proofs are valid for
+   */
+  chainId?: string;
+
+  /**
+   * Whether the poll is using quadratic voting or not.
+   */
+  isQuadratic: boolean;
+
+  /**
+   * The address of the Tally contract.
+   */
+  tallyAddress: string;
+
+  /**
+   * The new tally commitment.
+   */
+  newTallyCommitment: string;
+
+  /**
+   * The results of the poll.
+   */
+  results: {
+    /**
+     * The tally of the results.
+     */
+    tally: string[];
+
+    /**
+     * The salt of the results.
+     */
+    salt: string;
+
+    /**
+     * The commitment of the results.
+     */
+    commitment: string;
+  };
+
+  /**
+   * The total spent voice credits.
+   */
+  totalSpentVoiceCredits: {
+    /**
+     * The spent voice credits.
+     */
+    spent: string;
+
+    /**
+     * The salt of the spent voice credits.
+     */
+    salt: string;
+
+    /**
+     * The commitment of the spent voice credits.
+     */
+    commitment: string;
+  };
+
+  /**
+   * The per VO spent voice credits.
+   */
+  perVOSpentVoiceCredits?: {
+    /**
+     * The tally of the per VO spent voice credits.
+     */
+    tally: string[];
+
+    /**
+     * The salt of the per VO spent voice credits.
+     */
+    salt: string;
+
+    /**
+     * The commitment of the per VO spent voice credits.
+     */
+    commitment: string;
+  };
 }

--- a/contracts/tasks/runner/deployFull.ts
+++ b/contracts/tasks/runner/deployFull.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-console */
 import { task, types } from "hardhat/config";
 
-import type { IDeployParams } from "../helpers/types";
-
 import { Deployment } from "../helpers/Deployment";
+import { type IDeployParams } from "../helpers/types";
 
 /**
  * Main deployment task which runs deploy steps in the same order that `Deployment#deployTask` is called.

--- a/contracts/tasks/runner/deployPoll.ts
+++ b/contracts/tasks/runner/deployPoll.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-console */
 import { task, types } from "hardhat/config";
 
-import type { IDeployParams } from "../helpers/types";
-
 import { Deployment } from "../helpers/Deployment";
+import { type IDeployParams } from "../helpers/types";
 
 /**
  * Poll deployment task which runs deploy steps in the same order that `Deployment#deployTask` is called.

--- a/contracts/tasks/runner/prove.ts
+++ b/contracts/tasks/runner/prove.ts
@@ -16,6 +16,7 @@ import {
   type AccQueue,
   MessageProcessor,
   Tally,
+  TallyNonQv,
 } from "../../typechain-types";
 import { ContractStorage } from "../helpers/ContractStorage";
 import { Deployment } from "../helpers/Deployment";
@@ -150,10 +151,17 @@ task("prove", "Command to generate proof and prove the result of a poll on-chain
         name: EContracts.MessageProcessor,
         key: `poll-${poll.toString()}`,
       });
-      const tallyContract = await deployment.getContract<Tally>({
-        name: EContracts.Tally,
-        key: `poll-${poll.toString()}`,
-      });
+
+      // get the tally contract based on the useQuadraticVoting flag
+      const tallyContract = useQuadraticVoting
+        ? await deployment.getContract<Tally>({
+            name: EContracts.Tally,
+            key: `poll-${poll.toString()}`,
+          })
+        : await deployment.getContract<TallyNonQv>({
+            name: EContracts.TallyNonQv,
+            key: `poll-${poll.toString()}`,
+          });
       const tallyContractAddress = await tallyContract.getAddress();
 
       let subsidyContract: Subsidy | undefined;

--- a/contracts/tests/EASGatekeeper.test.ts
+++ b/contracts/tests/EASGatekeeper.test.ts
@@ -87,7 +87,14 @@ describe("EAS Gatekeeper", () => {
     let maciContract: MACI;
 
     before(async () => {
-      const r = await deployTestContracts(initialVoiceCreditBalance, STATE_TREE_DEPTH, signer, true, easGatekeeper);
+      const r = await deployTestContracts(
+        initialVoiceCreditBalance,
+        STATE_TREE_DEPTH,
+        signer,
+        true,
+        true,
+        easGatekeeper,
+      );
 
       maciContract = r.maciContract;
     });

--- a/contracts/tests/SignUpGatekeeper.test.ts
+++ b/contracts/tests/SignUpGatekeeper.test.ts
@@ -46,6 +46,7 @@ describe("SignUpGatekeeper", () => {
         STATE_TREE_DEPTH,
         signer,
         true,
+        true,
         signUpTokenGatekeeperContract,
       );
 

--- a/contracts/tests/Tally.test.ts
+++ b/contracts/tests/Tally.test.ts
@@ -59,7 +59,7 @@ describe("TallyVotes", () => {
 
     signer = await getDefaultSigner();
 
-    const r = await deployTestContracts(100, STATE_TREE_DEPTH, signer, true);
+    const r = await deployTestContracts(100, STATE_TREE_DEPTH, signer, true, true);
     maciContract = r.maciContract;
     verifierContract = r.mockVerifierContract as Verifier;
     vkRegistryContract = r.vkRegistryContract;
@@ -221,7 +221,7 @@ describe("TallyVotes", () => {
 
       const intStateTreeDepth = 2;
 
-      const r = await deployTestContracts(100, STATE_TREE_DEPTH, signer, true);
+      const r = await deployTestContracts(100, STATE_TREE_DEPTH, signer, true, true);
       maciContract = r.maciContract;
       verifierContract = r.mockVerifierContract as Verifier;
       vkRegistryContract = r.vkRegistryContract;
@@ -362,7 +362,7 @@ describe("TallyVotes", () => {
 
       const intStateTreeDepth = 2;
 
-      const r = await deployTestContracts(100, STATE_TREE_DEPTH, signer, true);
+      const r = await deployTestContracts(100, STATE_TREE_DEPTH, signer, true, true);
       maciContract = r.maciContract;
       verifierContract = r.mockVerifierContract as Verifier;
       vkRegistryContract = r.vkRegistryContract;

--- a/contracts/tests/TallyNonQv.test.ts
+++ b/contracts/tests/TallyNonQv.test.ts
@@ -1,0 +1,213 @@
+/* eslint-disable no-underscore-dangle */
+import { expect } from "chai";
+import { BaseContract, Signer } from "ethers";
+import { EthereumProvider } from "hardhat/types";
+import {
+  MaciState,
+  Poll,
+  packTallyVotesSmallVals,
+  IProcessMessagesCircuitInputs,
+  ITallyCircuitInputs,
+} from "maci-core";
+import { NOTHING_UP_MY_SLEEVE } from "maci-crypto";
+import { Keypair, Message, PubKey } from "maci-domainobjs";
+
+import type { Tally, MACI, Poll as PollContract, MessageProcessor, Verifier, VkRegistry } from "../typechain-types";
+
+import { parseArtifact } from "../ts/abi";
+import { IVerifyingKeyStruct } from "../ts/types";
+import { getDefaultSigner } from "../ts/utils";
+
+import {
+  STATE_TREE_DEPTH,
+  duration,
+  maxValues,
+  messageBatchSize,
+  tallyBatchSize,
+  testProcessVk,
+  testTallyVk,
+  treeDepths,
+} from "./constants";
+import { timeTravel, deployTestContracts } from "./utils";
+
+describe("TallyVotesNonQv", () => {
+  let signer: Signer;
+  let maciContract: MACI;
+  let pollContract: PollContract;
+  let tallyContract: Tally;
+  let mpContract: MessageProcessor;
+  let verifierContract: Verifier;
+  let vkRegistryContract: VkRegistry;
+
+  const coordinator = new Keypair();
+  let users: Keypair[];
+  let maciState: MaciState;
+
+  const [pollAbi] = parseArtifact("Poll");
+  const [mpAbi] = parseArtifact("MessageProcessor");
+  const [tallyAbi] = parseArtifact("TallyNonQv");
+
+  let pollId: bigint;
+  let poll: Poll;
+
+  let generatedInputs: IProcessMessagesCircuitInputs;
+
+  before(async () => {
+    maciState = new MaciState(STATE_TREE_DEPTH);
+
+    users = [new Keypair(), new Keypair()];
+
+    signer = await getDefaultSigner();
+
+    const r = await deployTestContracts(100, STATE_TREE_DEPTH, signer, false, true);
+    maciContract = r.maciContract;
+    verifierContract = r.mockVerifierContract as Verifier;
+    vkRegistryContract = r.vkRegistryContract;
+
+    // deploy a poll
+    // deploy on chain poll
+    const tx = await maciContract.deployPoll(
+      duration,
+      treeDepths,
+      coordinator.pubKey.asContractParam(),
+      verifierContract,
+      vkRegistryContract,
+      false,
+      {
+        gasLimit: 10000000,
+      },
+    );
+    const receipt = await tx.wait();
+
+    const block = await signer.provider!.getBlock(receipt!.blockHash);
+    const deployTime = block!.timestamp;
+
+    expect(receipt?.status).to.eq(1);
+    const iface = maciContract.interface;
+    const logs = receipt!.logs[receipt!.logs.length - 1];
+    const event = iface.parseLog(logs as unknown as { topics: string[]; data: string }) as unknown as {
+      args: {
+        _pollId: bigint;
+        pollAddr: {
+          poll: string;
+          messageProcessor: string;
+          tally: string;
+        };
+      };
+      name: string;
+    };
+    expect(event.name).to.eq("DeployPoll");
+
+    pollId = event.args._pollId;
+
+    const pollContractAddress = await maciContract.getPoll(pollId);
+    pollContract = new BaseContract(pollContractAddress, pollAbi, signer) as PollContract;
+    mpContract = new BaseContract(event.args.pollAddr.messageProcessor, mpAbi, signer) as MessageProcessor;
+    tallyContract = new BaseContract(event.args.pollAddr.tally, tallyAbi, signer) as Tally;
+
+    // deploy local poll
+    const p = maciState.deployPoll(BigInt(deployTime + duration), maxValues, treeDepths, messageBatchSize, coordinator);
+    expect(p.toString()).to.eq(pollId.toString());
+    // publish the NOTHING_UP_MY_SLEEVE message
+    const messageData = [NOTHING_UP_MY_SLEEVE];
+    for (let i = 1; i < 10; i += 1) {
+      messageData.push(BigInt(0));
+    }
+    const message = new Message(BigInt(1), messageData);
+    const padKey = new PubKey([
+      BigInt("10457101036533406547632367118273992217979173478358440826365724437999023779287"),
+      BigInt("19824078218392094440610104313265183977899662750282163392862422243483260492317"),
+    ]);
+
+    // save the poll
+    poll = maciState.polls.get(pollId)!;
+
+    poll.publishMessage(message, padKey);
+
+    // update the poll state
+    poll.updatePoll(BigInt(maciState.stateLeaves.length));
+
+    // process messages locally
+    generatedInputs = poll.processMessages(pollId, false);
+
+    // set the verification keys on the vk smart contract
+    await vkRegistryContract.setVerifyingKeys(
+      STATE_TREE_DEPTH,
+      treeDepths.intStateTreeDepth,
+      treeDepths.messageTreeDepth,
+      treeDepths.voteOptionTreeDepth,
+      messageBatchSize,
+      testProcessVk.asContractParam() as IVerifyingKeyStruct,
+      testTallyVk.asContractParam() as IVerifyingKeyStruct,
+      { gasLimit: 1000000 },
+    );
+  });
+
+  it("should not be possible to tally votes before the poll has ended", async () => {
+    await expect(tallyContract.tallyVotes(0, [0, 0, 0, 0, 0, 0, 0, 0])).to.be.revertedWithCustomError(
+      tallyContract,
+      "VotingPeriodNotPassed",
+    );
+  });
+
+  it("genTallyVotesPackedVals() should generate the correct value", async () => {
+    const onChainPackedVals = BigInt(await tallyContract.genTallyVotesPackedVals(users.length, 0, tallyBatchSize));
+    const packedVals = packTallyVotesSmallVals(0, tallyBatchSize, users.length);
+    expect(onChainPackedVals.toString()).to.eq(packedVals.toString());
+  });
+
+  it("updateSbCommitment() should revert when the messages have not been processed yet", async () => {
+    // go forward in time
+    await timeTravel(signer.provider! as unknown as EthereumProvider, duration + 1);
+
+    await expect(tallyContract.updateSbCommitment()).to.be.revertedWithCustomError(
+      tallyContract,
+      "ProcessingNotComplete",
+    );
+  });
+
+  it("tallyVotes() should fail as the messages have not been processed yet", async () => {
+    await expect(tallyContract.tallyVotes(0, [0, 0, 0, 0, 0, 0, 0, 0])).to.be.revertedWithCustomError(
+      tallyContract,
+      "ProcessingNotComplete",
+    );
+  });
+
+  describe("after merging acc queues", () => {
+    let tallyGeneratedInputs: ITallyCircuitInputs;
+    before(async () => {
+      await pollContract.mergeMaciStateAqSubRoots(0, pollId);
+      await pollContract.mergeMaciStateAq(0);
+
+      await pollContract.mergeMessageAqSubRoots(0);
+      await pollContract.mergeMessageAq();
+      tallyGeneratedInputs = poll.tallyVotes();
+    });
+
+    it("isTallied should return false", async () => {
+      const isTallied = await tallyContract.isTallied();
+      expect(isTallied).to.eq(false);
+    });
+
+    it("tallyVotes() should update the tally commitment", async () => {
+      // do the processing on the message processor contract
+      await mpContract.processMessages(generatedInputs.newSbCommitment, [0, 0, 0, 0, 0, 0, 0, 0]);
+
+      await tallyContract.tallyVotes(tallyGeneratedInputs.newTallyCommitment, [0, 0, 0, 0, 0, 0, 0, 0]);
+
+      const onChainNewTallyCommitment = await tallyContract.tallyCommitment();
+      expect(tallyGeneratedInputs.newTallyCommitment).to.eq(onChainNewTallyCommitment.toString());
+    });
+
+    it("isTallied should return true", async () => {
+      const isTallied = await tallyContract.isTallied();
+      expect(isTallied).to.eq(true);
+    });
+
+    it("tallyVotes() should revert when votes have already been tallied", async () => {
+      await expect(
+        tallyContract.tallyVotes(tallyGeneratedInputs.newTallyCommitment, [0, 0, 0, 0, 0, 0, 0, 0]),
+      ).to.be.revertedWithCustomError(tallyContract, "AllBallotsTallied");
+    });
+  });
+});

--- a/contracts/tests/utils.ts
+++ b/contracts/tests/utils.ts
@@ -488,7 +488,8 @@ export const deployTestContracts = async (
   initialVoiceCreditBalance: number,
   stateTreeDepth: number,
   signer?: Signer,
-  quiet = false,
+  useQv = true,
+  quiet = true,
   gatekeeper: FreeForAllGatekeeper | undefined = undefined,
 ): Promise<IDeployedTestContracts> => {
   const mockVerifierContract = await deployMockVerifier(signer, true);
@@ -520,6 +521,7 @@ export const deployTestContracts = async (
     topupCreditContractAddress,
     signer,
     stateTreeDepth,
+    useQv,
     quiet,
   });
 

--- a/contracts/ts/types.ts
+++ b/contracts/ts/types.ts
@@ -162,6 +162,11 @@ export interface IDeployMaciArgs {
    * Whether to suppress console output
    */
   quiet?: boolean;
+
+  /**
+   * Whether to support QV or not
+   */
+  useQv?: boolean;
 }
 
 /**

--- a/core/ts/__tests__/Poll.test.ts
+++ b/core/ts/__tests__/Poll.test.ts
@@ -527,17 +527,13 @@ describe("Poll", function test() {
       secondPoll.publishMessage(secondMessage, secondEcdhKeypair.pubKey);
 
       secondPoll.processAllMessages();
-      secondPoll.tallyVotes(false);
+      secondPoll.tallyVotesNonQv();
 
       const spentVoiceCredits = secondPoll.totalSpentVoiceCredits;
       const results = secondPoll.tallyResult;
       // spent voice credit is not vote weight * vote weight
       expect(spentVoiceCredits).to.eq(secondVoteWeight);
       expect(results[Number.parseInt(secondVoteOption.toString(), 10)]).to.eq(secondVoteWeight);
-      // per VO spent voice credit is not vote weight * vote weight
-      expect(secondPoll.perVOSpentVoiceCredits[Number.parseInt(secondVoteOption.toString(), 10)]).to.eq(
-        secondVoteWeight,
-      );
     });
 
     it("should throw when there are no more ballots to tally", () => {

--- a/core/ts/__tests__/e2e.test.ts
+++ b/core/ts/__tests__/e2e.test.ts
@@ -674,13 +674,10 @@ describe("MaciState/Poll e2e", function test() {
 
       expect(poll.hasUntalliedBallots()).to.eq(true);
 
-      poll.tallyVotes(useQv);
+      poll.tallyVotesNonQv();
 
       const finalTotal = calculateTotal(poll.tallyResult);
       expect(finalTotal.toString()).to.eq(voteWeight.toString());
-
-      // check that the perVOSpentVoiceCredits is correct
-      expect(poll.perVOSpentVoiceCredits[0].toString()).to.eq(voteWeight.toString());
 
       // check that the totalSpentVoiceCredits is correct
       expect(poll.totalSpentVoiceCredits.toString()).to.eq(voteWeight.toString());

--- a/core/ts/utils/types.ts
+++ b/core/ts/utils/types.ts
@@ -193,10 +193,10 @@ export interface ITallyCircuitInputs {
   currentResultsRootSalt: string;
   currentSpentVoiceCreditSubtotal: string;
   currentSpentVoiceCreditSubtotalSalt: string;
-  currentPerVOSpentVoiceCredits: string[];
-  currentPerVOSpentVoiceCreditsRootSalt: string;
+  currentPerVOSpentVoiceCredits?: string[];
+  currentPerVOSpentVoiceCreditsRootSalt?: string;
   newResultsRootSalt: string;
-  newPerVOSpentVoiceCreditsRootSalt: string;
+  newPerVOSpentVoiceCreditsRootSalt?: string;
   newSpentVoiceCreditSubtotalSalt: string;
 }
 

--- a/integrationTests/ts/__tests__/utils/utils.ts
+++ b/integrationTests/ts/__tests__/utils/utils.ts
@@ -136,7 +136,7 @@ export const expectTally = (
   });
 
   expect(tallyFile.results.tally).to.deep.equal(genTally);
-  expect(tallyFile.perVOSpentVoiceCredits.tally).to.deep.equal(genPerVOSpentVoiceCredits);
+  expect(tallyFile.perVOSpentVoiceCredits?.tally).to.deep.equal(genPerVOSpentVoiceCredits);
   expect(tallyFile.totalSpentVoiceCredits.spent).to.eq(expectedTotalSpentVoiceCredits.toString());
 };
 


### PR DESCRIPTION
# Description

Reduce the number of constraints for the `tallyVotesNonQv` circuit, and amend the repo code to support the changes. This includes a new Tally contract with reduced logic (no need for perVOSpentVoiceCredits anymore due to quadratic voting being removed).  

Relevant code to deploy either factory version of tally has been added, and as far as MACI is concerned, they implement the same interface so no changes were needed on the MACI contract.

With ceremony params (6,2,3) - from 398474 to 371675 constraints

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
