### PR TITLE
refactor(crypto): modify genPrivKey to generate a random seed

### DIFF
--- a/crypto/ts/__tests__/Crypto.test.ts
+++ b/crypto/ts/__tests__/Crypto.test.ts
@@ -481,10 +481,6 @@ describe("Crypto", function test() {
       });
     });
     describe("genPrivKey", () => {
-      it("should generate a private key that is < SNARK_FIELD_SIZE", () => {
-        const sk = genPrivKey();
-        expect(sk < SNARK_FIELD_SIZE).to.eq(true);
-      });
       it("should generate a random private key", () => {
         const sk1 = genPrivKey();
         const sk2 = genPrivKey();
@@ -538,19 +534,12 @@ describe("Crypto", function test() {
         expect(pk[0] < SNARK_FIELD_SIZE).to.eq(true);
         expect(pk[1] < SNARK_FIELD_SIZE).to.eq(true);
       });
-      it("should throw when given a private key which is >= SNARK_FIELD_SIZE", () => {
-        expect(() => genPubKey(SNARK_FIELD_SIZE)).to.throw();
-      });
     });
     describe("genKeypair", () => {
       it("should produce a public key which is < SNARK_FIELD_SIZE", () => {
         const { pubKey } = genKeypair();
         expect(pubKey[0] < SNARK_FIELD_SIZE).to.eq(true);
         expect(pubKey[1] < SNARK_FIELD_SIZE).to.eq(true);
-      });
-      it("should produce a private key which is < SNARK_FIELD_SIZE", () => {
-        const { privKey } = genKeypair();
-        expect(BigInt(privKey) < SNARK_FIELD_SIZE).to.eq(true);
       });
     });
     describe("genEcdhSharedKey", () => {

--- a/crypto/ts/keys.ts
+++ b/crypto/ts/keys.ts
@@ -1,17 +1,16 @@
 import { mulPointEscalar } from "@zk-kit/baby-jubjub";
 import { derivePublicKey, deriveSecretScalar, packPublicKey, unpackPublicKey } from "@zk-kit/eddsa-poseidon";
 
-import assert from "assert";
+import { randomBytes } from "crypto";
 
 import { genRandomBabyJubValue } from "./babyjub";
-import { SNARK_FIELD_SIZE } from "./constants";
 import { EcdhSharedKey, Keypair, Point, PrivKey, PubKey } from "./types";
 
 /**
  * Generate a private key
- * @returns A BabyJub-compatible private key.
+ * @returns A random seed for a private key.
  */
-export const genPrivKey = (): bigint => genRandomBabyJubValue();
+export const genPrivKey = (): bigint => BigInt(`0x${randomBytes(32).toString("hex")}`);
 
 /**
  * Generate a random value
@@ -50,9 +49,6 @@ export const unpackPubKey = (packed: bigint): PubKey => {
  * @returns A public key associated with the private key
  */
 export const genPubKey = (privKey: PrivKey): PubKey => {
-  // Check whether privKey is a field element
-  assert(BigInt(privKey) < SNARK_FIELD_SIZE);
-
   const key = derivePublicKey(privKey);
   return [BigInt(key[0]), BigInt(key[1])];
 };

--- a/domainobjs/ts/__tests__/privateKey.test.ts
+++ b/domainobjs/ts/__tests__/privateKey.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { SNARK_FIELD_SIZE, genRandomBabyJubValue } from "maci-crypto";
+import { SNARK_FIELD_SIZE, genPrivKey } from "maci-crypto";
 
 import { Keypair, PrivKey } from "..";
 
@@ -8,12 +8,12 @@ describe("privateKey", function test() {
 
   describe("constructor", () => {
     it("should create a private key", () => {
-      const priv = genRandomBabyJubValue();
+      const priv = genPrivKey();
       const k = new PrivKey(priv);
       expect(k).to.not.eq(null);
     });
     it("should create the same private key object for the same raw key", () => {
-      const priv = genRandomBabyJubValue();
+      const priv = genPrivKey();
       const k1 = new PrivKey(priv);
       const k2 = new PrivKey(priv);
       expect(k1.rawPrivKey.toString()).to.eq(k2.rawPrivKey.toString());
@@ -23,7 +23,7 @@ describe("privateKey", function test() {
   describe("serialization", () => {
     describe("serialize", () => {
       it("should serialize the private key", () => {
-        const priv = genRandomBabyJubValue();
+        const priv = genPrivKey();
         const k = new PrivKey(priv);
         const s = k.serialize();
         expect(s.startsWith("macisk.")).to.eq(true);
@@ -42,7 +42,7 @@ describe("privateKey", function test() {
 
     describe("deserialize", () => {
       it("should deserialize the private key", () => {
-        const priv = genRandomBabyJubValue();
+        const priv = genPrivKey();
         const k = new PrivKey(priv);
         const s = k.serialize();
         const k2 = PrivKey.deserialize(s);
@@ -52,7 +52,7 @@ describe("privateKey", function test() {
 
     describe("isValidSerializedPrivKey", () => {
       it("should return true for a valid serialized private key", () => {
-        const priv = genRandomBabyJubValue();
+        const priv = genPrivKey();
         const k = new PrivKey(priv);
         const s = k.serialize();
         expect(PrivKey.isValidSerializedPrivKey(s)).to.eq(true);
@@ -65,19 +65,19 @@ describe("privateKey", function test() {
 
     describe("toJSON", () => {
       it("should produce a JSON object", () => {
-        const priv = genRandomBabyJubValue();
+        const priv = genPrivKey();
         const k = new PrivKey(priv);
         const json = k.toJSON();
         expect(json).to.not.eq(null);
       });
       it("should produce a JSON object with the correct keys", () => {
-        const priv = genRandomBabyJubValue();
+        const priv = genPrivKey();
         const k = new PrivKey(priv);
         const json = k.toJSON();
         expect(Object.keys(json)).to.deep.eq(["privKey"]);
       });
       it("should preserve the data correctly", () => {
-        const priv = genRandomBabyJubValue();
+        const priv = genPrivKey();
         const k = new PrivKey(priv);
         const json = k.toJSON();
         expect(k.serialize()).to.eq(json.privKey);
@@ -86,7 +86,7 @@ describe("privateKey", function test() {
 
     describe("fromJSON", () => {
       it("should produce a PrivKey instance", () => {
-        const priv = genRandomBabyJubValue();
+        const priv = genPrivKey();
         const k = new PrivKey(priv);
         const json = k.toJSON();
         const k2 = PrivKey.fromJSON(json);

--- a/domainobjs/ts/privateKey.ts
+++ b/domainobjs/ts/privateKey.ts
@@ -1,4 +1,4 @@
-import { SNARK_FIELD_SIZE, formatPrivKeyForBabyJub, type PrivKey as RawPrivKey } from "maci-crypto";
+import { formatPrivKeyForBabyJub, type PrivKey as RawPrivKey } from "maci-crypto";
 
 import type { IJsonPrivateKey } from "./types";
 
@@ -66,12 +66,7 @@ export class PrivKey {
     const correctPrefix = s.startsWith(SERIALIZED_PRIV_KEY_PREFIX);
     const x = s.slice(SERIALIZED_PRIV_KEY_PREFIX.length);
 
-    try {
-      const value = BigInt(`0x${x}`);
-      return correctPrefix && value < SNARK_FIELD_SIZE;
-    } catch {
-      return false;
-    }
+    return correctPrefix && x.length === 64;
   };
 
   /**

--- a/domainobjs/ts/publicKey.ts
+++ b/domainobjs/ts/publicKey.ts
@@ -5,6 +5,7 @@ import assert from "assert";
 import type { IJsonPublicKey, IG1ContractParams } from "./types";
 
 export const SERIALIZED_PUB_KEY_PREFIX = "macipk.";
+
 /**
  * @notice A class representing a public key
  * This is a MACI public key, which is not to be


### PR DESCRIPTION
# Description

genPrivKey could generate a random seed vs a babyjubjub compatible value, to remove any unnecessary operations. As mentioned in the related issue, the seed is formatted correctly in the code before being used.

## Related issue(s)

fix #407 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
