### PR TITLE
refactor(contracts): add virtual to functions which could be overridden

### DIFF
--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -155,7 +155,7 @@ contract MACI is IMACI, Params, Utilities, Ownable {
     PubKey memory _pubKey,
     bytes memory _signUpGatekeeperData,
     bytes memory _initialVoiceCreditProxyData
-  ) public {
+  ) public virtual {
     // ensure we do not have more signups than what the circuits support
     if (numSignUps == uint256(TREE_ARITY) ** uint256(stateTreeDepth)) revert TooManySignups();
 
@@ -200,7 +200,7 @@ contract MACI is IMACI, Params, Utilities, Ownable {
     address _verifier,
     address _vkRegistry,
     bool useSubsidy
-  ) public onlyOwner returns (PollContracts memory pollAddr) {
+  ) public virtual onlyOwner returns (PollContracts memory pollAddr) {
     // cache the poll to a local variable so we can increment it
     uint256 pollId = nextPollId;
 
@@ -240,17 +240,17 @@ contract MACI is IMACI, Params, Utilities, Ownable {
   }
 
   /// @inheritdoc IMACI
-  function mergeStateAqSubRoots(uint256 _numSrQueueOps, uint256 _pollId) public override onlyPoll(_pollId) {
+  function mergeStateAqSubRoots(uint256 _numSrQueueOps, uint256 _pollId) public onlyPoll(_pollId) {
     stateAq.mergeSubRoots(_numSrQueueOps);
   }
 
   /// @inheritdoc IMACI
-  function mergeStateAq(uint256 _pollId) public override onlyPoll(_pollId) returns (uint256 root) {
+  function mergeStateAq(uint256 _pollId) public onlyPoll(_pollId) returns (uint256 root) {
     root = stateAq.merge(stateTreeDepth);
   }
 
   /// @inheritdoc IMACI
-  function getStateAqRoot() public view override returns (uint256 root) {
+  function getStateAqRoot() public view returns (uint256 root) {
     root = stateAq.getMainRoot(stateTreeDepth);
   }
 

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -142,7 +142,7 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
   }
 
   /// @inheritdoc IPoll
-  function topup(uint256 stateIndex, uint256 amount) public isWithinVotingDeadline {
+  function topup(uint256 stateIndex, uint256 amount) public virtual isWithinVotingDeadline {
     // we check that we do not exceed the max number of messages
     if (numMessages == maxValues.maxMessages) revert TooManyMessages();
 
@@ -163,7 +163,7 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
   }
 
   /// @inheritdoc IPoll
-  function publishMessage(Message calldata _message, PubKey calldata _encPubKey) public isWithinVotingDeadline {
+  function publishMessage(Message calldata _message, PubKey calldata _encPubKey) public virtual isWithinVotingDeadline {
     // we check that we do not exceed the max number of messages
     if (numMessages == maxValues.maxMessages) revert TooManyMessages();
 


### PR DESCRIPTION
# Description

Add the virtual keyword to certain contract functions which could be overridden by projects integrating MACI.

Examples:

* a project like clr.fund might override MACI.signup to accept first a contribution from a user to the QF round
* further checks could be added if wanting to gatekeep message publishing 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
