### PR TITLE
fix(tests): remove wrong chai matcher from integrationTests

### DIFF
--- a/integrationTests/ts/__tests__/integration.test.ts
+++ b/integrationTests/ts/__tests__/integration.test.ts
@@ -347,7 +347,7 @@ describe("Integration tests", function test() {
           subsidyAddress: pollContracts.subsidy,
           signer,
         }),
-      ).to.eventually.not.rejectedWith();
+      ).to.not.be.rejected;
 
       // verify the proofs
       await expect(
@@ -365,7 +365,7 @@ describe("Integration tests", function test() {
             : undefined,
           signer,
         }),
-      ).to.eventually.not.rejectedWith();
+      ).to.not.be.rejected;
     });
   });
 });


### PR DESCRIPTION
# Description

Remove wrong except matcher which causes invalid tests to pass.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
