### PR TITLE
fix(circuits): ensure we account for correct num signups in messageValidator

### DIFF
--- a/circuits/circom/messageValidator.circom
+++ b/circuits/circom/messageValidator.circom
@@ -11,12 +11,11 @@ template MessageValidator() {
     signal input stateTreeIndex;
     // how many signups we have in the state tree
     signal input numSignUps;
-    // we check that the state tree index is <= than the number of signups
+    // we check that the state tree index is < than the number of signups
     // as first validation
-    // it is <= because the state tree index is 1-based
+    // it is < because the state tree index is 0-based
     // 0 is for blank state leaf then 1 for the first actual user
-    // which is where the numSignUps starts
-    component validStateLeafIndex = SafeLessEqThan(252);
+    component validStateLeafIndex = SafeLessThan(252);
     validStateLeafIndex.in[0] <== stateTreeIndex;
     validStateLeafIndex.in[1] <== numSignUps;
 

--- a/circuits/circom/messageValidatorNonQv.circom
+++ b/circuits/circom/messageValidatorNonQv.circom
@@ -12,12 +12,11 @@ template MessageValidatorNonQv() {
     signal input stateTreeIndex;
     // how many signups we have in the state tree
     signal input numSignUps;
-    // we check that the state tree index is <= than the number of signups
+    // we check that the state tree index is < than the number of signups
     // as first validation
-    // it is <= because the state tree index is 1-based
+    // it is < because the state tree index is 0-based
     // 0 is for blank state leaf then 1 for the first actual user
-    // which is where the numSignUps starts
-    component validStateLeafIndex = SafeLessEqThan(252);
+    component validStateLeafIndex = SafeLessThan(252);
     validStateLeafIndex.in[0] <== stateTreeIndex;
     validStateLeafIndex.in[1] <== numSignUps;
 


### PR DESCRIPTION
#  Description

Ensure state index checks in `messageValidator` are 0 based

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
