### PR TITLE
fix(contracts): prevent user DoS the stateAq tree merging

### DIFF
--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -214,6 +214,7 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
     // deadline
     if (stateAqMerged) revert StateAqAlreadyMerged();
 
+    // set merged to true so it cannot be called again
     stateAqMerged = true;
 
     // the subtrees must have been merged first


### PR DESCRIPTION
# Description

prevent user DoS the stateAq tree merging. Currently a user could signup (gatekeeper allowing) after the subtrees have been merged, and prevent a coordinator from calling `mergeStateAq` without having to call `mergeStateAqSubRoots` again. 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
