### PR TITLE
refactor(contracts): add public to Tally.isTallied

### DIFF
--- a/contracts/contracts/Tally.sol
+++ b/contracts/contracts/Tally.sol
@@ -80,7 +80,7 @@ contract Tally is Ownable, SnarkCommon, CommonUtilities, Hasher {
 
   /// @notice Check if all ballots are tallied
   /// @return tallied whether all ballots are tallied
-  function isTallied() external view returns (bool tallied) {
+  function isTallied() public view returns (bool tallied) {
     (uint8 intStateTreeDepth, , , ) = poll.treeDepths();
     (uint256 numSignUps, ) = poll.numSignUpsAndMessages();
 


### PR DESCRIPTION
# Description

Set public to Tally.isTallied() so it can be called from inheriting contracts too 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
