### PR TITLE
fix(cli): run all the tests for package

### DIFF
--- a/cli/tests/e2e/e2e.test.ts
+++ b/cli/tests/e2e/e2e.test.ts
@@ -620,7 +620,7 @@ describe("e2e tests", function test() {
       maciAddresses = await deploy({ ...deployArgs, signer });
     });
 
-    it.only("should run the first poll", async () => {
+    it("should run the first poll", async () => {
       // deploy a poll contract
       pollAddresses = await deployPoll({ ...deployPollArgs, signer });
 


### PR DESCRIPTION
# Description

Remove `.only` for cli tests

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
