### PR TITLE
fix(ci): fix tag publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
 
       - name: Publish NPM
         run: |
+          # Prevent `git commit error`
+          # It will not be pushed to GitHub as it is ephemeral
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+
           # Depending on the STATE_TREE_DEPTH param, there 
           # might be changes in the EmptyBallotRoots.sol file
           git add contracts/contracts/trees/EmptyBallotRoots.sol


### PR DESCRIPTION
# Description

Fix issue with tag publishing not working due to missing git config directive.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
