### PR TITLE
fix(cli): read state index from event args

### DIFF
--- a/cli/ts/commands/signup.ts
+++ b/cli/ts/commands/signup.ts
@@ -103,7 +103,7 @@ export const isRegisteredUser = async ({
   const publicKey = PubKey.deserialize(maciPubKey).asContractParam();
 
   const events = await maciContract.queryFilter(maciContract.filters.SignUp(undefined, publicKey.x, publicKey.y));
-  const stateIndex = events[0]?.args.toString() as string | undefined;
+  const stateIndex = events[0]?.args[0].toString() as string | undefined;
 
   logGreen(quiet, success(`State index: ${stateIndex?.toString()}, registered: ${stateIndex !== undefined}`));
 


### PR DESCRIPTION
# Description

Get state index from event args array

## Additional Notes

N/A

## Related issue(s)

Related to https://github.com/privacy-scaling-explorations/maci-rpgf/issues/7

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
