### PR TITLE
fix: fix unable to publish package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,7 @@ jobs:
           pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build
-        run: |
-          pnpm run build
+        run: pnpm run build
 
       - name: Publish NPM
         run: |
@@ -52,11 +51,11 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
 
-          # Depending on the STATE_TREE_DEPTH param, there 
+          # Depending on the STATE_TREE_DEPTH param, there
           # might be changes in the EmptyBallotRoots.sol file
           git add contracts/contracts/trees/EmptyBallotRoots.sol
           git diff --staged --quiet || git commit -m "Commit changes before publishing"
 
-          pnpm exec lerna publish from-git --yes
+          pnpm exec lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description
[Recent attempt](https://github.com/privacy-scaling-explorations/maci/actions/runs/8064499516/job/22028505253) to publish packages to npm failed and the root of the problem was our use of `lerna publish from-git`, which is designed to publish packages tagged in the current commit. However, our CI process includes an additional commit after tagging (see [here](https://github.com/privacy-scaling-explorations/maci/blob/d3952dd886c8e6692a36f6e83d85a751b19281b1/.github/workflows/release.yml#L55-L58)), meaning the current commit wasn't tagged at the time of publishing. This discrepancy led to Lerna's inability to publish using the `from-git` method.

To address the issue, this PR updates lerna to switch from `from-git` to [`from-package`](https://github.com/lerna/lerna/blob/main/libs/commands/publish/README.md#bump-from-package) method

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
