### PR TITLE
fix(cli): generate ecdh shared key only one time

### DIFF
--- a/cli/ts/commands/publish.ts
+++ b/cli/ts/commands/publish.ts
@@ -204,6 +204,7 @@ export const publishBatch = async ({
   ]);
 
   const encryptionKeypair = new Keypair();
+  const sharedKey = Keypair.genEcdhSharedKey(encryptionKeypair.privKey, coordinatorPubKey);
 
   const payload: [IMessageContractParams, IG1ContractParams][] = messages.map(
     ({ salt, stateIndex, voteOptionIndex, newVoteWeight, nonce }) => {
@@ -223,7 +224,6 @@ export const publishBatch = async ({
       // sign the command with the user private key
       const signature = command.sign(userMaciPrivKey);
 
-      const sharedKey = Keypair.genEcdhSharedKey(encryptionKeypair.privKey, coordinatorPubKey);
       const message = command.encrypt(signature, sharedKey);
 
       return [message.asContractParam(), encryptionKeypair.pubKey.asContractParam()];


### PR DESCRIPTION
# Description

Generate ECDH shared key for batch message publish only one time.

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
