### PR TITLE
feat(cli): return additional data from publish batch command

### DIFF
--- a/cli/tests/unit/publish.test.ts
+++ b/cli/tests/unit/publish.test.ts
@@ -75,13 +75,15 @@ describe("publish", () => {
       const pollContract = PollFactory.connect(pollAddresses.poll, signer);
       const initialNumMessages = await pollContract.numMessages();
 
-      const { hash } = await publishBatch(defaultArgs);
+      const { hash, encryptedMessages, privateKey } = await publishBatch(defaultArgs);
       const numMessages = await pollContract.numMessages();
 
       expect(initialNumMessages).to.eq(1n);
       expect(hash).to.not.eq(null);
       expect(hash).to.not.eq(undefined);
       expect(numMessages).to.eq(BigInt(messages.length + 1));
+      expect(privateKey).to.not.eq(undefined);
+      expect(encryptedMessages.length).to.eq(defaultArgs.messages.length);
     });
 
     it("should throw error if public key is invalid", async () => {

--- a/cli/ts/commands/publish.ts
+++ b/cli/ts/commands/publish.ts
@@ -239,5 +239,7 @@ export const publishBatch = async ({
 
   return {
     hash: receipt?.hash,
+    encryptedMessages: preparedMessages,
+    privateKey: encryptionKeypair.privKey.serialize(),
   };
 };

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -2,6 +2,7 @@ import { Signer } from "ethers";
 
 import type { SnarkProof } from "maci-contracts";
 import type { CircuitInputs } from "maci-core";
+import type { IMessageContractParams } from "maci-domainobjs";
 import type { Groth16Proof, PublicSignals } from "snarkjs";
 
 export interface DeployedContracts {
@@ -810,8 +811,24 @@ export interface IPublishMessage {
   salt?: bigint;
 }
 
+/**
+ * Interface that represents publish batch return data
+ */
 export interface IPublishBatchData {
+  /**
+   * Publish transaction hash
+   */
   hash?: string;
+
+  /**
+   * Encrypted publish messages
+   */
+  encryptedMessages: IMessageContractParams[];
+
+  /**
+   * Encryption private key
+   */
+  privateKey: string;
 }
 
 /**


### PR DESCRIPTION
# Description

- [x] Return encryption private key
- [x] Return encrypted messages

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
