### PR TITLE
feat(cli): add initial voice credits from signup event

### DIFF
--- a/cli/ts/commands/signup.ts
+++ b/cli/ts/commands/signup.ts
@@ -89,14 +89,14 @@ export const signup = async ({
 /**
  * Checks if user is registered with public key
  * @param IRegisteredArgs - The arguments for the register check command
- * @returns user registered or not and state index
+ * @returns user registered or not and state index, voice credit balance
  */
 export const isRegisteredUser = async ({
   maciAddress,
   maciPubKey,
   signer,
   quiet = true,
-}: IRegisteredUserArgs): Promise<{ isRegistered: boolean; stateIndex?: string }> => {
+}: IRegisteredUserArgs): Promise<{ isRegistered: boolean; stateIndex?: string; voiceCredits?: string }> => {
   banner(quiet);
 
   const maciContract = MACIFactory.connect(maciAddress, signer);
@@ -104,11 +104,13 @@ export const isRegisteredUser = async ({
 
   const events = await maciContract.queryFilter(maciContract.filters.SignUp(undefined, publicKey.x, publicKey.y));
   const stateIndex = events[0]?.args[0].toString() as string | undefined;
+  const voiceCredits = events[0]?.args[3].toString() as string | undefined;
 
   logGreen(quiet, success(`State index: ${stateIndex?.toString()}, registered: ${stateIndex !== undefined}`));
 
   return {
     isRegistered: stateIndex !== undefined,
     stateIndex,
+    voiceCredits,
   };
 };


### PR DESCRIPTION
# Description

Add initial voice credits for poll sdk method

## Additional Notes

N/A

## Related issue(s)

Related to https://github.com/privacy-scaling-explorations/maci-rpgf/pull/39

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
