### PR TITLE
chore(core): do not print warning on failed decryption of message 0

### DIFF
--- a/core/ts/Poll.ts
+++ b/core/ts/Poll.ts
@@ -548,8 +548,8 @@ export class Poll implements IPoll {
               // otherwise we continue processing but add the default blank data instead of
               // this invalid message
               if (e instanceof ProcessMessageError) {
-                // if logging is enabled, print the error
-                if (!quiet) {
+                // if logging is enabled, and it's not the first message, print the error
+                if (!quiet && idx !== 0) {
                   // eslint-disable-next-line no-console
                   console.log(`Error at message index ${idx} - ${e.message}`);
                 }


### PR DESCRIPTION
# Description

Avoid printing confusing message on core.Poll when processing the message at position 0

## Related issue(s)

fix #1134 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
