### PR TITLE
fix: for genLocalState '-o' represents the path where to write the local state and not the pollId and must be be parsed as int.

### DIFF
--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -635,7 +635,7 @@ program
 program
   .command("genLocalState")
   .description("generate a local MACI state from the smart contracts events")
-  .requiredOption("-o, --output <outputPath>", "the path where to write the state", parseInt)
+  .requiredOption("-o, --output <outputPath>", "the path where to write the state")
   .requiredOption("-p, --poll-id <pollId>", "the id of the poll", BigInt)
   .option("-x, --contract <contract>", "the MACI contract address")
   .option("-sk, --privkey <privkey>", "your serialized MACI private key")


### PR DESCRIPTION
# Description

In the cli the command `genLocalState` has ha '-o' parameter used to specifiy the path where to write the local state. 

## Additional Notes

For other commands '-o' represented the pollId and the parameter required to be parsed into an integer but here trying to parse a path does nto allow to specify the path ending up to store the local store in a file called 'NaN'

## Related issue(s)

--

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
