### PR TITLE
feat(cli): add provider fallback for poll data sdk method

### DIFF
--- a/cli/tests/unit/poll.test.ts
+++ b/cli/tests/unit/poll.test.ts
@@ -53,7 +53,7 @@ describe("poll", () => {
     });
 
     it("should get finished poll properly", async () => {
-      const pollData = await getPoll({ maciAddress: maciAddresses.maciAddress, signer });
+      const pollData = await getPoll({ maciAddress: maciAddresses.maciAddress, provider: signer.provider! });
 
       await timeTravel({ seconds: Number(pollData.duration), signer });
       await mergeMessages({ pollId: BigInt(pollData.id), signer });
@@ -64,6 +64,12 @@ describe("poll", () => {
       expect(pollData.id).to.eq(finishedPollData.id);
       expect(pollData.address).to.eq(finishedPollData.address);
       expect(finishedPollData.isStateAqMerged).to.eq(true);
+    });
+
+    it("should throw error if there are no signer and provider", async () => {
+      await expect(getPoll({ maciAddress: maciAddresses.maciAddress, pollId: -1n })).eventually.rejectedWith(
+        "No signer and provider are provided",
+      );
     });
 
     it("should throw error if current poll id is invalid", async () => {

--- a/cli/ts/commands/poll.ts
+++ b/cli/ts/commands/poll.ts
@@ -11,10 +11,20 @@ import { logError, logGreen, success } from "../utils/theme";
  * @param {IGetPollArgs} args - The arguments for the get poll command
  * @returns {IGetPollData} poll data
  */
-export const getPoll = async ({ maciAddress, signer, pollId, quiet = true }: IGetPollArgs): Promise<IGetPollData> => {
+export const getPoll = async ({
+  maciAddress,
+  signer,
+  provider,
+  pollId,
+  quiet = true,
+}: IGetPollArgs): Promise<IGetPollData> => {
   banner(quiet);
 
-  const maciContract = MACIFactory.connect(maciAddress, signer);
+  if (!signer && !provider) {
+    logError("No signer and provider are provided");
+  }
+
+  const maciContract = MACIFactory.connect(maciAddress, signer ?? provider);
   const id =
     pollId === undefined ? await maciContract.nextPollId().then((nextPollId) => nextPollId - 1n) : BigInt(pollId);
 
@@ -28,7 +38,7 @@ export const getPoll = async ({ maciAddress, signer, pollId, quiet = true }: IGe
     logError(`MACI contract doesn't have any deployed poll ${id}`);
   }
 
-  const pollContract = PollFactory.connect(pollAddress, signer);
+  const pollContract = PollFactory.connect(pollAddress, signer ?? provider);
 
   const [[deployTime, duration], isStateAqMerged] = await Promise.all([
     pollContract.getDeployTimeAndDuration(),

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -1,5 +1,4 @@
-import { Signer } from "ethers";
-
+import type { Provider, Signer } from "ethers";
 import type { SnarkProof } from "maci-contracts";
 import type { CircuitInputs } from "maci-core";
 import type { IMessageContractParams } from "maci-domainobjs";
@@ -973,7 +972,12 @@ export interface IGetPollArgs {
   /**
    * A signer object
    */
-  signer: Signer;
+  signer?: Signer;
+
+  /**
+   * A provider fallback object
+   */
+  provider?: Provider;
 
   /**
    * The address of the MACI contract


### PR DESCRIPTION
# Description

Add provider object to read poll data without signer

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
