### PR TITLE
fix(cli): fix cli vkRegistry typo

### DIFF
--- a/cli/ts/commands/proveOnChain.ts
+++ b/cli/ts/commands/proveOnChain.ts
@@ -126,7 +126,7 @@ export const proveOnChain = async ({
     logError("There is no VkRegistry contract linked to the specified MACI contract.");
   }
 
-  const vkRegsitryContract = VkRegistryFactory.connect(vkRegistryContractAddress, signer);
+  const vkRegistryContract = VkRegistryFactory.connect(vkRegistryContractAddress, signer);
   const verifierContractAddress = await mpContract.verifier();
 
   if (!(await contractExists(signer.provider!, verifierContractAddress))) {
@@ -199,7 +199,7 @@ export const proveOnChain = async ({
   const messageRootOnChain = await messageAqContract.getMainRoot(Number(treeDepths.messageTreeDepth));
 
   const stateTreeDepth = Number(await maciContract.stateTreeDepth());
-  const onChainProcessVk = await vkRegsitryContract.getProcessVk(
+  const onChainProcessVk = await vkRegistryContract.getProcessVk(
     stateTreeDepth,
     treeDepths.messageTreeDepth,
     treeDepths.voteOptionTreeDepth,

--- a/contracts/tasks/helpers/Prover.ts
+++ b/contracts/tasks/helpers/Prover.ts
@@ -48,7 +48,7 @@ export class Prover {
   /**
    * VkRegistry contract typechain wrapper
    */
-  private vkRegsitryContract: VkRegistry;
+  private vkRegistryContract: VkRegistry;
 
   /**
    * Verifier contract typechain wrapper
@@ -75,7 +75,7 @@ export class Prover {
     mpContract,
     messageAqContract,
     maciContract,
-    vkRegsitryContract,
+    vkRegistryContract,
     verifierContract,
     subsidyContract,
     tallyContract,
@@ -84,7 +84,7 @@ export class Prover {
     this.mpContract = mpContract;
     this.messageAqContract = messageAqContract;
     this.maciContract = maciContract;
-    this.vkRegsitryContract = vkRegsitryContract;
+    this.vkRegistryContract = vkRegistryContract;
     this.verifierContract = verifierContract;
     this.subsidyContract = subsidyContract;
     this.tallyContract = tallyContract;
@@ -119,7 +119,7 @@ export class Prover {
 
     const [messageRootOnChain, onChainProcessVk] = await Promise.all([
       this.messageAqContract.getMainRoot(Number(treeDepths[2])),
-      this.vkRegsitryContract.getProcessVk(
+      this.vkRegistryContract.getProcessVk(
         stateTreeDepth,
         treeDepths.messageTreeDepth,
         treeDepths.voteOptionTreeDepth,

--- a/contracts/tasks/helpers/types.ts
+++ b/contracts/tasks/helpers/types.ts
@@ -337,7 +337,7 @@ export interface IProverParams {
   /**
    * VkRegistry contract typechain wrapper
    */
-  vkRegsitryContract: VkRegistry;
+  vkRegistryContract: VkRegistry;
 
   /**
    * Verifier contract typechain wrapper

--- a/contracts/tasks/runner/prove.ts
+++ b/contracts/tasks/runner/prove.ts
@@ -97,7 +97,7 @@ task("prove", "Command to generate proof and prove the result of a poll on-chain
 
       const maciContractAddress = storage.mustGetAddress(EContracts.MACI, network.name);
       const maciContract = await deployment.getContract<MACI>({ name: EContracts.MACI, address: maciContractAddress });
-      const vkRegsitryContract = await deployment.getContract<VkRegistry>({ name: EContracts.VkRegistry });
+      const vkRegistryContract = await deployment.getContract<VkRegistry>({ name: EContracts.VkRegistry });
       const verifierContract = await deployment.getContract<Verifier>({ name: EContracts.Verifier });
 
       const pollAddress = await maciContract.polls(poll);
@@ -213,7 +213,7 @@ task("prove", "Command to generate proof and prove the result of a poll on-chain
         messageAqContract,
         mpContract,
         pollContract,
-        vkRegsitryContract,
+        vkRegistryContract,
         verifierContract,
         tallyContract,
         subsidyContract,


### PR DESCRIPTION
# Description

fix `vkRegsitryContract` -> `vkRegistryContract` typo

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [X] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
