### PR TITLE
fix(build): add missing typescript dependency for integration tests package

### DIFF
--- a/integrationTests/package.json
+++ b/integrationTests/package.json
@@ -28,7 +28,8 @@
     "hardhat-artifactor": "^0.2.0",
     "hardhat-contract-sizer": "^2.0.3",
     "mocha": "^10.3.0",
-    "ts-mocha": "^10.0.0"
+    "ts-mocha": "^10.0.0",
+    "typescript": "^5.4.3"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       ts-mocha:
         specifier: ^10.0.0
         version: 10.0.0(mocha@10.3.0)
+      typescript:
+        specifier: ^5.4.3
+        version: 5.4.3
 
   website:
     dependencies:


### PR DESCRIPTION
# Description

Add missing typescript dependency for integration tests package

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
