### PR TITLE
chore: use non-zero start and end blocks for proof generation

### DIFF
--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -75,10 +75,10 @@ contract Poll is Params, Utilities, SnarkCommon, Ownable, EmptyBallotRoots, IPol
 
   event PublishMessage(Message _message, PubKey _encPubKey);
   event TopupMessage(Message _message);
-  event MergeMaciStateAqSubRoots(uint256 _numSrQueueOps);
-  event MergeMaciStateAq(uint256 _stateRoot, uint256 _numSignups);
-  event MergeMessageAqSubRoots(uint256 _numSrQueueOps);
-  event MergeMessageAq(uint256 _messageRoot);
+  event MergeMaciStateAqSubRoots(uint256 indexed _numSrQueueOps);
+  event MergeMaciStateAq(uint256 indexed _stateRoot, uint256 indexed _numSignups);
+  event MergeMessageAqSubRoots(uint256 indexed _numSrQueueOps);
+  event MergeMessageAq(uint256 indexed _messageRoot);
 
   /// @notice Each MACI instance can have multiple Polls.
   /// When a Poll is deployed, its voting period starts immediately.

--- a/contracts/deploy-config-example.json
+++ b/contracts/deploy-config-example.json
@@ -28,7 +28,7 @@
     },
     "Poll": {
       "pollDuration": 30,
-      "coordinatorPubkey": "macipk.ea638a3366ed91f2e955110888573861f7c0fc0bb5fb8b8dca9cd7a08d7d6b93",
+      "coordinatorPubkey": "macipk.9a59264310d95cfd8eb7083aebeba221b5c26e77427f12b7c0f50bc1cc35e621",
       "subsidyEnabled": false,
       "useQuadraticVoting": true
     }

--- a/contracts/tasks/helpers/types.ts
+++ b/contracts/tasks/helpers/types.ts
@@ -255,9 +255,19 @@ export interface ICircuitFiles {
  */
 export interface IPrepareStateParams {
   /**
-   * MACI contract address
+   * MACI contract
    */
-  maciContractAddress: string;
+  maciContract: MACI;
+
+  /**
+   * Poll contract
+   */
+  pollContract: Poll;
+
+  /**
+   * MessageAq contract
+   */
+  messageAq: AccQueue;
 
   /**
    * Poll id


### PR DESCRIPTION
# Description

- [x] Update maci-contracts task
- [x] Update maci-cli task
- [x] Add indexed params for poll events
- [x] Change deploy config example maci public key

## Additional Notes

Now you don't need to specify start and end blocks. By default start block is a first signup event block; end - last merge aq event block. 

## Related issue(s)

MACI rpgf feedback discussion

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
