### PR TITLE
feat(cli): add start block for signup event parsing

### DIFF
--- a/cli/ts/commands/genLocalState.ts
+++ b/cli/ts/commands/genLocalState.ts
@@ -79,8 +79,10 @@ export const genLocalState = async ({
   const messageAqContract = AccQueueFactory.connect(messageAq, signer);
 
   const [defaultStartBlockSignup, defaultStartBlockPoll, stateRoot, numSignups, messageRoot] = await Promise.all([
-    maciContract.queryFilter(maciContract.filters.SignUp()).then((events) => events[0]?.blockNumber ?? 0),
-    maciContract.queryFilter(maciContract.filters.DeployPoll()).then((events) => events[0]?.blockNumber ?? 0),
+    maciContract.queryFilter(maciContract.filters.SignUp(), startBlock).then((events) => events[0]?.blockNumber ?? 0),
+    maciContract
+      .queryFilter(maciContract.filters.DeployPoll(), startBlock)
+      .then((events) => events[0]?.blockNumber ?? 0),
     maciContract.getStateAqRoot(),
     maciContract.numSignUps(),
     messageAqContract.getMainRoot(messageTreeDepth),

--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -241,8 +241,10 @@ export const genProofs = async ({
   } else {
     // build an off-chain representation of the MACI contract using data in the contract storage
     const [defaultStartBlockSignup, defaultStartBlockPoll, stateRoot, numSignups, messageRoot] = await Promise.all([
-      maciContract.queryFilter(maciContract.filters.SignUp()).then((events) => events[0]?.blockNumber ?? 0),
-      maciContract.queryFilter(maciContract.filters.DeployPoll()).then((events) => events[0]?.blockNumber ?? 0),
+      maciContract.queryFilter(maciContract.filters.SignUp(), startBlock).then((events) => events[0]?.blockNumber ?? 0),
+      maciContract
+        .queryFilter(maciContract.filters.DeployPoll(), startBlock)
+        .then((events) => events[0]?.blockNumber ?? 0),
       maciContract.getStateAqRoot(),
       maciContract.numSignUps(),
       messageAqContract.getMainRoot(messageTreeDepth),

--- a/cli/ts/commands/signup.ts
+++ b/cli/ts/commands/signup.ts
@@ -95,6 +95,7 @@ export const isRegisteredUser = async ({
   maciAddress,
   maciPubKey,
   signer,
+  startBlock,
   quiet = true,
 }: IRegisteredUserArgs): Promise<{ isRegistered: boolean; stateIndex?: string; voiceCredits?: string }> => {
   banner(quiet);
@@ -102,7 +103,10 @@ export const isRegisteredUser = async ({
   const maciContract = MACIFactory.connect(maciAddress, signer);
   const publicKey = PubKey.deserialize(maciPubKey).asContractParam();
 
-  const events = await maciContract.queryFilter(maciContract.filters.SignUp(undefined, publicKey.x, publicKey.y));
+  const events = await maciContract.queryFilter(
+    maciContract.filters.SignUp(undefined, publicKey.x, publicKey.y),
+    startBlock,
+  );
   const stateIndex = events[0]?.args[0].toString() as string | undefined;
   const voiceCredits = events[0]?.args[3].toString() as string | undefined;
 

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -960,6 +960,11 @@ export interface IRegisteredUserArgs {
   maciAddress: string;
 
   /**
+   * Start block for event parsing
+   */
+  startBlock?: number;
+
+  /**
    * Whether to log the output
    */
   quiet?: boolean;

--- a/contracts/tasks/helpers/ProofGenerator.ts
+++ b/contracts/tasks/helpers/ProofGenerator.ts
@@ -105,8 +105,12 @@ export class ProofGenerator {
     // build an off-chain representation of the MACI contract using data in the contract storage
     const [defaultStartBlockSignup, defaultStartBlockPoll, { messageTreeDepth }, stateRoot, numSignups] =
       await Promise.all([
-        maciContract.queryFilter(maciContract.filters.SignUp()).then((events) => events[0]?.blockNumber ?? 0),
-        maciContract.queryFilter(maciContract.filters.DeployPoll()).then((events) => events[0]?.blockNumber ?? 0),
+        maciContract
+          .queryFilter(maciContract.filters.SignUp(), startBlock)
+          .then((events) => events[0]?.blockNumber ?? 0),
+        maciContract
+          .queryFilter(maciContract.filters.DeployPoll(), startBlock)
+          .then((events) => events[0]?.blockNumber ?? 0),
         pollContract.treeDepths(),
         maciContract.getStateAqRoot(),
         maciContract.numSignUps(),


### PR DESCRIPTION
# Description

Add start block for `isRegistered` cli sdk method and for deployment event parsing to prevent rate limit errors

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
