### PR TITLE
refactor(circuits): simplify generatePathIndices templates

### DIFF
--- a/circuits/circom/trees/incrementalMerkleTree.circom
+++ b/circuits/circom/trees/incrementalMerkleTree.circom
@@ -124,7 +124,6 @@ template MerkleGeneratePathIndices(levels) {
 
     signal input in; 
     signal output out[levels];
-    signal n[levels + 1];
 
     var m = in;
     var computedResults[levels];
@@ -132,14 +131,9 @@ template MerkleGeneratePathIndices(levels) {
     for (var i = 0; i < levels; i++) {
         // circom's best practices suggests to avoid using <-- unless you
         // are aware of what's going on. This is the only way to do modulo operation.
-        n[i] <-- m;        
         out[i] <-- m % BASE;
         m = m \ BASE;
-    }
 
-    n[levels] <-- m;
-
-    for (var i = 0; i < levels; i++) {
         // Check that each output element is less than the base.
         var computedIsOutputElementLessThanBase = SafeLessThan(3)([out[i], BASE]);
         computedIsOutputElementLessThanBase === 1;

--- a/circuits/circom/trees/incrementalQuinaryTree.circom
+++ b/circuits/circom/trees/incrementalQuinaryTree.circom
@@ -199,7 +199,6 @@ template QuinGeneratePathIndices(levels) {
 
     signal input in; 
     signal output out[levels];
-    signal n[levels + 1];
 
     var m = in;
     var computedResults[levels];
@@ -207,14 +206,9 @@ template QuinGeneratePathIndices(levels) {
     for (var i = 0; i < levels; i++) {
         // circom's best practices suggests to avoid using <-- unless you
         // are aware of what's going on. This is the only way to do modulo operation.
-        n[i] <-- m;        
         out[i] <-- m % BASE;
         m = m \ BASE;
-    }
 
-    n[levels] <-- m;
-
-    for (var i = 0; i < levels; i++) {
         // Check that each output element is less than the base.
         var computedIsOutputElementLessThanBase = SafeLessThan(3)([out[i], BASE]);
         computedIsOutputElementLessThanBase === 1;


### PR DESCRIPTION
# Description

Simplify the generate path indices templates (binary and quinary)

## Related issue(s)

fix #1420 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
