### PR TITLE
refactor: general cleanup, variables/events/functions renaming

### DIFF
--- a/cli/ts/commands/genLocalState.ts
+++ b/cli/ts/commands/genLocalState.ts
@@ -95,7 +95,7 @@ export const genLocalState = async ({
       .queryFilter(pollContract.filters.MergeMessageAq(messageRoot), fromBlock)
       .then((events) => events[events.length - 1]?.blockNumber),
     pollContract
-      .queryFilter(pollContract.filters.MergeMaciStateAq(stateRoot, numSignups), fromBlock)
+      .queryFilter(pollContract.filters.MergeMaciState(stateRoot, numSignups), fromBlock)
       .then((events) => events[events.length - 1]?.blockNumber),
   ]).then((blocks) => Math.max(...blocks));
 

--- a/cli/ts/commands/genProofs.ts
+++ b/cli/ts/commands/genProofs.ts
@@ -156,7 +156,7 @@ export const genProofs = async ({
   const messageAqContract = AccQueueFactory.connect(messageAqContractAddr, signer);
 
   // Check that the state and message trees have been merged
-  if (!(await pollContract.stateAqMerged())) {
+  if (!(await pollContract.stateMerged())) {
     logError("The state tree has not been merged yet. Please use the mergeSignups subcommmand to do so.");
   }
 
@@ -201,7 +201,7 @@ export const genProofs = async ({
         .queryFilter(pollContract.filters.MergeMessageAq(messageRoot), fromBlock)
         .then((events) => events[events.length - 1]?.blockNumber),
       pollContract
-        .queryFilter(pollContract.filters.MergeMaciStateAq(stateRoot, numSignups), fromBlock)
+        .queryFilter(pollContract.filters.MergeMaciState(stateRoot, numSignups), fromBlock)
         .then((events) => events[events.length - 1]?.blockNumber),
     ]).then((blocks) => Math.max(...blocks));
 

--- a/cli/ts/commands/mergeMessages.ts
+++ b/cli/ts/commands/mergeMessages.ts
@@ -58,14 +58,6 @@ export const mergeMessages = async ({
 
   const accQueueContract = AccQueueFactory.connect(messageAqContractAddr, signer);
 
-  // we need to ensure that the signer is the owner of the poll contract
-  // this is because only the owner can merge the message AQ
-  const pollOwner = await pollContract.owner();
-  const signerAddress = await signer.getAddress();
-  if (pollOwner.toLowerCase() !== signerAddress.toLowerCase()) {
-    logError("The signer is not the owner of this Poll contract");
-  }
-
   // check if it's time to merge the message AQ
   const dd = await pollContract.getDeployTimeAndDuration();
   const deadline = Number(dd[0]) + Number(dd[1]);

--- a/cli/ts/commands/mergeSignups.ts
+++ b/cli/ts/commands/mergeSignups.ts
@@ -54,10 +54,10 @@ export const mergeSignups = async ({ pollId, maciAddress, signer, quiet = true }
     logError("Voting period is not over");
   }
 
-  if (!(await pollContract.stateAqMerged())) {
+  if (!(await pollContract.stateMerged())) {
     // go and merge the state tree
-    logYellow(quiet, info("Merging subroots to a main state root..."));
-    const tx = await pollContract.mergeMaciStateAq();
+    logYellow(quiet, info("Calculating root and storing on Poll..."));
+    const tx = await pollContract.mergeMaciState();
     const receipt = await tx.wait();
 
     if (receipt?.status !== 1) {

--- a/cli/ts/commands/poll.ts
+++ b/cli/ts/commands/poll.ts
@@ -42,7 +42,7 @@ export const getPoll = async ({
 
   const [[deployTime, duration], isStateAqMerged] = await Promise.all([
     pollContract.getDeployTimeAndDuration(),
-    pollContract.stateAqMerged(),
+    pollContract.stateMerged(),
   ]);
 
   const numSignups = await (isStateAqMerged ? pollContract.numSignups() : maciContract.numSignUps());

--- a/contracts/contracts/MessageProcessorFactory.sol
+++ b/contracts/contracts/MessageProcessorFactory.sol
@@ -18,8 +18,7 @@ contract MessageProcessorFactory is Params, DomainObjs, IMessageProcessorFactory
     Mode _mode
   ) public returns (address messageProcessorAddr) {
     // deploy MessageProcessor for this Poll
-    MessageProcessor messageProcessor = new MessageProcessor(_verifier, _vkRegistry, _poll, _mode);
-    messageProcessor.transferOwnership(_owner);
+    MessageProcessor messageProcessor = new MessageProcessor(_verifier, _vkRegistry, _poll, _owner, _mode);
     messageProcessorAddr = address(messageProcessor);
   }
 }

--- a/contracts/contracts/PollFactory.sol
+++ b/contracts/contracts/PollFactory.sol
@@ -31,8 +31,7 @@ contract PollFactory is Params, DomainObjs, IPollFactory {
     TreeDepths calldata _treeDepths,
     PubKey calldata _coordinatorPubKey,
     address _maci,
-    TopupCredit _topupCredit,
-    address _pollOwner
+    TopupCredit _topupCredit
   ) public virtual returns (address pollAddr) {
     /// @notice Validate _maxValues
     /// maxVoteOptions must be less than 2 ** 50 due to circuit limitations;
@@ -61,8 +60,6 @@ contract PollFactory is Params, DomainObjs, IPollFactory {
 
     // init Poll
     poll.init();
-
-    poll.transferOwnership(_pollOwner);
 
     pollAddr = address(poll);
   }

--- a/contracts/contracts/Tally.sol
+++ b/contracts/contracts/Tally.sol
@@ -15,7 +15,7 @@ import { DomainObjs } from "./utilities/DomainObjs.sol";
 /// @title Tally
 /// @notice The Tally contract is used during votes tallying
 /// and by users to verify the tally results.
-contract Tally is Ownable(msg.sender), SnarkCommon, CommonUtilities, Hasher, DomainObjs {
+contract Tally is Ownable, SnarkCommon, CommonUtilities, Hasher, DomainObjs {
   uint256 internal constant TREE_ARITY = 2;
   uint256 internal constant VOTE_OPTION_TREE_ARITY = 5;
 
@@ -65,7 +65,16 @@ contract Tally is Ownable(msg.sender), SnarkCommon, CommonUtilities, Hasher, Dom
   /// @param _vkRegistry The VkRegistry contract
   /// @param _poll The Poll contract
   /// @param _mp The MessageProcessor contract
-  constructor(address _verifier, address _vkRegistry, address _poll, address _mp, Mode _mode) payable {
+  /// @param _tallyOwner The owner of the Tally contract
+  /// @param _mode The mode of the poll
+  constructor(
+    address _verifier,
+    address _vkRegistry,
+    address _poll,
+    address _mp,
+    address _tallyOwner,
+    Mode _mode
+  ) payable Ownable(_tallyOwner) {
     verifier = IVerifier(_verifier);
     vkRegistry = IVkRegistry(_vkRegistry);
     poll = IPoll(_poll);

--- a/contracts/contracts/TallyFactory.sol
+++ b/contracts/contracts/TallyFactory.sol
@@ -18,8 +18,7 @@ contract TallyFactory is ITallyFactory, DomainObjs {
     Mode _mode
   ) public virtual returns (address tallyAddr) {
     // deploy Tally for this Poll
-    Tally tally = new Tally(_verifier, _vkRegistry, _poll, _messageProcessor, _mode);
-    tally.transferOwnership(_owner);
+    Tally tally = new Tally(_verifier, _vkRegistry, _poll, _messageProcessor, _owner, _mode);
     tallyAddr = address(tally);
   }
 }

--- a/contracts/contracts/interfaces/IPoll.sol
+++ b/contracts/contracts/interfaces/IPoll.sol
@@ -30,7 +30,7 @@ interface IPoll {
   /// @notice The second step of merging the MACI state AccQueue. This allows the
   /// ProcessMessages circuit to access the latest state tree and ballots via
   /// currentSbCommitment.
-  function mergeMaciStateAq() external;
+  function mergeMaciState() external;
 
   /// @notice The first step in merging the message AccQueue so that the
   /// ProcessMessages circuit can access the message root.
@@ -48,7 +48,7 @@ interface IPoll {
 
   /// @notice Get the result of whether the MACI contract's stateAq has been merged by this contract
   /// @return Whether the MACI contract's stateAq has been merged by this contract
-  function stateAqMerged() external view returns (bool);
+  function stateMerged() external view returns (bool);
 
   /// @notice Get the depths of the merkle trees
   /// @return intStateTreeDepth The depth of the state tree

--- a/contracts/contracts/interfaces/IPollFactory.sol
+++ b/contracts/contracts/interfaces/IPollFactory.sol
@@ -15,7 +15,6 @@ interface IPollFactory {
   /// @param _coordinatorPubKey The coordinator's public key
   /// @param _maci The MACI contract interface reference
   /// @param _topupCredit The TopupCredit contract
-  /// @param _pollOwner The owner of the poll
   /// @return The deployed Poll contract
   function deploy(
     uint256 _duration,
@@ -23,7 +22,6 @@ interface IPollFactory {
     Params.TreeDepths memory _treeDepths,
     DomainObjs.PubKey memory _coordinatorPubKey,
     address _maci,
-    TopupCredit _topupCredit,
-    address _pollOwner
+    TopupCredit _topupCredit
   ) external returns (address);
 }

--- a/contracts/tasks/helpers/ProofGenerator.ts
+++ b/contracts/tasks/helpers/ProofGenerator.ts
@@ -113,7 +113,7 @@ export class ProofGenerator {
         .queryFilter(pollContract.filters.MergeMessageAq(messageRoot), fromBlock)
         .then((events) => events[events.length - 1]?.blockNumber),
       pollContract
-        .queryFilter(pollContract.filters.MergeMaciStateAq(stateRoot, numSignups), fromBlock)
+        .queryFilter(pollContract.filters.MergeMaciState(stateRoot, numSignups), fromBlock)
         .then((events) => events[events.length - 1]?.blockNumber),
     ]).then((blocks) => Math.max(...blocks));
 

--- a/contracts/tasks/helpers/TreeMerger.ts
+++ b/contracts/tasks/helpers/TreeMerger.ts
@@ -35,18 +35,6 @@ export class TreeMerger {
   }
 
   /**
-   * Check if signer is an owner. Otherwise, throw an error.
-   */
-  async checkPollOwner(): Promise<void> {
-    const pollOwner = await this.pollContract.owner();
-    const deployerAddress = await this.deployer.getAddress();
-
-    if (pollOwner.toLowerCase() !== deployerAddress.toLowerCase()) {
-      throw new Error("The signer is not the owner of this Poll contract");
-    }
-  }
-
-  /**
    * Check if voting period is over. Otherwise, throw an error.
    */
   async checkPollDuration(): Promise<void> {
@@ -70,10 +58,10 @@ export class TreeMerger {
    */
   async mergeSignups(): Promise<void> {
     // check if the state tree has been fully merged
-    if (!(await this.pollContract.stateAqMerged())) {
+    if (!(await this.pollContract.stateMerged())) {
       // go and merge the state tree
       console.log("Merging subroots to a main state root...");
-      const receipt = await this.pollContract.mergeMaciStateAq().then((tx) => tx.wait());
+      const receipt = await this.pollContract.mergeMaciState().then((tx) => tx.wait());
 
       if (receipt?.status !== 1) {
         throw new Error("Error merging signup state subroots");

--- a/contracts/tasks/runner/merge.ts
+++ b/contracts/tasks/runner/merge.ts
@@ -49,7 +49,6 @@ task("merge", "Merge signups and messages")
 
     console.log("Start balance: ", Number(startBalance / 10n ** 12n) / 1e6);
 
-    await treeMerger.checkPollOwner();
     await treeMerger.checkPollDuration();
 
     await treeMerger.mergeSignups();

--- a/contracts/tasks/runner/prove.ts
+++ b/contracts/tasks/runner/prove.ts
@@ -95,7 +95,7 @@ task("prove", "Command to generate proof and prove the result of a poll on-chain
         name: EContracts.AccQueue,
         address: messageAqContractAddress,
       });
-      const isStateAqMerged = await pollContract.stateAqMerged();
+      const isStateAqMerged = await pollContract.stateMerged();
 
       // Check that the state and message trees have been merged for at least the first poll
       if (!isStateAqMerged && poll.toString() === "0") {

--- a/contracts/tests/MessageProcessor.test.ts
+++ b/contracts/tests/MessageProcessor.test.ts
@@ -146,14 +146,14 @@ describe("MessageProcessor", () => {
     it("processMessages() should fail if the state AQ has not been merged", async () => {
       await expect(mpContract.processMessages(0, [0, 0, 0, 0, 0, 0, 0, 0])).to.be.revertedWithCustomError(
         mpContract,
-        "StateAqNotMerged",
+        "StateNotMerged",
       );
     });
   });
 
   describe("after merging acc queues", () => {
     before(async () => {
-      await pollContract.mergeMaciStateAq();
+      await pollContract.mergeMaciState();
 
       await pollContract.mergeMessageAqSubRoots(0);
       await pollContract.mergeMessageAq();

--- a/contracts/tests/PollFactory.test.ts
+++ b/contracts/tests/PollFactory.test.ts
@@ -27,7 +27,6 @@ describe("pollFactory", () => {
         coordinatorPubKey.asContractParam(),
         ZeroAddress,
         ZeroAddress,
-        await signer.getAddress(),
       );
       const receipt = await tx.wait();
       expect(receipt?.status).to.eq(1);
@@ -45,7 +44,6 @@ describe("pollFactory", () => {
           coordinatorPubKey.asContractParam(),
           ZeroAddress,
           ZeroAddress,
-          await signer.getAddress(),
         ),
       ).to.be.revertedWithCustomError(pollFactory, "InvalidMaxValues");
     });

--- a/contracts/tests/Tally.test.ts
+++ b/contracts/tests/Tally.test.ts
@@ -183,7 +183,7 @@ describe("TallyVotes", () => {
   describe("after merging acc queues", () => {
     let tallyGeneratedInputs: ITallyCircuitInputs;
     before(async () => {
-      await pollContract.mergeMaciStateAq();
+      await pollContract.mergeMaciState();
 
       await pollContract.mergeMessageAqSubRoots(0);
       await pollContract.mergeMessageAq();
@@ -337,7 +337,7 @@ describe("TallyVotes", () => {
       );
 
       await timeTravel(signer.provider! as unknown as EthereumProvider, updatedDuration);
-      await pollContract.mergeMaciStateAq();
+      await pollContract.mergeMaciState();
 
       await pollContract.mergeMessageAqSubRoots(0);
       await pollContract.mergeMessageAq();
@@ -482,7 +482,7 @@ describe("TallyVotes", () => {
       );
 
       await timeTravel(signer.provider! as unknown as EthereumProvider, updatedDuration);
-      await pollContract.mergeMaciStateAq();
+      await pollContract.mergeMaciState();
 
       await pollContract.mergeMessageAqSubRoots(0);
       await pollContract.mergeMessageAq();

--- a/contracts/tests/TallyNonQv.test.ts
+++ b/contracts/tests/TallyNonQv.test.ts
@@ -182,7 +182,7 @@ describe("TallyVotesNonQv", () => {
   describe("after merging acc queues", () => {
     let tallyGeneratedInputs: ITallyCircuitInputs;
     before(async () => {
-      await pollContract.mergeMaciStateAq();
+      await pollContract.mergeMaciState();
 
       await pollContract.mergeMessageAqSubRoots(0);
       await pollContract.mergeMessageAq();

--- a/coordinator/ts/proof/__tests__/proof.service.test.ts
+++ b/coordinator/ts/proof/__tests__/proof.service.test.ts
@@ -47,7 +47,7 @@ describe("ProofGeneratorService", () => {
     getMainRoot: jest.fn(),
     treeDepths: jest.fn(),
     extContracts: jest.fn(),
-    stateAqMerged: jest.fn(),
+    stateMerged: jest.fn(),
   };
 
   let defaultProofGenerator = {
@@ -71,7 +71,7 @@ describe("ProofGeneratorService", () => {
       getMainRoot: jest.fn(() => Promise.resolve(1n)),
       treeDepths: jest.fn(() => Promise.resolve([1, 2, 3])),
       extContracts: jest.fn(() => Promise.resolve({ messageAq: ZeroAddress })),
-      stateAqMerged: jest.fn(() => Promise.resolve(true)),
+      stateMerged: jest.fn(() => Promise.resolve(true)),
     };
 
     defaultProofGenerator = {
@@ -103,7 +103,7 @@ describe("ProofGeneratorService", () => {
   });
 
   test("should throw error if state is not merged yet", async () => {
-    mockContract.stateAqMerged.mockResolvedValue(false);
+    mockContract.stateMerged.mockResolvedValue(false);
 
     const service = new ProofGeneratorService();
 

--- a/coordinator/ts/proof/proof.service.ts
+++ b/coordinator/ts/proof/proof.service.ts
@@ -64,7 +64,7 @@ export class ProofGeneratorService {
       address: messageAqAddress,
     });
 
-    const isStateAqMerged = await pollContract.stateAqMerged();
+    const isStateAqMerged = await pollContract.stateMerged();
 
     if (!isStateAqMerged) {
       throw new Error("The state tree has not been merged yet. Please use the mergeSignups subcommmand to do so.");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maci",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Minimal Anti-Collusion Infrastructure",
   "repository": "https://github.com/privacy-scaling-explorations/maci",
   "license": "MIT",


### PR DESCRIPTION
# Description

Ensure functions/events/variables/test descriptions reflect the latest code changes optimize contracts and remove unnecessary logic

- [x] Remove ownable from MACI - anyone can deploy a poll now and they all are independent
- [x] Remove ownable from Poll - anyone can technically merge the message tree if they are willing to pay the gas for it
- [x] Remove transferOwnership in MpFactory and TallyFactory - directly use caller from Maci.deployPoll
- [x] Rename functions/events to reflect removal of state acc queue
- [x] Remove dead code
- [x] Add tests to ensure above changes do not affect logic

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
