### PR TITLE
feat(gatekeepers): implement a gitcoin passport gatekeeper

### DIFF
--- a/contracts/contracts/gatekeepers/EASGatekeeper.sol
+++ b/contracts/contracts/gatekeepers/EASGatekeeper.sol
@@ -11,7 +11,7 @@ import { IEAS } from "../interfaces/IEAS.sol";
 /// only if they've received an attestation of a specific schema from a trusted attester
 contract EASGatekeeper is SignUpGatekeeper, Ownable(msg.sender) {
   // the reference to the EAS contract
-  IEAS private immutable eas;
+  IEAS public immutable eas;
 
   // the schema to check against
   bytes32 public immutable schema;

--- a/contracts/contracts/gatekeepers/GitcoinPassportGatekeeper.sol
+++ b/contracts/contracts/gatekeepers/GitcoinPassportGatekeeper.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import { SignUpGatekeeper } from "./SignUpGatekeeper.sol";
+import { IGitcoinPassportDecoder } from "../interfaces/IGitcoinPassportDecoder.sol";
+
+/// @title GitcoinPassportGatekeeper
+/// @notice A gatekeeper contract which allows users to sign up to MACI
+/// only if they've received an attestation of a specific schema from a trusted attester
+contract GitcoinPassportGatekeeper is SignUpGatekeeper, Ownable(msg.sender) {
+  /// @notice the gitcoin passport decoder instance
+  IGitcoinPassportDecoder public immutable passportDecoder;
+
+  /// @notice the reference to the MACI contract
+  address public maci;
+
+  /// @notice the threshold score to be considered human
+  uint256 public immutable thresholdScore;
+
+  /// @notice to get the score we need to divide by this factor
+  uint256 public constant FACTOR = 100;
+
+  // a mapping of attestations that have already registered
+  mapping(address => bool) public registeredUsers;
+
+  /// @notice custom errors
+  error AlreadyRegistered();
+  error OnlyMACI();
+  error ZeroAddress();
+  error ScoreTooLow();
+
+  /// @notice Deploy an instance of GitcoinPassportGatekeeper
+  /// @param _passportDecoder The GitcoinPassportDecoder contract
+  /// @param _thresholdScore The threshold score to be considered human
+  constructor(address _passportDecoder, uint256 _thresholdScore) payable {
+    if (_passportDecoder == address(0)) revert ZeroAddress();
+    passportDecoder = IGitcoinPassportDecoder(_passportDecoder);
+    thresholdScore = _thresholdScore;
+  }
+
+  /// @notice Adds an uninitialised MACI instance to allow for token signups
+  /// @param _maci The MACI contract interface to be stored
+  function setMaciInstance(address _maci) public override onlyOwner {
+    if (_maci == address(0)) revert ZeroAddress();
+    maci = _maci;
+  }
+
+  /// @notice Register an user based on their attestation
+  /// @dev Throw if the attestation is not valid or just complete silently
+  /// @param _user The user's Ethereum address.
+  function register(address _user, bytes memory /*_data*/) public override {
+    // ensure that the caller is the MACI contract
+    if (maci != msg.sender) revert OnlyMACI();
+
+    // ensure that the user has not been registered yet
+    if (registeredUsers[_user]) revert AlreadyRegistered();
+
+    // register the user so it cannot register again
+    registeredUsers[_user] = true;
+
+    // get the score from the GitcoinPassportDecoder contract
+    uint256 score = passportDecoder.getScore(_user);
+
+    // check if the score is enough
+    if (score / FACTOR < thresholdScore) {
+      revert ScoreTooLow();
+    }
+  }
+}

--- a/contracts/contracts/interfaces/IGitcoinPassportDecoder.sol
+++ b/contracts/contracts/interfaces/IGitcoinPassportDecoder.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL
+pragma solidity ^0.8.20;
+
+/// @dev A struct storing a passport credential
+struct Credential {
+  string provider;
+  bytes32 hash;
+  uint64 time;
+  uint64 expirationTime;
+}
+
+/// @title IGitcoinPassportDecoder
+/// @notice Minimal interface for consuming GitcoinPassportDecoder data
+interface IGitcoinPassportDecoder {
+  function getPassport(address user) external returns (Credential[] memory);
+
+  function getScore(address user) external view returns (uint256);
+
+  function isHuman(address user) external view returns (bool);
+}

--- a/contracts/contracts/mocks/MockGitcoinPassportDecoder.sol
+++ b/contracts/contracts/mocks/MockGitcoinPassportDecoder.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title MockGitcoinPassportDecoder
+/// @notice A mock contract to test the GitcoinPassportDecoder gatekeeper
+contract MockGitcoinPassportDecoder {
+  uint256 public score;
+
+  /// @notice Get the score of a user's passport
+  /// @param _user The address of the user
+  function getScore(address _user) external returns (uint256) {
+    return score;
+  }
+
+  /// @notice Change the return value of getScore
+  function changeScore(uint256 newScore) external {
+    score = newScore;
+  }
+}

--- a/contracts/contracts/mocks/MockHatsProtocol.sol
+++ b/contracts/contracts/mocks/MockHatsProtocol.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.20;
 
 /// @title MockHatsProtocol
 /// @notice A mock contract to test the HatsProtocolSingle gatekeeper

--- a/contracts/deploy-config-example.json
+++ b/contracts/deploy-config-example.json
@@ -13,6 +13,11 @@
       "schema": "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
       "attester": "attester-address"
     },
+    "GitcoinPassportGatekeeper": {
+      "deploy": false,
+      "decoderAddress": "0xe53C60F8069C2f0c3a84F9B3DB5cf56f3100ba56",
+      "passingScore": 5
+    },
     "MACI": {
       "stateTreeDepth": 10,
       "gatekeeper": "EASGatekeeper"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -49,6 +49,7 @@
     "test:pollFactory": "pnpm run test ./tests/PollFactory.test.ts",
     "test:eas_gatekeeper": "pnpm run test ./tests/EASGatekeeper.test.ts",
     "test:hats_gatekeeper": "pnpm run test ./tests/HatsGatekeeper.test.ts",
+    "test:gitcoin_gatekeeper": "pnpm run test ./tests/GitcoinPassportGatekeeper.test.ts",
     "deploy": "hardhat deploy-full",
     "deploy-poll": "hardhat deploy-poll",
     "verify": "hardhat verify-full",

--- a/contracts/tasks/deploy/maci/09-maci.ts
+++ b/contracts/tasks/deploy/maci/09-maci.ts
@@ -1,4 +1,4 @@
-import type { EASGatekeeper, MACI } from "../../../typechain-types";
+import type { EASGatekeeper, GitcoinPassportGatekeeper, MACI } from "../../../typechain-types";
 
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
@@ -71,6 +71,14 @@ deployment.deployTask("full:deploy-maci", "Deploy MACI contract").then((task) =>
     if (gatekeeper === EContracts.EASGatekeeper) {
       const gatekeeperContract = await deployment.getContract<EASGatekeeper>({
         name: EContracts.EASGatekeeper,
+        address: gatekeeperContractAddress,
+      });
+      const maciInstanceAddress = await maciContract.getAddress();
+
+      await gatekeeperContract.setMaciInstance(maciInstanceAddress).then((tx) => tx.wait());
+    } else if (gatekeeper === EContracts.GitcoinPassportGatekeeper) {
+      const gatekeeperContract = await deployment.getContract<GitcoinPassportGatekeeper>({
+        name: EContracts.GitcoinPassportGatekeeper,
         address: gatekeeperContractAddress,
       });
       const maciInstanceAddress = await maciContract.getAddress();

--- a/contracts/tasks/helpers/types.ts
+++ b/contracts/tasks/helpers/types.ts
@@ -470,6 +470,7 @@ export enum EContracts {
   ConstantInitialVoiceCreditProxy = "ConstantInitialVoiceCreditProxy",
   FreeForAllGatekeeper = "FreeForAllGatekeeper",
   EASGatekeeper = "EASGatekeeper",
+  GitcoinPassportGatekeeper = "GitcoinPassportGatekeeper",
   Verifier = "Verifier",
   TopupCredit = "TopupCredit",
   MACI = "MACI",

--- a/contracts/tests/EASGatekeeper.test.ts
+++ b/contracts/tests/EASGatekeeper.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import dotenv from "dotenv";
 import { AbiCoder, Signer, ZeroAddress, toBeArray } from "ethers";
 import { Keypair } from "maci-domainobjs";
 
@@ -9,8 +8,6 @@ import { EASGatekeeper, MACI } from "../typechain-types";
 
 import { STATE_TREE_DEPTH, initialVoiceCreditBalance } from "./constants";
 import { deployTestContracts } from "./utils";
-
-dotenv.config();
 
 describe("EAS Gatekeeper", () => {
   let easGatekeeper: EASGatekeeper;

--- a/contracts/tests/GitcoinPassportGatekeeper.test.ts
+++ b/contracts/tests/GitcoinPassportGatekeeper.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "chai";
+import { AbiCoder, Signer, ZeroAddress } from "ethers";
+import { Keypair } from "maci-domainobjs";
+
+import { deployContract, getDefaultSigner, getSigners } from "../ts";
+import { GitcoinPassportGatekeeper, MACI, MockGitcoinPassportDecoder } from "../typechain-types";
+
+import { initialVoiceCreditBalance, STATE_TREE_DEPTH } from "./constants";
+import { deployTestContracts } from "./utils";
+
+describe("GitcoinPassport Gatekeeper", () => {
+  let gitcoinGatekeeper: GitcoinPassportGatekeeper;
+  let maciContract: MACI;
+  let mockDecoder: MockGitcoinPassportDecoder;
+
+  let signer: Signer;
+  let signerAddress: string;
+  let decoderAddress: string;
+
+  // @note score is 4 digit (2 decimals)
+  // 50.00
+  const passingScore = 5000;
+
+  const user = new Keypair();
+
+  before(async () => {
+    signer = await getDefaultSigner();
+    signerAddress = await signer.getAddress();
+    mockDecoder = await deployContract("MockGitcoinPassportDecoder", signer, true);
+    decoderAddress = await mockDecoder.getAddress();
+    gitcoinGatekeeper = await deployContract("GitcoinPassportGatekeeper", signer, true, decoderAddress, passingScore);
+
+    const r = await deployTestContracts(initialVoiceCreditBalance, STATE_TREE_DEPTH, signer, true, gitcoinGatekeeper);
+    maciContract = r.maciContract;
+  });
+
+  describe("Deployment", () => {
+    it("The gatekeeper should be deployed correctly", () => {
+      expect(gitcoinGatekeeper).to.not.eq(undefined);
+    });
+
+    it("should fail to deploy when the decoder contract address is not valid", async () => {
+      await expect(
+        deployContract("GitcoinPassportGatekeeper", signer, true, ZeroAddress, passingScore),
+      ).to.be.revertedWithCustomError(gitcoinGatekeeper, "ZeroAddress");
+    });
+  });
+
+  describe("GitcoinGakeeper", () => {
+    it("sets MACI instance correctly", async () => {
+      const maciAddress = await maciContract.getAddress();
+      await gitcoinGatekeeper.setMaciInstance(maciAddress).then((tx) => tx.wait());
+
+      expect(await gitcoinGatekeeper.maci()).to.eq(maciAddress);
+    });
+
+    it("should fail to set MACI instance when the caller is not the owner", async () => {
+      const [, secondSigner] = await getSigners();
+      await expect(
+        gitcoinGatekeeper.connect(secondSigner).setMaciInstance(signerAddress),
+      ).to.be.revertedWithCustomError(gitcoinGatekeeper, "OwnableUnauthorizedAccount");
+    });
+
+    it("should fail to set MACI instance when the MACI instance is not valid", async () => {
+      await expect(gitcoinGatekeeper.setMaciInstance(ZeroAddress)).to.be.revertedWithCustomError(
+        gitcoinGatekeeper,
+        "ZeroAddress",
+      );
+    });
+
+    it("should throw when the score is not high enough", async () => {
+      await gitcoinGatekeeper.setMaciInstance(signerAddress).then((tx) => tx.wait());
+
+      await expect(gitcoinGatekeeper.register(signerAddress, "0x")).to.be.revertedWithCustomError(
+        gitcoinGatekeeper,
+        "ScoreTooLow",
+      );
+    });
+
+    it("should allow to signup when the score is high enough", async () => {
+      await mockDecoder.changeScore(passingScore * 100).then((tx) => tx.wait());
+      await gitcoinGatekeeper.register(signerAddress, "0x").then((tx) => tx.wait());
+
+      expect(await gitcoinGatekeeper.registeredUsers(signerAddress)).to.eq(true);
+    });
+
+    it("should prevent signing up twice", async () => {
+      await expect(gitcoinGatekeeper.register(signerAddress, "0x")).to.be.revertedWithCustomError(
+        gitcoinGatekeeper,
+        "AlreadyRegistered",
+      );
+    });
+
+    it("should signup via MACI", async () => {
+      const [, secondSigner] = await getSigners();
+
+      await gitcoinGatekeeper.setMaciInstance(await maciContract.getAddress()).then((tx) => tx.wait());
+
+      const tx = await maciContract
+        .connect(secondSigner)
+        .signUp(
+          user.pubKey.asContractParam(),
+          AbiCoder.defaultAbiCoder().encode(["uint256"], [1]),
+          AbiCoder.defaultAbiCoder().encode(["uint256"], [1]),
+        );
+
+      const receipt = await tx.wait();
+
+      expect(receipt?.status).to.eq(1);
+    });
+  });
+});

--- a/contracts/tests/HatsGatekeeper.test.ts
+++ b/contracts/tests/HatsGatekeeper.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import dotenv from "dotenv";
 import { AbiCoder, Signer, ZeroAddress } from "ethers";
 import { Keypair } from "maci-domainobjs";
 
@@ -9,8 +8,6 @@ import { HatsGatekeeperMultiple, HatsGatekeeperSingle, MACI, MockHatsProtocol } 
 
 import { STATE_TREE_DEPTH, initialVoiceCreditBalance } from "./constants";
 import { deployTestContracts } from "./utils";
-
-dotenv.config();
 
 describe("HatsProtocol Gatekeeper", () => {
   let maciContract: MACI;

--- a/contracts/ts/deploy.ts
+++ b/contracts/ts/deploy.ts
@@ -30,6 +30,7 @@ import {
   MACI__factory as MACIFactory,
   MessageProcessorFactory__factory as MessageProcessorFactoryFactory,
   TallyFactory__factory as TallyFactoryFactory,
+  GitcoinPassportGatekeeper,
 } from "../typechain-types";
 
 import { log } from "./utils";
@@ -153,6 +154,28 @@ export const deploySignupTokenGatekeeper = async (
  */
 export const deployFreeForAllSignUpGatekeeper = async (signer?: Signer, quiet = false): Promise<FreeForAllGatekeeper> =>
   deployContract<FreeForAllGatekeeper>("FreeForAllGatekeeper", signer, quiet);
+
+/**
+ * Deploy a GitcoinPassportGatekeeper contract
+ * @param decoderAddress - the address of the GitcoinPassportDecoder contract
+ * @param minimumScore - the minimum score required to pass
+ * @param signer - the signer to use to deploy the contract
+ * @param quiet - whether to suppress console output
+ * @returns the deployed GitcoinPassportGatekeeper contract
+ */
+export const deployGitcoinPassportGatekeeper = async (
+  decoderAddress: string,
+  minimumScore: number,
+  signer?: Signer,
+  quiet = false,
+): Promise<GitcoinPassportGatekeeper> =>
+  deployContract<GitcoinPassportGatekeeper>(
+    "GitcoinPassportGatekeeper",
+    signer,
+    quiet,
+    decoderAddress,
+    minimumScore.toString(),
+  );
 
 /**
  * Deploy Poseidon contracts

--- a/contracts/ts/index.ts
+++ b/contracts/ts/index.ts
@@ -9,6 +9,7 @@ export {
   deploySignupTokenGatekeeper,
   deployConstantInitialVoiceCreditProxy,
   deployFreeForAllSignUpGatekeeper,
+  deployGitcoinPassportGatekeeper,
   deployPollFactory,
   createContractFactory,
   deployPoseidonContracts,


### PR DESCRIPTION
# Description

Implement a gatekeeper that uses a gitcoin passport score as criteria to signup to MACI. 

## Related issue(s)

fix #1444 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
