### PR TITLE
feat: add signer as input for deployContractWithLinkedLibraries

### DIFF
--- a/contracts/tasks/deploy/maci/06-pollFactory.ts
+++ b/contracts/tasks/deploy/maci/06-pollFactory.ts
@@ -34,7 +34,9 @@ deployment.deployTask("full:deploy-poll-factory", "Deploy poll factory").then((t
       },
     });
 
-    const pollFactoryContract = await deployment.deployContractWithLinkedLibraries(linkedPollFactoryContract);
+    const pollFactoryContract = await deployment.deployContractWithLinkedLibraries({
+      contractFactory: linkedPollFactoryContract,
+    });
 
     await storage.register({
       id: EContracts.PollFactory,

--- a/contracts/tasks/deploy/maci/07-messageProcessorFactory.ts
+++ b/contracts/tasks/deploy/maci/07-messageProcessorFactory.ts
@@ -40,9 +40,9 @@ deployment.deployTask("full:deploy-message-processor-factory", "Deploy message p
       },
     );
 
-    const messageProcessorFactoryContract = await deployment.deployContractWithLinkedLibraries(
-      linkedMessageProcessorFactoryContract,
-    );
+    const messageProcessorFactoryContract = await deployment.deployContractWithLinkedLibraries({
+      contractFactory: linkedMessageProcessorFactoryContract,
+    });
 
     await storage.register({
       id: EContracts.MessageProcessorFactory,

--- a/contracts/tasks/deploy/maci/08-tallyFactory.ts
+++ b/contracts/tasks/deploy/maci/08-tallyFactory.ts
@@ -34,7 +34,9 @@ deployment.deployTask("full:deploy-tally-factory", "Deploy tally factory").then(
       },
     });
 
-    const tallyFactoryContract = await deployment.deployContractWithLinkedLibraries(linkedTallyFactoryContract);
+    const tallyFactoryContract = await deployment.deployContractWithLinkedLibraries({
+      contractFactory: linkedTallyFactoryContract,
+    });
 
     await storage.register({
       id: EContracts.TallyFactory,

--- a/contracts/tasks/deploy/maci/09-maci.ts
+++ b/contracts/tasks/deploy/maci/09-maci.ts
@@ -58,7 +58,7 @@ deployment.deployTask("full:deploy-maci", "Deploy MACI contract").then((task) =>
       deployment.getDeployConfigField<number | null>(EContracts.MACI, "stateTreeDepth") ?? DEFAULT_STATE_TREE_DEPTH;
 
     const maciContract = await deployment.deployContractWithLinkedLibraries<MACI>(
-      maciContractFactory,
+      { contractFactory: maciContractFactory },
       pollFactoryContractAddress,
       messageProcessorFactoryContractAddress,
       tallyFactoryContractAddress,

--- a/contracts/tasks/helpers/Deployment.ts
+++ b/contracts/tasks/helpers/Deployment.ts
@@ -15,6 +15,7 @@ import { ContractStorage } from "./ContractStorage";
 import {
   EContracts,
   IDeployContractArgs,
+  IDeployContractWithLinkedLibrariesArgs,
   IDeployParams,
   IDeployStep,
   IDeployStepCatalog,
@@ -341,15 +342,15 @@ export class Deployment {
    * @returns deployed contract
    */
   async deployContractWithLinkedLibraries<T extends BaseContract>(
-    contractFactory: ContractFactory,
+    { contractFactory, signer }: IDeployContractWithLinkedLibrariesArgs,
     ...args: unknown[]
   ): Promise<T> {
-    const deployer = await this.getDeployer();
-    const feeData = await deployer.provider.getFeeData();
+    const deployer = signer || (await this.getDeployer());
+    const feeData = await deployer.provider?.getFeeData();
 
     const contract = await contractFactory.deploy(...args, {
-      maxFeePerGas: feeData.maxFeePerGas,
-      maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+      maxFeePerGas: feeData?.maxFeePerGas,
+      maxPriorityFeePerGas: feeData?.maxPriorityFeePerGas,
     });
     await contract.deploymentTransaction()!.wait();
 

--- a/contracts/tasks/helpers/types.ts
+++ b/contracts/tasks/helpers/types.ts
@@ -1,6 +1,6 @@
 import type { AccQueue, MACI, MessageProcessor, Poll, Tally, Verifier, VkRegistry } from "../../typechain-types";
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
-import type { BaseContract, BigNumberish, Fragment, JsonFragment, Signer } from "ethers";
+import type { BaseContract, BigNumberish, Fragment, JsonFragment, Signer, ContractFactory } from "ethers";
 import type { Libraries, TaskArguments } from "hardhat/types";
 import type { Poll as PollWrapper } from "maci-core";
 import type { Keypair, PrivKey } from "maci-domainobjs";
@@ -666,6 +666,21 @@ export interface IDeployContractArgs {
    * Contract bytecode
    */
   bytecode?: string;
+
+  /**
+   * Eth signer
+   */
+  signer?: Signer;
+}
+
+/**
+ * Interface that represents deploy params
+ */
+export interface IDeployContractWithLinkedLibrariesArgs {
+  /**
+   * Contract factory
+   */
+  contractFactory: ContractFactory;
 
   /**
    * Eth signer

--- a/contracts/ts/deploy.ts
+++ b/contracts/ts/deploy.ts
@@ -219,7 +219,7 @@ export const deployContractWithLinkedLibraries = async <T extends BaseContract>(
   const deployment = Deployment.getInstance(hre);
   deployment.setHre(hre);
 
-  return deployment.deployContractWithLinkedLibraries(contractFactory, ...args);
+  return deployment.deployContractWithLinkedLibraries({ contractFactory }, ...args);
 };
 
 /**


### PR DESCRIPTION
# Description

Currently, if using `Deployment` helper to deploy contracts with linked libraries, it would check if there is hardhat environment running or not. Make this optional by accepting `signer` as input argument, for frontend to call and use.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
