### PR TITLE
fix(nightly): do not run maci-coordinator tests from root on nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:cli": "lerna run test --scope \"maci-cli\"",
     "test:cli-ceremony": "lerna run test:ceremony --scope \"maci-cli\"",
     "test:integration": "lerna run test --scope \"maci-integrationtests\"",
-    "test": "lerna run test --ignore maci-integrationtests --ignore maci-cli",
+    "test": "lerna run test --ignore maci-integrationtests --ignore maci-cli --ignore maci-coordinator",
     "types": "lerna run types",
     "docs": "lerna run docs",
     "prepare": "is-ci || husky"


### PR DESCRIPTION
# Description

Do not run maci-coordinator tests together with unit tests on nightly CI as they require extra steps

## Related issue(s)

fix #1414 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
