### PR TITLE
fix: add uq argument in cli/index

### DIFF
--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -173,7 +173,12 @@ program
   .requiredOption("-m, --msg-tree-depth <messageTreeDepth>", "the message tree depth", parseInt)
   .requiredOption("-v, --vote-option-tree-depth <voteOptionTreeDepth>", "the vote option tree depth", parseInt)
   .requiredOption("-pk, --pubkey <coordinatorPubkey>", "the coordinator public key")
-  .option("-uq, --use-quadratic-voting", "whether to use quadratic voting", (value) => value === "true", true)
+  .option(
+    "-uq, --use-quadratic-voting <useQuadraticVoting>",
+    "whether to use quadratic voting",
+    (value) => value === "true",
+    true,
+  )
   .option("-x, --maci-address <maciAddress>", "the MACI contract address")
   .option("-q, --quiet <quiet>", "whether to print values to the console", (value) => value === "true", false)
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
@@ -511,7 +516,12 @@ program
   .option("-sb, --start-block <startBlock>", "the block number to start looking for events from", parseInt)
   .option("-eb, --end-block <endBlock>", "the block number to end looking for events from", parseInt)
   .option("-bb, --blocks-per-batch <blockPerBatch>", "the number of blocks to process per batch", parseInt)
-  .option("-uq, --use-quadratic-voting", "whether to use quadratic voting", (value) => value === "true", true)
+  .option(
+    "-uq, --use-quadratic-voting <useQuadraticVoting>",
+    "whether to use quadratic voting",
+    (value) => value === "true",
+    true,
+  )
   .action(async (cmdObj) => {
     try {
       const signer = await getSigner();


### PR DESCRIPTION
# Description

The problem is the `<useQuadraticVoting>` argument is missing for the cli commands after `-uq`, that's why `cmdObj.useQuadraticVoting` would always be false.

## Related issue(s)

close #1465 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
