### PR TITLE
feat: allow getContract without hardhat environment

### DIFF
--- a/contracts/tasks/helpers/Deployment.ts
+++ b/contracts/tasks/helpers/Deployment.ts
@@ -396,9 +396,13 @@ export class Deployment {
    * @param {IGetContractParams} params - params
    * @returns contract wrapper
    */
-  async getContract<T extends BaseContract>({ name, key, address, signer }: IGetContractParams): Promise<T> {
+  async getContract<T extends BaseContract>({ name, key, address, abi, signer }: IGetContractParams): Promise<T> {
     const deployer = signer || (await this.getDeployer());
     const contractAddress = address || this.storage.mustGetAddress(name, this.hre!.network.name, key);
+
+    if (abi) {
+      return new BaseContract(contractAddress, abi, deployer) as unknown as T;
+    }
 
     const factory = await this.hre?.ethers.getContractAt(name.toString(), contractAddress, deployer);
 

--- a/contracts/tasks/helpers/types.ts
+++ b/contracts/tasks/helpers/types.ts
@@ -1,6 +1,15 @@
 import type { AccQueue, MACI, MessageProcessor, Poll, Tally, Verifier, VkRegistry } from "../../typechain-types";
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
-import type { BaseContract, BigNumberish, Fragment, JsonFragment, Signer, ContractFactory } from "ethers";
+import type {
+  BaseContract,
+  BigNumberish,
+  Fragment,
+  JsonFragment,
+  Signer,
+  ContractFactory,
+  Interface,
+  InterfaceAbi,
+} from "ethers";
 import type { Libraries, TaskArguments } from "hardhat/types";
 import type { Poll as PollWrapper } from "maci-core";
 import type { Keypair, PrivKey } from "maci-domainobjs";
@@ -361,6 +370,11 @@ export interface IGetContractParams {
    * Contract address
    */
   address?: string;
+
+  /**
+   * Contract abi
+   */
+  abi?: Interface | InterfaceAbi;
 
   /**
    * Eth signer


### PR DESCRIPTION
# Description

Allow the `Deployment` helper to call `getContract` without hardhat environment.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
