### PR TITLE
docs: separate deployment docs and keep up to date

### DIFF
--- a/website/versioned_docs/version-v2.0_alpha/developers-references/integrating.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/integrating.md
@@ -5,228 +5,37 @@ sidebar_label: Integrating
 sidebar_position: 1
 ---
 
-# Integrating MACI
-
 MACI can be used in any protocol that requires collusion resistance, for instance it has been proven to be quite efficient when integrated in quadratic funding applications such as [clr.fund](https://github.com/clrfund/monorepo) and [qfi](https://github.com/quadratic-funding/qfi/tree/feat/code-freeze).
 
-Here we will be looking at QFI and how it was used. Please note that this will be expanded as QFI is updated to use the newest version of MACI. Should you decide to integrate MACI in the meantime, feel free to open an issue on the GitHub repo.
-
-## Deployment
-
-First, you need to deploy contracts to start using MACI. This could be done through either `maci-cli` or by using hardhat tasks in the `contracts` folder.
-
-### Via `maci-cli`
-
-This can be easily done via [`maci-cli`](/docs/developers-references/typescript-code/cli#subcommands).
-Deployment order is:
-
-1. Deploy crypto (Hasher, Poseidon)
-2. Deploy VK Registry
-3. Set verification keys
-4. Deploy VoiceCreditProxy
-5. Deploy Gatekeeper
-6. Deploy Verifier
-7. Deploy Topup credit
-8. Deploy MessageProcessorFactory, PollFactory, SubsidyFactory, TallyFactory
-9. Deploy MACI, AccQueueQuinaryMaci
-10. Deploy Poll, AccQueueQuinaryMaci, MessageProcessor, Tally and Subsidy (optional)
-
-Before running the deploy command make sure you have [zkey files](https://maci.pse.dev/docs/security/trusted-setup) from trusted setup and env variables `ETH_PROVIDER` (RPC endpoint) and `ETH_SK` (wallet private key) are set. For production environment make sure you don't use zkey files from our examples.
-
-:::note Non Quadratic Voting
-
-Make sure that if you intend to run a non quadratic voting Poll, you set the **NonQv** zKey files on the VkRegistry contract, as well as deploy the Poll with the option `--use-quadratic-voting false`. Finally, remember to use the correct zk-SNARK artifacts (zKeys, and witnesses) in the genProof/prove commands.
-
-:::
-
-```bash
-maci-cli deployVkRegistry
-maci-cli setVerifyingKeys \
-    --state-tree-depth 10 \
-    --int-state-tree-depth 1 \
-    --msg-tree-depth 2 \
-    --vote-option-tree-depth 2 \
-    --msg-batch-depth 1 \
-    --process-messages-zkey ./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey \
-    --tally-votes-zkey ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey
-maci-cli create --stateTreeDepth 10 --use-quadratic-voting true
-maci-cli deployPoll \
-    --pubkey coordinator-public-key \
-    --duration 30 \
-    --int-state-tree-depth 1 \
-    --msg-tree-depth 2 \
-    --msg-batch-depth 1 \
-    --vote-option-tree-depth 2
-```
-
-### Deploy contracts in `maci/contracts`
-
-This could also be done via running commands in `maci/contracts`. Please download the maci repository, install and build everything, then navigate to the `contracts` folder.
-
-First of all, modify the `deploy-config.json` file:
-
-```
-{
-  "choose-a-network": {
-    "ConstantInitialVoiceCreditProxy": {
-      "deploy": true,
-      "amount": 99
-    },
-    "FreeForAllGatekeeper": {
-      "deploy": false
-    },
-    "EASGatekeeper": {
-      "deploy": true,
-      "easAddress": "0xC2679fBD37d54388Ce493F1DB75320D236e1815e",
-      "schema": "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
-      "attester": "attester-address"
-    },
-    "MACI": {
-      "stateTreeDepth": 10,
-      "gatekeeper": "EASGatekeeper"
-    },
-    "VkRegistry": {
-      "stateTreeDepth": 10,
-      "intStateTreeDepth": 1,
-      "messageTreeDepth": 2,
-      "voteOptionTreeDepth": 2,
-      "messageBatchDepth": 1,
-      "zkeys": {
-        "qv": {
-          "processMessagesZkey": "../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey",
-          "tallyVotesZkey": "../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey"
-        },
-        "nonQv": {
-          "processMessagesZkey": "../cli/zkeys/ProcessMessagesNonQv_10-2-1-2_test/ProcessMessagesNonQv_10-2-1-2_test.0.zkey",
-          "tallyVotesZkey": "../cli/zkeys/TallyVotesNonQv_10-1-2_test/TallyVotesNonQv_10-1-2_test.0.zkey"
-        }
-      }
-    },
-    "Poll": {
-      "pollDuration": 30,
-      "coordinatorPubkey": "macipk.9a59264310d95cfd8eb7083aebeba221b5c26e77427f12b7c0f50bc1cc35e621",
-      "useQuadraticVoting": true
-    }
-  }
-}
-```
-
-and run the following command:
-
-```
-pnpm run deploy:[network]
-pnpm run deploy-poll:[network]
-```
-
-The network options are: **_localhost, sepolia, and optimism-sepolia_**, and the tasks flags and parameters are as follows:
-
-| Command     | Flags                                                                                                                     | Options                                               |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| deploy      | `--incremental`: incremental deployment <br/> `--strict`: fail on warning <br/> `--verify`: verify contracts on Etherscan | `--skip <index>`: Skip steps with less or equal index |
-| deploy-poll | `--incremental`: incremental deployment <br/> `--strict`: fail on warning <br/> `--verify`: verify contracts on Etherscan | `--skip <index>`: Skip steps with less or equal index |
-
-## Signups and votes
-
-Next, you can start accept user signup and votes. This can be done via `maci-cli` as well:
-
-```bash
-maci-cli signup \
-    --pubkey user-public-key
-maci-cli publish \
-    --pubkey user-public-key \
-    --privkey user-private-key \
-    --state-index 1 \
-    --vote-option-index 0 \
-    --new-vote-weight 9 \
-    --nonce 1 \
-    --poll-id 0
-```
-
-## Poll finalization
-
-As a coordinator, first you need to merge signups and messages (votes). Signups and messages are stored in a queue so when the poll in over, the coordinator needs to create the tree from the queue. This optimization is needed to reduce gas cost for voters. Then coordinator generates proofs for the message processing, and tally calculations. This allows to publish the poll results on-chain and then everyone can verify the results when the poll is over.
-
-This could also be done by `maci-cli` or run commands in `contracts` folder.
-
-### Via `maci-cli`
-
-```bash
-maci-cli mergeSignups --poll-id 0
-maci-cli mergeMessages --poll-id 0
-maci-cli genProofs \
-    --privkey coordinator-private-key \
-    --poll-id 0 \
-    --process-zkey ./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey \
-    --tally-zkey ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey \
-    --tally-file tally.json \
-    --output proofs/ \
-    --tally-wasm ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test_js/TallyVotes_10-1-2_test.wasm \
-    --process-wasm ./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test_js/ProcessMessages_10-2-1-2_test.wasm \
-    --wasm
-maci-cli proveOnChain \
-    --poll-id 0 \
-    --proof-dir proofs/ \
-maci-cli verify \
-    --poll-id 0 \
-    --tally-file tally.json # this file is generated in genProofs
-```
-
-### Finalize in `maci/contracts`
-
-```
-pnpm merge:[network] --poll 0
-pnpm run prove:[network] --poll 0 \
-    --coordinator-private-key "macisk.1751146b59d32e3c0d7426de411218172428263f93b2fc4d981c036047a4d8c0" \
-    --process-zkey ../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey \
-    --tally-zkey ../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey \
-    --tally-file ../cli/tally.json \
-    --output-dir ../cli/proofs/ \
-    --tally-wasm ../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test_js/TallyVotes_10-1-2_test.wasm \
-    --process-wasm ../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test_js/ProcessMessages_10-2-1-2_test.wasm
-```
-
-The network options are: **_localhost, sepolia, and optimism-sepolia_**, and the tasks flags and parameters are as follows:
-
-| Command | Flags                                                            | Options                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| merge   |                                                                  | `--poll <pollId>`: the poll id <br/> `--queue-ops <queueOps>`: The number of queue operations to perform <br/> `--prove <prove>`: Run prove command after merging or not                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| prove   | `--use-quadratic-voting`: Whether to use quadratic voting or not | `--poll <pollId>`: the poll id <br/> `--output-dir <outputDir>`: Output directory for proofs <br /> `--coordinator-private-key <coordinatorPrivateKey>`: Coordinator maci private key <br /> `--rapid-snark <rapidSnark>`: Rapidsnark binary path <br /> `--process-zkey <processKey>`: Process zkey file path <br /> `--process-witgen <processWitgen>`: Process witgen binary path <br /> `--process-wasm <processWasm>`: Process wasm file path <br /> `--tally-file <tallyFile>`: The file to store the tally proof <br /> `--tally-zkey <tallyZkey>`: Tally zkey file path <br /> `--tally-witgen <tallyWitgen>`: Tally witgen binary path <br /> `--tally-wasm <tallyWasm>`: Tally wasm file path <br /> `--state-file <stateFile>`: The file with the serialized maci state <br /> `--start-block <startBlock>`: The block number to start fetching logs from <br /> `--blocks-per-batch <blocksPerBatch>`: The number of blocks to fetch logs from <br /> `--end-block <endBlock>`: The block number to stop fetching logs from <br /> `--transaction-hash <transactionHash>`: The transaction hash of the first transaction |
+Here we will be looking at how the smart contracts can be integrated. Please note that this will be expanded as QFI is updated to use the newest version of MACI. Should you decide to integrate MACI in the meantime, feel free to open an issue on the GitHub repo.
 
 ## MACI Contract
 
-The MACI contract is the core of the protocol. Contracts can inherit from MACI and thus expose the signup and topup functions. As with standalone MACI, one would need to deploy a [sign up gatekeeper](/docs/developers-references/smart-contracts/Gatekeepers) as well as the [voice credit proxy](/docs/developers-references/smart-contracts/VoiceCreditProxy).
+The MACI contract is the core of the protocol. Contracts can inherit from MACI and thus expose the `signUp` and `deployPoll` functions. As with standalone MACI, one would need to deploy a [sign up gatekeeper](/docs/developers-references/smart-contracts/Gatekeepers) as well as the [voice credit proxy](/docs/developers-references/smart-contracts/VoiceCreditProxy).
 
-As an example, within the quadratic funding infrastructure project, the QFI contract inherits from MACI and allows sign up via the contribute function.
+As an example, a [contract](https://github.com/ctrlc03/minimalQF/blob/main/contracts/MinimalQf.sol#L113) could inherit from MACI and allows sign up via a custom signup function.
 
 ```javascript
-function contribute(
-    PubKey calldata pubKey,
-    uint256 amount
-    ) external {
+function signUp(
+    PubKey memory _pubKey,
+    bytes memory _signUpGatekeeperData,
+    bytes memory _initialVoiceCreditProxyData
+) public override {
+  // the amount must be set in the initial voice credit proxy data
+  uint256 amount = abi.decode(_initialVoiceCreditProxyData, (uint256));
 
-    [..snip]
+  // transfer tokens to this contract
+  nativeToken.safeTransferFrom(msg.sender, address(this), amount);
 
-    uint256 voiceCredits = amount / voiceCreditFactor;
-    // The user is marked as registered here upon contribution
-    grantRoundToContributors[nextGrantRoundId][msg.sender] = ContributorStatus(voiceCredits, true);
+  // the voice credits will be the amount divided by the factor
+  // the factor should be decimals of the token
+  // normal signup
+  super.signUp(_pubKey, _signUpGatekeeperData, _initialVoiceCreditProxyData);
 
-    // Increase the number of contributors for this round
-    grantRoundToContributorsCount[nextGrantRoundId]++;
-
-    bytes memory signUpGatekeeperAndInitialVoiceCreditProxyData = abi.encode(
-        msg.sender,
-        voiceCredits
-    );
-
-    signUp(
-        pubKey,
-        signUpGatekeeperAndInitialVoiceCreditProxyData,
-        signUpGatekeeperAndInitialVoiceCreditProxyData
-    );
-
-    [..snip]
-
-    emit ContributionSent(msg.sender, amount);
+  // store the address of the user signing up and amount so they can be refunded just in case
+  // the round is cancelled
+  // they will be able to vote from different addresses though
+  contributors[msg.sender] = amount;
 }
 ```
 
@@ -234,15 +43,7 @@ function contribute(
 
 If you'd like to extend the functionality of how votes are distributed among users, you need to extend [InitialVoiceCreditProxy](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/initialVoiceCreditProxy/InitialVoiceCreditProxy.sol) contract. You can see our [basic example](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/initialVoiceCreditProxy/ConstantInitialVoiceCreditProxy.sol) how it's implemented for constant distribution.
 
-```javascript
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.10;
-
-import { InitialVoiceCreditProxy } from "./InitialVoiceCreditProxy.sol";
-
-/// @title ConstantInitialVoiceCreditProxy
-/// @notice This contract allows to set a constant initial voice credit balance
-/// for MACI's voters.
+```ts
 contract ConstantInitialVoiceCreditProxy is InitialVoiceCreditProxy {
   /// @notice the balance to be returned by getVoiceCredits
   uint256 internal balance;
@@ -263,26 +64,10 @@ contract ConstantInitialVoiceCreditProxy is InitialVoiceCreditProxy {
 
 ## Poll Contract
 
-On the other hand, the Poll contract can be inherited to expose functionality such as top ups and publishing of messages/commands.
+On the other hand, the Poll contract can be inherited to expose functionality such as publishing of messages/commands.
 
-For instance, within QFI, the `publishMessageBatch` function call the `publishMessage` function of Poll, as shown below:
+For instance, should it be required to gatekeep who can send a message, overriding the `publishMessage` function could be the best way to go.
 
-```javascript
-function publishMessageBatch(
-    Message[] calldata _messages,
-    PubKey[] calldata _encPubKeys
-) external {
-    // Check that the two arrays have the same length
-    require(
-        _messages.length == _encPubKeys.length,
-        "GrantRound: _messages and _encPubKeys should be the same length"
-    );
+## Tally Contract
 
-    uint256 batchSize = _messages.length;
-    for (uint8 i = 0; i < batchSize; ++i) {
-        publishMessage(_messages[i], _encPubKeys[i]);
-    }
-
-    emit Voted(msg.sender);
-}
-```
+Given the verification functions being exposed by the Tally contract, quadratic funding protocols might require to extend the Tally contract to add distribution logic. Looking at this [example](https://github.com/ctrlc03/minimalQF/blob/main/contracts/MinimalQFTally.sol#L114) the `claimFunds` function is added to a contract inheriting from `Tally`, and uses functions such as `verifyPerVOSpentVoiceCredits` to distribute funds to projects part of a quadratic funding round.

--- a/website/versioned_docs/version-v2.0_alpha/quick-start/deployment.md
+++ b/website/versioned_docs/version-v2.0_alpha/quick-start/deployment.md
@@ -12,9 +12,13 @@ Currently, it is possible to deploy MACI contracts in two ways:
 - using the cli (`maci-cli`)
 - using the hardhat tasks inside the `maci-contracts` package
 
+:::info
+We recommend to use the hardhat tasks inside the `maci-contracts` folder, due to their semplicity and customizability.
+:::
+
 ## MACI Deployment Steps
 
-In order, these are the steps for contract deployment:
+In order, these are the steps for a full MACI deployment:
 
 1. Deploy crypto (Hasher, Poseidon)
 2. Deploy VK Registry
@@ -22,16 +26,95 @@ In order, these are the steps for contract deployment:
 4. Deploy VoiceCreditProxy
 5. Deploy Gatekeeper
 6. Deploy Verifier
-7. Deploy Topup credit
-8. Deploy MessageProcessorFactory, PollFactory, SubsidyFactory, TallyFactory
-9. Deploy MACI, AccQueueQuinaryMaci
-10. Deploy Poll, AccQueueQuinaryMaci, MessageProcessor, Tally and Subsidy (optional)
+7. Deploy MessageProcessorFactory, PollFactory, TallyFactory
+8. Deploy MACI
+9. Deploy Poll, AccQueueQuinaryMaci, MessageProcessor and Tally
 
 ### Note on ZKey artifacts
 
 For testing purposes, you can use the test zkeys and artifacts that you can download using `pnpm download:test-zkeys`. For production use, you can download the most recent artifacts that have undergone a trusted setup. Please refer to the [Trusted Setup](/docs/security/trusted-setup) section for more information. To download those, please use `pnpm download:ceremony-zkeys`.
 
 Please do not use test artifacts in production. If you do require zKeys configured for larger param sizes, please reach out to us if you will be using them in production and we'll discuss running a new ceremony for those parameters. To build new circuits artifacts for testing purposes, please refer to the [installation page](/docs/quick-start/installation#configure-circomkit) and to the [circuits](/docs/developers-references/zk-snark-circuits/circuits) section.
+
+### Deployment using `maci-contracts` hardhat tasks
+
+1. Take the `deploy-config-example.json` file and copy it over to `deploy-config.json`
+2. Update the fields as necessary:
+
+```json
+{
+  "localhost": {
+    "ConstantInitialVoiceCreditProxy": {
+      "deploy": true,
+      "amount": 99
+    },
+    "FreeForAllGatekeeper": {
+      "deploy": false
+    },
+    "EASGatekeeper": {
+      "deploy": true,
+      "easAddress": "0xC2679fBD37d54388Ce493F1DB75320D236e1815e",
+      "schema": "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+      "attester": "0xa73C483623C0EA0A8AA11AD696a29622ba381555"
+    },
+    "GitcoinPassportGatekeeper": {
+      "deploy": false,
+      "decoderAddress": "0xe53C60F8069C2f0c3a84F9B3DB5cf56f3100ba56",
+      "passingScore": 5
+    },
+    "MACI": {
+      "stateTreeDepth": 10,
+      "gatekeeper": "EASGatekeeper"
+    },
+    "VkRegistry": {
+      "stateTreeDepth": 10,
+      "intStateTreeDepth": 1,
+      "messageTreeDepth": 2,
+      "voteOptionTreeDepth": 2,
+      "messageBatchDepth": 1,
+      "zkeys": {
+        "qv": {
+          "processMessagesZkey": "../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey",
+          "tallyVotesZkey": "../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey"
+        },
+        "nonQv": {
+          "processMessagesZkey": "../cli/zkeys/ProcessMessagesNonQv_10-2-1-2_test/ProcessMessagesNonQv_10-2-1-2_test.0.zkey",
+          "tallyVotesZkey": "../cli/zkeys/TallyVotesNonQv_10-1-2_test/TallyVotesNonQv_10-1-2_test.0.zkey"
+        }
+      }
+    },
+    "Poll": {
+      "pollDuration": 30000,
+      "coordinatorPubkey": "macipk.8c7d230547b3ccd75610b2db934ee7e1ea0a01db679e2cfcabe535234f046a18",
+      "useQuadraticVoting": true
+    }
+  }
+}
+```
+
+3. Fill the `.env` file with the appropriate data (you will find an example in the `.env.example` file):
+   - your mnemonic
+   - an RPC key
+4. Run `pnpm deploy` to deploy the contracts (you can specify the network by appending `:network` to the command, e.g. `pnpm deploy:sepolia` - please refer to the available networks on the `package.json` scripts section)
+
+The network options are: **_localhost, sepolia, and optimism-sepolia_**, and the tasks flags and parameters are as follows:
+
+| Command     | Flags                                                                                                                     | Options                                               |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| deploy      | `--incremental`: incremental deployment <br/> `--strict`: fail on warning <br/> `--verify`: verify contracts on Etherscan | `--skip <index>`: Skip steps with less or equal index |
+| deploy-poll | `--incremental`: incremental deployment <br/> `--strict`: fail on warning <br/> `--verify`: verify contracts on Etherscan | `--skip <index>`: Skip steps with less or equal index |
+
+5. Run `pnpm deploy-poll` to deploy your first Poll (you can specify the network by appending `:network` to the command, e.g. `pnpm deploy-poll:sepolia` - please refer to the available networks on the `package.json` scripts section)
+
+:::info
+Should you wish to deploy on a different network, you will need to update the [contracts/tasks/helpers/constants.ts](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/tasks/helpers/constants.ts) file.
+:::
+
+6. You will find all of the deployed contracts addresses and configs in the `deployed-contracts.json` file inside the contracts folder.
+
+:::info
+You can find more information on integration and usage in the [Integrating MACI](/docs/developers-references/integrating) section.
+:::
 
 ### Deployment using `maci-cli`
 
@@ -44,77 +127,20 @@ maci-cli setVerifyingKeys \
     --vote-option-tree-depth 2 \
     --msg-batch-depth 1 \
     --process-messages-zkey ./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey \
-    --tally-votes-zkey ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey
-maci-cli create --stateTreeDepth 10 --use-quadratic-voting true
+    --tally-votes-zkey ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey \
+    --useQuadraticVoting true
+maci-cli create --stateTreeDepth 10
 maci-cli deployPoll \
     --pubkey coordinator-public-key \
     --duration 300 \
     --int-state-tree-depth 1 \
     --msg-tree-depth 2 \
     --msg-batch-depth 1 \
-    --vote-option-tree-depth 2
+    --vote-option-tree-depth 2 \
+    --useQuadraticVoting true
 ```
 
 :::info
-For quadratic voting polls, you can use the `--use-quadratic-voting true` flag when creating the MACI instance.
-For non-quadratic voting polls, you can use the `--use-quadratic-voting false` flag when creating the MACI instance.
-:::
-
-### Deployment using `maci-contracts` hardhat tasks
-
-1. Take the `deploy-config-example.json` file and copy it over to `deploy-config.json`
-2. Update the fields as necessary:
-
-```json
-{
-  "sepolia": {
-    "ConstantInitialVoiceCreditProxy": {
-      "deploy": true,
-      "amount": 99
-    },
-    "FreeForAllGatekeeper": {
-      "deploy": false
-    },
-    "EASGatekeeper": {
-      "deploy": true,
-      "easAddress": "0xC2679fBD37d54388Ce493F1DB75320D236e1815e",
-      "schema": "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
-      "attester": "attester-address"
-    },
-    "MACI": {
-      "stateTreeDepth": 10,
-      "gatekeeper": "EASGatekeeper"
-    },
-    "VkRegistry": {
-      "stateTreeDepth": 10,
-      "intStateTreeDepth": 1,
-      "messageTreeDepth": 2,
-      "voteOptionTreeDepth": 2,
-      "messageBatchDepth": 1,
-      "processMessagesZkey": "../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey",
-      "tallyVotesZkey": "../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey"
-    },
-    "Poll": {
-      "pollDuration": 30,
-      "coordinatorPubkey": "macipk.ea638a3366ed91f2e955110888573861f7c0fc0bb5fb8b8dca9cd7a08d7d6b93",
-      "useQuadraticVoting": true
-    }
-  }
-}
-```
-
-3. Fill the `.env` file with the appropriate data (you will find an example in the `.env.example` file:
-   - your mnemonic
-   - an RPC key
-4. Run `pnpm deploy` to deploy the contracts (you can specify the network by appending `:network` to the command, e.g. `pnpm deploy:sepolia` - please refer to the available networks on the `package.json` scripts section)
-5. Run `pnpm deploy-poll` to deploy your first Poll (you can specify the network by appending `:network` to the command, e.g. `pnpm deploy-poll:sepolia` - please refer to the available networks on the `package.json` scripts section)
-
-:::info
-Should you wish to deploy on a different network, you will need to update the [contracts/tasks/helpers/constants.ts](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/tasks/helpers/constants.ts) file.
-:::
-
-6. You will find all of the deployed contracts addresses and configs in the `deployed-contracts.json` file inside the contracts folder.
-
-:::info
-You can find more information on integration and usage in the [Integrating MACI](/docs/developers-references/integrating) section.
+For quadratic voting polls, you can use the `--use-quadratic-voting true` flag when deploying a Poll.
+For non-quadratic voting polls, you can use the `--use-quadratic-voting false` flag when deploying a Poll.
 :::

--- a/website/versioned_docs/version-v2.0_alpha/quick-start/poll-finalization.md
+++ b/website/versioned_docs/version-v2.0_alpha/quick-start/poll-finalization.md
@@ -1,0 +1,144 @@
+---
+title: Poll Finalization
+description: How to finalize a MACI Poll
+sidebar_label: Poll Finalization
+sidebar_position: 4
+---
+
+As a coordinator, first you need to merge signups and messages (votes). Messages are stored in a queue so when the poll is over, the coordinator needs to create the tree from the queue ([AccQueue](/docs/core-concepts/merkle-trees#accumulator-queue)). This optimization is needed to reduce gas cost for voters. Then coordinator generates proofs for the message processing, and tally calculations. This allows to publish the poll results on-chain and then everyone can verify the results when the poll is over.
+
+This could be done using `maci-cli` or by running commands in the `contracts` folder.
+
+## Via `maci-cli`
+
+```bash
+maci-cli mergeSignups --poll-id 0
+maci-cli mergeMessages --poll-id 0
+maci-cli genProofs \
+    --privkey coordinator-private-key \
+    --poll-id 0 \
+    --process-zkey ./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey \
+    --tally-zkey ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey \
+    --tally-file tally.json \
+    --output proofs/ \
+    --tally-wasm ./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test_js/TallyVotes_10-1-2_test.wasm \
+    --process-wasm ./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test_js/ProcessMessages_10-2-1-2_test.wasm \
+    --wasm \
+    --useQuadraticVoting true
+maci-cli proveOnChain \
+    --poll-id 0 \
+    --proof-dir proofs/
+maci-cli verify \
+    --poll-id 0 \
+    --tally-file tally.json # this file is generated in genProofs
+```
+
+## Finalize in `maci/contracts`
+
+```bash
+pnpm merge:[network] --poll 0
+pnpm run prove:[network] --poll 0 \
+    --coordinator-private-key "macisk.1751146b59d32e3c0d7426de411218172428263f93b2fc4d981c036047a4d8c0" \
+    --process-zkey ../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey \
+    --tally-zkey ../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey \
+    --tally-file ../cli/tally.json \
+    --output-dir ../cli/proofs/ \
+    --tally-wasm ../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test_js/TallyVotes_10-1-2_test.wasm \
+    --process-wasm ../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test_js/ProcessMessages_10-2-1-2_test.wasm
+```
+
+The network options are: **_localhost, sepolia, and optimism-sepolia_**, and the tasks flags and parameters are as follows:
+
+| Command | Flags                                                            | Options                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| merge   |                                                                  | `--poll <pollId>`: the poll id <br/> `--queue-ops <queueOps>`: The number of queue operations to perform <br/> `--prove <prove>`: Run prove command after merging or not                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| prove   | `--use-quadratic-voting`: Whether to use quadratic voting or not | `--poll <pollId>`: the poll id <br/> `--output-dir <outputDir>`: Output directory for proofs <br /> `--coordinator-private-key <coordinatorPrivateKey>`: Coordinator maci private key <br /> `--rapid-snark <rapidSnark>`: Rapidsnark binary path <br /> `--process-zkey <processKey>`: Process zkey file path <br /> `--process-witgen <processWitgen>`: Process witgen binary path <br /> `--process-wasm <processWasm>`: Process wasm file path <br /> `--tally-file <tallyFile>`: The file to store the tally proof <br /> `--tally-zkey <tallyZkey>`: Tally zkey file path <br /> `--tally-witgen <tallyWitgen>`: Tally witgen binary path <br /> `--tally-wasm <tallyWasm>`: Tally wasm file path <br /> `--state-file <stateFile>`: The file with the serialized maci state <br /> `--start-block <startBlock>`: The block number to start fetching logs from <br /> `--blocks-per-batch <blocksPerBatch>`: The number of blocks to fetch logs from <br /> `--end-block <endBlock>`: The block number to stop fetching logs from <br /> `--transaction-hash <transactionHash>`: The transaction hash of the first transaction |
+
+## Tally
+
+After proofs are generated, and results tallied, the results (Tally) is written to a file. This file contains the result of a Poll. Let's take a look at one:
+
+```json
+{
+  "maci": "0xd54b47F8e6A1b97F3A84f63c867286272b273b7C",
+  "pollId": "0",
+  "network": "localhost",
+  "chainId": "31337",
+  "isQuadratic": true,
+  "tallyAddress": "0xD4fbAF1dFe100d07f8Ef73d8c92e93d0Bcf7b45D",
+  "newTallyCommitment": "0x2f55cc85f7f141098ba791a9f6a646f8773b9bb4f5852ccc33b5a28e7b0756e5",
+  "results": {
+    "tally": [
+      "9",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0"
+    ],
+    "salt": "0x2e9cd240b86cf456fa4deced8e7420c45e3c16941d2dcec308f8b6d48264dda3",
+    "commitment": "0x296eac2a7289974f23497bebd39e86599d0b7032796fb84dcc1f6bbda38262ca"
+  },
+  "totalSpentVoiceCredits": {
+    "spent": "81",
+    "salt": "0x24f57b75c227987727c13d1e83409d70478b42bdc12a4a4df8129c72fbaf5aaf",
+    "commitment": "0xb4ebe68b0da828c0b978ddee86ba934b8e215499ac766491f236ad85fd606de"
+  },
+  "perVOSpentVoiceCredits": {
+    "tally": [
+      "81",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0"
+    ],
+    "salt": "0x2590434ea2d600f7bd2396ba7fa454ad4c975c29424ee481561d9786538a5e48",
+    "commitment": "0x54ec996599886da21c4b07c25d1de544292a8b7c38b79726995c869c9e95db"
+  }
+}
+```
+
+We see that there is an array named results, this contains the aggregated votes for each option, where each option is represented by an index in the array. In this case above, the first option (index 0) received a total of 9 votes, where every other option did not receive any votes.
+
+The `totalSpentVoiceCredits` object contains the total amount of voice credits spent in the poll. This is the sum of all voice credits spent by all voters, and in quadratic voting, is the sum of the squares of all votes.
+
+The `perVOSpentVoiceCredits` will contain the amount of voice credits spent per vote option. In this case, the first option received 81 voice credits, and every other option received 0 voice credits. This is because there was only one valid vote casted, with a weight of 9. Given the quadratic voting formula, the total amount of voice credits spent is 81.

--- a/website/versioned_docs/version-v2.0_alpha/quick-start/troubleshooting.md
+++ b/website/versioned_docs/version-v2.0_alpha/quick-start/troubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshooting
 description: How to troubleshoot MACI's failures
 sidebar_label: Troubleshooting
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Troubleshooting


### PR DESCRIPTION
# Description

Separate deployment docs, add poll finalization and keep up to date.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
