### PR TITLE
docs: cleanup docs and re organize order

### DIFF
--- a/website/blog/2024-04-10-roadmap-q2.md
+++ b/website/blog/2024-04-10-roadmap-q2.md
@@ -56,7 +56,7 @@ This quarter we're excited to keep building out MACI-RPGF with additional functi
 
 From [years of supporting QF rounds on MACI](https://qf.pse.dev/case-studies) we've learned a lot about the pain-points of community organizers. The blunt truth is that many technical barriers still exist - in order to operate a MACI poll (whether in a QF round or a simple voting application), you essentially must be a developer to deploy the smart contracts, execute on-chain transactions, and run tooling to generate zero-knowledge proofs to guarantee the integrity of a MACI poll. This is no trivial feat, and as a result, MACI is simply not a viable option for many communities to use today.
 
-We're aiming to change this by building a "Coordinator Service" to simplify the [role of the coordinator](/docs/quick-start/workflow#coordinator), automate tasks, and remove technical barriers to running MACI-RPGF (and all MACI) rounds. This will include a web interface to deploy and operate MACI instances as well as a server to generate proofs and submit them on-chain. We're confident this tooling will accelerate community adoption by offloading the technical overhead and domain knowledge currently required to use this technology stack. More details to come on this soon!
+We're aiming to change this by building a "Coordinator Service" to simplify the [role of the coordinator](/docs/overview/workflow#coordinator), automate tasks, and remove technical barriers to running MACI-RPGF (and all MACI) rounds. This will include a web interface to deploy and operate MACI instances as well as a server to generate proofs and submit them on-chain. We're confident this tooling will accelerate community adoption by offloading the technical overhead and domain knowledge currently required to use this technology stack. More details to come on this soon!
 
 ### 🎯 MACI Core Protocol Improvements
 
@@ -66,7 +66,7 @@ Currently, we have a couple of focus areas:
 
 **Unconditional Privacy**
 
-As of now, MACI's [coordinator](/docs/quick-start/workflow#coordinator) can track [user key changes](/docs/core-concepts/key-change), which allows them to associate voters with their respective votes, and thus potentially collude with bribers to deanonymize users. We're investigating ways to prevent this possibility. The [3227](https://3327.io/) team implemented a [proof of concept](https://github.com/privacy-scaling-explorations/maci/issues/796) using El-Gamal to remove the link between a new MACI key and their original key. Furthermore, there is a proposal under discussion on how to implement anonymous poll signups, which would provide the same benefits of the El-Gamal protocol, though with a much better user experience.
+As of now, MACI's [coordinator](/docs/overview/workflow#coordinator) can track [user key changes](/docs/core-concepts/key-change), which allows them to associate voters with their respective votes, and thus potentially collude with bribers to deanonymize users. We're investigating ways to prevent this possibility. The [3227](https://3327.io/) team implemented a [proof of concept](https://github.com/privacy-scaling-explorations/maci/issues/796) using El-Gamal to remove the link between a new MACI key and their original key. Furthermore, there is a proposal under discussion on how to implement anonymous poll signups, which would provide the same benefits of the El-Gamal protocol, though with a much better user experience.
 
 **Deployment Improvements**
 

--- a/website/versioned_docs/version-v2.0_alpha/core-concepts/_category_.json
+++ b/website/versioned_docs/version-v2.0_alpha/core-concepts/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Core Concepts",
-  "position": 4,
+  "position": 3,
   "link": {
     "type": "generated-index",
     "description": "Understand MACI's core concepts."

--- a/website/versioned_docs/version-v2.0_alpha/core-concepts/ballot.md
+++ b/website/versioned_docs/version-v2.0_alpha/core-concepts/ballot.md
@@ -1,7 +1,7 @@
 ---
-title: MACI Ballot
+title: Ballot
 description: A short introduction of the main primitives used by MACI
-sidebar_label: MACI Ballot
+sidebar_label: Ballot
 sidebar_position: 4
 ---
 

--- a/website/versioned_docs/version-v2.0_alpha/core-concepts/key-change.md
+++ b/website/versioned_docs/version-v2.0_alpha/core-concepts/key-change.md
@@ -1,5 +1,5 @@
 ---
-title: MACI key change
+title: Key change
 description: How key change messages work
 sidebar_label: Key change
 sidebar_position: 8

--- a/website/versioned_docs/version-v2.0_alpha/core-concepts/maci-messages.md
+++ b/website/versioned_docs/version-v2.0_alpha/core-concepts/maci-messages.md
@@ -1,7 +1,7 @@
 ---
-title: MACI Commands and Messages
+title: Commands and Messages
 description: A short introduction of MACI's commands and messages
-sidebar_label: MACI Commands and Messages
+sidebar_label: Commands and Messages
 sidebar_position: 3
 ---
 

--- a/website/versioned_docs/version-v2.0_alpha/core-concepts/poll-types.md
+++ b/website/versioned_docs/version-v2.0_alpha/core-concepts/poll-types.md
@@ -1,7 +1,7 @@
 ---
-title: MACI Poll Types
+title: Poll Types
 description: Which type of polls you can run on MACI
-sidebar_label: MACI poll types
+sidebar_label: Poll types
 sidebar_position: 9
 ---
 

--- a/website/versioned_docs/version-v2.0_alpha/core-concepts/state-leaf.md
+++ b/website/versioned_docs/version-v2.0_alpha/core-concepts/state-leaf.md
@@ -1,7 +1,7 @@
 ---
-title: MACI StateLeaf
+title: StateLeaf
 description: A short introduction of the main primitives used by MACI
-sidebar_label: MACI StateLeaf
+sidebar_label: StateLeaf
 sidebar_position: 6
 ---
 

--- a/website/versioned_docs/version-v2.0_alpha/overview/resources.md
+++ b/website/versioned_docs/version-v2.0_alpha/overview/resources.md
@@ -1,7 +1,7 @@
 ---
-title: MACI resources
+title: Resources
 description: A collection of resources for better understanding MACI
-sidebar_label: MACI resources
+sidebar_label: Resources
 sidebar_position: 3
 ---
 

--- a/website/versioned_docs/version-v2.0_alpha/overview/workflow.md
+++ b/website/versioned_docs/version-v2.0_alpha/overview/workflow.md
@@ -2,7 +2,7 @@
 title: MACI Workflow
 description: Overview of the MACI workflow
 sidebar_label: Workflow
-sidebar_position: 2
+sidebar_position: 4
 ---
 
 <!-- TODO: create flowcharts, similar to Kyle's (but make light/dark mode compatible) -->

--- a/website/versioned_docs/version-v2.0_alpha/quick-start/_category_.json
+++ b/website/versioned_docs/version-v2.0_alpha/quick-start/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Quick Start",
-  "position": 3,
+  "position": 4,
   "link": {
     "type": "generated-index",
     "description": "Check out how to get started using MACI."

--- a/website/versioned_docs/version-v2.0_alpha/quick-start/deployment.md
+++ b/website/versioned_docs/version-v2.0_alpha/quick-start/deployment.md
@@ -1,11 +1,9 @@
 ---
-title: MACI Deployment
+title: Deployment
 description: MACI Smart Contracts deployment
-sidebar_label: MACI deployment
+sidebar_label: Deployment
 sidebar_position: 3
 ---
-
-# MACI Deployment
 
 Currently, it is possible to deploy MACI contracts in two ways:
 
@@ -16,7 +14,7 @@ Currently, it is possible to deploy MACI contracts in two ways:
 We recommend to use the hardhat tasks inside the `maci-contracts` folder, due to their semplicity and customizability.
 :::
 
-## MACI Deployment Steps
+## Deployment Steps
 
 In order, these are the steps for a full MACI deployment:
 


### PR DESCRIPTION
# Description

Remove redundant MACI word from everywhere,  and organise order

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
