### PR TITLE
feat: store deployment transaction hash

### DIFF
--- a/contracts/tasks/helpers/ContractStorage.ts
+++ b/contracts/tasks/helpers/ContractStorage.ts
@@ -87,6 +87,7 @@ export class ContractStorage {
 
     const logEntry: IStorageInstanceEntry = {
       id,
+      deploymentTxHash: deploymentTx?.hash,
     };
 
     if (args !== undefined) {
@@ -175,6 +176,20 @@ export class ContractStorage {
     }
 
     return address;
+  }
+
+  /**
+   * Get Contract Deployment Transaction Hash
+   */
+  getDeploymentTxHash(id: EContracts, network: string, address: string): string | undefined {
+    const collection = this.db.get(`${network}.instance.${address}`);
+    const instanceEntry = collection.value() as IStorageInstanceEntry | undefined;
+
+    if (instanceEntry?.id !== id) {
+      throw new Error(`Contract ${id} with address ${address} and network ${network} not found.`);
+    }
+
+    return instanceEntry.deploymentTxHash;
   }
 
   /**

--- a/contracts/tasks/helpers/types.ts
+++ b/contracts/tasks/helpers/types.ts
@@ -432,6 +432,11 @@ export interface IStorageInstanceEntry {
   id: string;
 
   /**
+   * Deployment Transaction Hash
+   */
+  deploymentTxHash?: string;
+
+  /**
    * Params for verification
    */
   verify?: {


### PR DESCRIPTION
# Description

want to: get deployment transaction information

how?
1. store transaction hash of deployment transaction in the ContractStorage.
2. add a function `getDeploymentTxHash` for user to get the transaction hash to get the complete information of that transaction.

## Related issue(s)

https://github.com/privacy-scaling-explorations/maci-rpgf/issues/115

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
