### PR TITLE
feat: GH Actions workflow to support coordinator auto-deployment to Fargate

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+cp coordinator/.env.example coordinator/.env
+
+sed -i "s|^\(COORDINATOR_RPC_URL=\).*|\1$1|" coordinator/.env
+sed -i "s|^\(COORDINATOR_ADDRESS=\).*|\1$2|" coordinator/.env
+sed -i "s|^\(COORDINATOR_ALLOWED_ORIGIN=\).*|\1$3|" coordinator/.env
+
+aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 490752553772.dkr.ecr.eu-central-1.amazonaws.com
+
+docker build -t maci-coordinator -f coordinator/apps/Dockerfile .
+docker tag maci-coordinator:latest 490752553772.dkr.ecr.eu-central-1.amazonaws.com/maci-coordinator:latest
+docker push 490752553772.dkr.ecr.eu-central-1.amazonaws.com/maci-coordinator:latest
+
+exit 0

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+tasks="maci-coordinator"
+for task in $tasks; do
+  maci_coordinator_revision=$(aws ecs describe-task-definition --task-definition $task --query "taskDefinition.revision")
+  aws ecs update-service --cluster maci-coordinator --service $task --force-new-deployment --task-definition $task:$maci_coordinator_revision
+done
+
+for loop in {1..3}; do
+  [ "$loop" -eq 3 ] && exit 1
+  aws ecs wait services-stable --cluster maci-coordinator --services $tasks && break || continue
+done

--- a/.github/workflows/coordinator-deploy.yml
+++ b/.github/workflows/coordinator-deploy.yml
@@ -1,0 +1,37 @@
+name: CoordinatorDeploy
+on:
+  push:
+    branches:
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::490752553772:role/maci-coordinator-ecs-deploy-slc
+          role-duration-seconds: 2700
+          aws-region: eu-central-1
+
+      - name: Build and Push images to ECR
+        run: |
+          .github/scripts/build.sh ${{ secrets.COORDINATOR_RPC_URL }} ${{ secrets.COORDINATOR_ADDRESS }} ${{ secrets.COORDINATOR_ALLOWED_ORIGIN }}
+
+      - name: Create Deployment
+        run: |
+          .github/scripts/deploy.sh

--- a/coordinator/apps/Dockerfile
+++ b/coordinator/apps/Dockerfile
@@ -1,0 +1,33 @@
+# Copy source code and build the project
+FROM node:20-alpine as builder
+
+WORKDIR /builder
+
+COPY . .
+
+RUN npm i -g pnpm@8
+RUN pnpm install --frozen-lockfile --prefer-offline
+RUN pnpm run build
+
+# Create image by copying build artifacts
+FROM node:20-alpine as runner
+RUN npm i -g pnpm@8
+
+RUN mkdir -p ~/rapidsnark/build; \
+    wget -qO ~/rapidsnark/build/prover https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/rapidsnark-linux-amd64-1c137; \
+    chmod +x ~/rapidsnark/build/prover
+RUN wget -qO ~/circom https://github.com/iden3/circom/releases/download/v2.1.6/circom-linux-amd64; \
+    chmod +x ~/circom; \
+    mv ~/circom /bin
+
+USER node
+ARG PORT=3000
+
+WORKDIR ./maci
+COPY --chown=node:node  --from=builder /builder/ ./
+WORKDIR /maci/coordinator
+RUN pnpm run download-zkeys:test
+RUN pnpm run generate-keypair
+
+EXPOSE ${PORT}
+CMD ["node", "build/ts/main.js"]


### PR DESCRIPTION
# Description

With this PR, a new GH Actions workflow is introduced to enable coordinator auto deployment to a dedicated AWS Fargate cluster, each time there is a push to the dev branch.

The workflow execution triggers the following events:
- Authentication against AWS using short lived credentials to specific cloud resources
- Docker image build
- Image upload to AWS Repository (ECR)
- Update ECS cluster deployment with the latest image

The endpoint can be reached at: http://maci-coordinator.pse.dev:8545

## Confirmation

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [X] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).