### PR TITLE
fix(circuits): ensure we check index < numSignups

### DIFF
--- a/circuits/circom/utils/non-qv/messageValidator.circom
+++ b/circuits/circom/utils/non-qv/messageValidator.circom
@@ -48,10 +48,10 @@ template MessageValidatorNonQv() {
     signal output isValid;
 
     // Check (1) - The state leaf index must be valid.
-    // The check ensure that the stateTreeIndex <= numSignUps as first validation.
-    // Must be <= because the stateTreeIndex is 1-based. Zero is for blank state leaf
-    // while 1 is for the first actual user matching the numSignUps start.
-    var computedIsStateLeafIndexValid = SafeLessEqThan(252)([stateTreeIndex, numSignUps]);
+    // The check ensure that the stateTreeIndex < numSignUps as first validation.
+    // Must be < because the stateTreeIndex is 0-based. Zero is for blank state leaf
+    // while 1 is for the first actual user.
+    var computedIsStateLeafIndexValid = SafeLessThan(252)([stateTreeIndex, numSignUps]);
 
     // Check (2) - The max vote option tree index must be correct.
     var computedIsVoteOptionIndexValid = SafeLessThan(252)([voteOptionIndex, maxVoteOptions]);

--- a/circuits/circom/utils/qv/messageValidator.circom
+++ b/circuits/circom/utils/qv/messageValidator.circom
@@ -48,10 +48,10 @@ template MessageValidator() {
     signal output isValid;
 
     // Check (1) - The state leaf index must be valid.
-    // The check ensure that the stateTreeIndex <= numSignUps as first validation.
-    // Must be <= because the stateTreeIndex is 1-based. Zero is for blank state leaf
-    // while 1 is for the first actual user matching the numSignUps start.
-    var computedIsStateLeafIndexValid = SafeLessEqThan(252)([stateTreeIndex, numSignUps]);
+    // The check ensure that the stateTreeIndex < numSignUps as first validation.
+    // Must be < because the stateTreeIndex is 0-based. Zero is for blank state leaf
+    // while 1 is for the first actual user.
+    var computedIsStateLeafIndexValid = SafeLessThan(252)([stateTreeIndex, numSignUps]);
 
     // Check (2) - The max vote option tree index must be correct.
     var computedIsVoteOptionIndexValid = SafeLessThan(252)([voteOptionIndex, maxVoteOptions]);


### PR DESCRIPTION
# Description

Ensure we do the correct validation on messages, by checking that the index is < total signups (not <=)

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
