### PR TITLE
docs: ensure that it's clear that num signups account for empty leaf

### DIFF
--- a/website/versioned_docs/version-v1.2/contracts.md
+++ b/website/versioned_docs/version-v1.2/contracts.md
@@ -180,6 +180,10 @@ function deployPoll(
 }
 ```
 
+:::info
+Please be advised that the number of signups in the MACI contract (number of leaves in the merkle tree holding MACI's state) considers the initial zero leaf as one signup. For this reason, when accounting for the real users signed up to MACI, you should subtract one from the value returned from the `numSignUps` function.
+:::
+
 ## Poll.sol
 
 This contract allows users to submit their votes.

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/MACI.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/MACI.md
@@ -147,3 +147,7 @@ Polls require the following information:
 - `verifier`: the address of the zk-SNARK verifier contract
 - `vkRegistry`: the address of the vk registry contract
 - `mode`: the mode of the poll, to set whether it supports quadratic voting or non quadratic voting
+
+:::info
+Please be advised that the number of signups in the MACI contract (number of leaves in the merkle tree holding MACI's state) considers the initial zero leaf as one signup. For this reason, when accounting for the real users signed up to MACI, you should subtract one from the value returned from the `numSignUps` function.
+:::

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Poll.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Poll.md
@@ -94,3 +94,7 @@ At the same time, the coordinator can merge the message accumulator queue and ge
 
 - `mergeMessageAqSubRoots` - merges the Poll's messages tree subroot
 - `mergeMessageAq` - merges the Poll's messages tree
+
+:::info
+Please be advised that the number of signups in this case includes the zero leaf. For this reason, when accounting for the real users signed up to the Poll, you should subtract one from the value stored in the Poll contract.
+:::


### PR DESCRIPTION
# Description

Describe how to get the actual number of "real" users signed up for a maci poll.

## Related issue(s)

fix #962 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
