### PR TITLE
chore: add port as env variable and remove redundant param in testScript

### DIFF
--- a/contracts/testScriptLocalhost.sh
+++ b/contracts/testScriptLocalhost.sh
@@ -10,9 +10,5 @@ pnpm run merge:localhost --poll 0
 
 pnpm run prove:localhost --poll 0 \
     --coordinator-private-key "macisk.1751146b59d32e3c0d7426de411218172428263f93b2fc4d981c036047a4d8c0" \
-    --process-zkey ../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey \
-    --tally-zkey ../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey \
     --tally-file ../cli/tally.json \
-    --output-dir ../cli/proofs/ \
-    --tally-wasm ../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test_js/TallyVotes_10-1-2_test.wasm \
-    --process-wasm ../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test_js/ProcessMessages_10-2-1-2_test.wasm
+    --output-dir ../cli/proofs/

--- a/coordinator/.env.example
+++ b/coordinator/.env.example
@@ -27,6 +27,8 @@ COORDINATOR_RPC_URL=http://localhost:8545
 # Coordinator Ethereum addresses (see ts/auth/AccountSignatureGuard.service.ts)
 COORDINATOR_ADDRESSES=
 
-# Allowed origin host
+# Allowed origin host, use comma to separate each of them
 COORDINATOR_ALLOWED_ORIGINS=
 
+# Specify port for coordinator service (optional)
+COORDINATOR_PORT=

--- a/coordinator/ts/main.ts
+++ b/coordinator/ts/main.ts
@@ -39,7 +39,7 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup("api", app, document);
 
-  await app.listen(3000);
+  await app.listen(process.env.COORDINATOR_PORT ?? 3000);
 }
 
 bootstrap();


### PR DESCRIPTION
# Description

- add `COORDINATOR_PORT` as one of the environment variable input, it's fixed to 3000 originally
- remove `process-zkey`, `process-wasm`, `tally-zkey`, `tally-wasm` as `prove:[network]` command parameters in the `testScriptLocalhost.sh` in contracts package.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
