### PR TITLE
chore: add mnemonic to hardhat config file

### DIFF
--- a/coordinator/hardhat.config.js
+++ b/coordinator/hardhat.config.js
@@ -7,12 +7,19 @@ const path = require("path");
 dotenv.config();
 
 const parentDir = __dirname.includes("build") ? ".." : "";
+const TEST_MNEMONIC = "test test test test test test test test test test test junk";
 
 module.exports = {
   defaultNetwork: "localhost",
   networks: {
     localhost: {
       url: process.env.COORDINATOR_RPC_URL,
+      accounts: {
+        mnemonic: TEST_MNEMONIC,
+        path: "m/44'/60'/0'/0",
+        initialIndex: 0,
+        count: 20,
+      },
       loggingEnabled: false,
     },
     hardhat: {


### PR DESCRIPTION
# Description

Currently, when I'm running on my localhost, the `signer` cannot be found, so the accounts should be provided.

⬇️ This is the problem I encountered.
<img width="867" alt="image" src="https://github.com/privacy-scaling-explorations/maci/assets/9023842/34ad143d-03fb-4161-82a6-ab16d4d008d5">

## Related issue(s)

https://github.com/privacy-scaling-explorations/maci-rpgf/pull/167

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
