### PR TITLE
fix: export typechain instead of contract

### DIFF
--- a/cli/ts/commands/mergeMessages.ts
+++ b/cli/ts/commands/mergeMessages.ts
@@ -2,7 +2,7 @@ import {
   MACI__factory as MACIFactory,
   Poll__factory as PollFactory,
   AccQueue__factory as AccQueueFactory,
-} from "maci-contracts";
+} from "maci-contracts/typechain-types";
 
 import {
   DEFAULT_SR_QUEUE_OPS,

--- a/cli/ts/commands/mergeSignups.ts
+++ b/cli/ts/commands/mergeSignups.ts
@@ -1,4 +1,4 @@
-import { MACI__factory as MACIFactory, Poll__factory as PollFactory } from "maci-contracts";
+import { MACI__factory as MACIFactory, Poll__factory as PollFactory } from "maci-contracts/typechain-types";
 
 import {
   banner,

--- a/cli/ts/commands/proveOnChain.ts
+++ b/cli/ts/commands/proveOnChain.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { type BigNumberish } from "ethers";
+import { type IVerifyingKeyStruct, formatProofForVerifierContract } from "maci-contracts";
 import {
   MACI__factory as MACIFactory,
   AccQueue__factory as AccQueueFactory,
@@ -8,9 +9,7 @@ import {
   Poll__factory as PollFactory,
   VkRegistry__factory as VkRegistryFactory,
   Verifier__factory as VerifierFactory,
-  formatProofForVerifierContract,
-  type IVerifyingKeyStruct,
-} from "maci-contracts";
+} from "maci-contracts/typechain-types";
 import { MESSAGE_TREE_ARITY, STATE_TREE_ARITY } from "maci-core";
 import { G1Point, G2Point, hashLeftRight } from "maci-crypto";
 import { VerifyingKey } from "maci-domainobjs";
@@ -158,7 +157,7 @@ export const proveOnChain = async ({
     logRed(
       quiet,
       error(
-        `The proof files inside ${proofDir} do not have the correct number of message processign proofs` +
+        `The proof files inside ${proofDir} do not have the correct number of message processing proofs` +
           `(expected ${totalMessageBatches}, got ${numProcessProofs}).`,
       ),
     );

--- a/cli/ts/commands/setVerifyingKeys.ts
+++ b/cli/ts/commands/setVerifyingKeys.ts
@@ -1,5 +1,6 @@
 import { extractVk } from "maci-circuits";
-import { type IVerifyingKeyStruct, VkRegistry__factory as VkRegistryFactory, EMode } from "maci-contracts";
+import { type IVerifyingKeyStruct, EMode } from "maci-contracts";
+import { VkRegistry__factory as VkRegistryFactory } from "maci-contracts/typechain-types";
 import { genProcessVkSig, genTallyVkSig, MESSAGE_TREE_ARITY } from "maci-core";
 import { VerifyingKey } from "maci-domainobjs";
 


### PR DESCRIPTION
# Description

Since the `mergeSignups` and `mergeMessages` import `MACIFactory` from `maci-contracts`, so the frontend would accidentally import `hardhat` packages, which caused the frontend error.

<img width="1409" alt="image" src="https://github.com/privacy-scaling-explorations/maci/assets/9023842/d93e52d5-a3cd-479b-ac21-7377559ff9f7">


## Related issue(s)

https://github.com/privacy-scaling-explorations/maci-rpgf/pull/167

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
