### PR TITLE
fix: avoid export prompt in cli/sdk

### DIFF
--- a/cli/ts/commands/extractVkToFile.ts
+++ b/cli/ts/commands/extractVkToFile.ts
@@ -2,7 +2,7 @@ import { extractVk } from "maci-circuits";
 
 import fs from "fs";
 
-import { ExtractVkToFileArgs } from "../utils";
+import { ExtractVkToFileArgs } from "../utils/interfaces";
 
 /**
  * Command to confirm that the verifying keys in the contract match the

--- a/cli/ts/commands/mergeMessages.ts
+++ b/cli/ts/commands/mergeMessages.ts
@@ -4,19 +4,13 @@ import {
   AccQueue__factory as AccQueueFactory,
 } from "maci-contracts/typechain-types";
 
-import {
-  DEFAULT_SR_QUEUE_OPS,
-  banner,
-  contractExists,
-  currentBlockTimestamp,
-  info,
-  logError,
-  logGreen,
-  logYellow,
-  success,
-  readContractAddress,
-  type MergeMessagesArgs,
-} from "../utils";
+import type { MergeMessagesArgs } from "../utils/interfaces";
+
+import { banner } from "../utils/banner";
+import { contractExists, currentBlockTimestamp } from "../utils/contracts";
+import { DEFAULT_SR_QUEUE_OPS } from "../utils/defaults";
+import { readContractAddress } from "../utils/storage";
+import { info, logError, logGreen, logYellow, success } from "../utils/theme";
 
 /**
  * Merge the message queue on chain

--- a/cli/ts/commands/mergeSignups.ts
+++ b/cli/ts/commands/mergeSignups.ts
@@ -1,17 +1,11 @@
 import { MACI__factory as MACIFactory, Poll__factory as PollFactory } from "maci-contracts/typechain-types";
 
-import {
-  banner,
-  contractExists,
-  currentBlockTimestamp,
-  info,
-  logError,
-  logGreen,
-  logYellow,
-  success,
-  readContractAddress,
-  type MergeSignupsArgs,
-} from "../utils";
+import type { MergeSignupsArgs } from "../utils/interfaces";
+
+import { banner } from "../utils/banner";
+import { contractExists, currentBlockTimestamp } from "../utils/contracts";
+import { readContractAddress } from "../utils/storage";
+import { info, logError, logGreen, logYellow, success } from "../utils/theme";
 
 /**
  * Command to merge the signups of a MACI contract


### PR DESCRIPTION
# Description

<img width="976" alt="image" src="https://github.com/privacy-scaling-explorations/maci/assets/9023842/76d057c0-cb5d-4469-89f2-e8cb3283aa50">

The `prompt` package cannot be called from the frontend too, so instead of importing functions from `cli/utils` (which imports functions from `cli/utils/index.ts`), need to import from different files.

## Related issue(s)

https://github.com/privacy-scaling-explorations/maci-rpgf/pull/167

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
