### PR TITLE
refactor: optimize poll and tally contracts variables

### DIFF
--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -203,11 +203,12 @@ contract Poll is Params, Utilities, SnarkCommon, EmptyBallotRoots, IPoll {
     // set merged to true so it cannot be called again
     stateMerged = true;
 
-    mergedStateRoot = extContracts.maci.getStateTreeRoot();
+    uint256 _mergedStateRoot = extContracts.maci.getStateTreeRoot();
+    mergedStateRoot = _mergedStateRoot;
 
     // Set currentSbCommitment
     uint256[3] memory sb;
-    sb[0] = mergedStateRoot;
+    sb[0] = _mergedStateRoot;
     sb[1] = emptyBallotRoots[treeDepths.voteOptionTreeDepth - 1];
     sb[2] = uint256(0);
 
@@ -225,7 +226,7 @@ contract Poll is Params, Utilities, SnarkCommon, EmptyBallotRoots, IPoll {
 
     actualStateTreeDepth = depth;
 
-    emit MergeMaciState(mergedStateRoot, numSignups);
+    emit MergeMaciState(_mergedStateRoot, _numSignups);
   }
 
   /// @inheritdoc IPoll

--- a/contracts/contracts/Tally.sol
+++ b/contracts/contracts/Tally.sol
@@ -260,11 +260,6 @@ contract Tally is Ownable, SnarkCommon, CommonUtilities, Hasher, DomainObjs {
     uint256 _resultCommitment,
     uint256 _perVOSpentVoiceCreditsHash
   ) public view returns (bool isValid) {
-    uint256[3] memory tally;
-    tally[0] = _resultCommitment;
-    tally[1] = hashLeftRight(_totalSpent, _totalSpentSalt);
-    tally[2] = _perVOSpentVoiceCreditsHash;
-
     if (mode == Mode.QV) {
       isValid = verifyQvSpentVoiceCredits(_totalSpent, _totalSpentSalt, _resultCommitment, _perVOSpentVoiceCreditsHash);
     } else if (mode == Mode.NON_QV) {


### PR DESCRIPTION
# Description

Remove unused code from Tally contract and optimize memory read for Poll contract.

## Additional Notes

N/A

## Related issue(s)

Related to #1614 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
