### PR TITLE
chore: add function to get semaphore gatekeeper details

### DIFF
--- a/cli/ts/sdk/index.ts
+++ b/cli/ts/sdk/index.ts
@@ -5,7 +5,7 @@ import { mergeMessages } from "../commands/mergeMessages";
 import { mergeSignups } from "../commands/mergeSignups";
 import { getPoll } from "../commands/poll";
 import { publish, publishBatch } from "../commands/publish";
-import { signup, isRegisteredUser, getGatekeeperTrait } from "../commands/signup";
+import { signup, isRegisteredUser, getGatekeeperTrait, getSemaphoreGatekeeperData } from "../commands/signup";
 import { verify } from "../commands/verify";
 
 export {
@@ -21,6 +21,7 @@ export {
   mergeSignups,
   mergeMessages,
   getGatekeeperTrait,
+  getSemaphoreGatekeeperData,
 };
 
 export type { ISnarkJSVerificationKey } from "maci-circuits";
@@ -53,4 +54,6 @@ export type {
   IGenKeypairArgs,
   IPublishBatchData,
   IPublishMessage,
+  IGetSemaphoreGatekeeperDataArgs,
+  ISemaphoreGatekeeperData,
 } from "../utils";

--- a/cli/ts/utils/index.ts
+++ b/cli/ts/utils/index.ts
@@ -46,6 +46,8 @@ export type {
   IPublishMessage,
   IParseSignupEventsArgs,
   IGetGatekeeperTraitArgs,
+  ISemaphoreGatekeeperData,
+  IGetSemaphoreGatekeeperDataArgs,
 } from "./interfaces";
 export { GatekeeperTrait } from "./interfaces";
 export { compareVks } from "./vks";

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -1131,11 +1131,6 @@ export interface IGetGatekeeperTraitArgs {
    * A signer object
    */
   signer: Signer;
-
-  /**
-   * Whether to log the output
-   */
-  quiet?: boolean;
 }
 
 /**
@@ -1149,4 +1144,34 @@ export enum GatekeeperTrait {
   Semaphore = "Semaphore",
   Token = "Token",
   Zupass = "Zupass",
+}
+
+/**
+ * Interface for the arguments to the get semaphore gatekeeper data command
+ */
+export interface IGetSemaphoreGatekeeperDataArgs {
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress: string;
+
+  /**
+   * A signer object
+   */
+  signer: Signer;
+}
+
+/**
+ * Interface for the semaphore gatekeeper data
+ */
+export interface ISemaphoreGatekeeperData {
+  /**
+   * The address of the semaphore gatekeeper
+   */
+  address: string;
+
+  /**
+   * The group ID
+   */
+  groupId: string;
 }


### PR DESCRIPTION
# Description

Add utility function to get semaphore contract address and group id from the gatekeeper.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
