### PR TITLE
fix: export value from utils/interfaces vs utils

### DIFF
--- a/cli/ts/sdk/index.ts
+++ b/cli/ts/sdk/index.ts
@@ -39,7 +39,7 @@ export * from "maci-contracts/typechain-types";
 
 export { VerifyingKey, PubKey, type IVkObjectParams } from "maci-domainobjs";
 
-export { GatekeeperTrait } from "../utils";
+export { GatekeeperTrait } from "../utils/interfaces";
 
 export type {
   TallyData,


### PR DESCRIPTION
# Description

export directly from utils/interfaces to avoid importing unneded modules

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
