### PR TITLE
refactor(circuits): remove duplicate constraints

### DIFF
--- a/circuits/circom/core/qv/processMessages.circom
+++ b/circuits/circom/core/qv/processMessages.circom
@@ -345,7 +345,6 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
     var STATE_LEAF_VOICE_CREDIT_BALANCE_IDX = 2;
     // Timestamp.
     var STATE_LEAF_TIMESTAMP_IDX = 3;
-    var N_BITS = 252;
 
     // Inputs representing the message and the current state.
     signal input numSignUps;
@@ -397,8 +396,8 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
 
     // 1. Transform a state leaf and a ballot with a command.
     // The result is a new state leaf, a new ballot, and an isValid signal (0 or 1).
-    var computedNewSlPubKey[2], computedNewBallotNonce, computedIsValid;
-    (computedNewSlPubKey, computedNewBallotNonce, computedIsValid) = StateLeafAndBallotTransformer()(
+    var computedNewSlPubKey[2], computedNewBallotNonce, computedIsValid, computedIsStateLeafIndexValid, computedIsVoteOptionIndexValid;
+    (computedNewSlPubKey, computedNewBallotNonce, computedIsValid, computedIsStateLeafIndexValid, computedIsVoteOptionIndexValid) = StateLeafAndBallotTransformer()(
         numSignUps,
         maxVoteOptions,
         [stateLeaf[STATE_LEAF_PUB_X_IDX], stateLeaf[STATE_LEAF_PUB_Y_IDX]],
@@ -419,10 +418,9 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
         packedCmd
     );
 
-    // 2. If isValid is equal to zero, generate indices for leaf zero.
+    // 2. If computedIsStateLeafIndexValid is equal to zero, generate indices for leaf zero.
     // Otherwise, generate indices for command.stateIndex.
-    var stateLeafIndexValid = SafeLessThan(N_BITS)([cmdStateIndex, numSignUps]);
-    var stateIndexMux = Mux1()([0, cmdStateIndex], stateLeafIndexValid);
+    var stateIndexMux = Mux1()([0, cmdStateIndex], computedIsStateLeafIndexValid);
     var computedStateLeafPathIndices[stateTreeDepth] = MerkleGeneratePathIndices(stateTreeDepth)(stateIndexMux);
 
     // 3. Verify that the original state leaf exists in the given state root.
@@ -455,14 +453,7 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
     b <== currentVoteWeight * currentVoteWeight;
     c <== cmdNewVoteWeight * cmdNewVoteWeight;
 
-    var voiceCreditAmountValid = SafeGreaterEqThan(252)([
-        stateLeaf[STATE_LEAF_VOICE_CREDIT_BALANCE_IDX] + b,
-        c
-    ]);
-
-    var computedIsMessageEqual = IsEqual()([2, computedIsValid + voiceCreditAmountValid]);
-    var voteOptionIndexValid = SafeLessThan(N_BITS)([cmdVoteOptionIndex, maxVoteOptions]);
-    var cmdVoteOptionIndexMux = Mux1()([0, cmdVoteOptionIndex], voteOptionIndexValid);
+    var cmdVoteOptionIndexMux = Mux1()([0, cmdVoteOptionIndex], computedIsVoteOptionIndexValid);
     var computedCurrentVoteWeightPathIndices[voteOptionTreeDepth] = QuinGeneratePathIndices(voteOptionTreeDepth)(cmdVoteOptionIndexMux);
 
     var computedCurrentVoteWeightQip = QuinTreeInclusionProof(voteOptionTreeDepth)(
@@ -473,20 +464,13 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
 
     computedCurrentVoteWeightQip === ballot[BALLOT_VO_ROOT_IDX];
 
-    var voteWeightMux = Mux1()([currentVoteWeight, cmdNewVoteWeight], computedIsMessageEqual);
-    var newSlVoiceCreditBalanceMux = Mux1()(
+    var voteWeightMux = Mux1()([currentVoteWeight, cmdNewVoteWeight], computedIsValid);
+    var voiceCreditBalanceMux = Mux1()(
         [
             stateLeaf[STATE_LEAF_VOICE_CREDIT_BALANCE_IDX],
             stateLeaf[STATE_LEAF_VOICE_CREDIT_BALANCE_IDX] + b - c
         ],
-        voiceCreditAmountValid
-    );
-    var voiceCreditBalanceMux = Mux1()(
-        [
-            stateLeaf[STATE_LEAF_VOICE_CREDIT_BALANCE_IDX],
-            newSlVoiceCreditBalanceMux
-        ],
-        computedIsMessageEqual
+        computedIsValid
     );
 
     // 5.1. Update the ballot's vote option root with the new vote weight.
@@ -499,7 +483,7 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
     // The new vote option root in the ballot
     var newBallotVoRootMux = Mux1()(
         [ballot[BALLOT_VO_ROOT_IDX], computedNewVoteOptionTreeQip],
-        computedIsMessageEqual
+        computedIsValid
     );
 
     newBallotVoRoot <== newBallotVoRootMux;
@@ -522,8 +506,7 @@ template ProcessOne(stateTreeDepth, voteOptionTreeDepth) {
     newStateRoot <== computedNewStateLeafQip;
  
     // 7. Generate a new ballot root.    
-    var newBallotNonceMux = Mux1()([ballot[BALLOT_NONCE_IDX], computedNewBallotNonce], computedIsMessageEqual);
-    var computedNewBallot = PoseidonHasher(2)([newBallotNonceMux, newBallotVoRoot]);
+    var computedNewBallot = PoseidonHasher(2)([computedNewBallotNonce, newBallotVoRoot]);
     var computedNewBallotQip = MerkleTreeInclusionProof(stateTreeDepth)(
         computedNewBallot,
         computedStateLeafPathIndices,

--- a/circuits/circom/utils/non-qv/messageValidator.circom
+++ b/circuits/circom/utils/non-qv/messageValidator.circom
@@ -46,6 +46,10 @@ template MessageValidatorNonQv() {
 
     // True when the command is valid; otherwise false.
     signal output isValid;
+    // True if the state leaf index is valid
+    signal output isStateLeafIndexValid;
+    // True if the vote option index is valid
+    signal output isVoteOptionIndexValid;
 
     // Check (1) - The state leaf index must be valid.
     // The check ensure that the stateTreeIndex < numSignUps as first validation.
@@ -88,4 +92,6 @@ template MessageValidatorNonQv() {
     );
 
     isValid <== computedIsUpdateValid;
+    isStateLeafIndexValid <== computedIsStateLeafIndexValid;
+    isVoteOptionIndexValid <== computedIsVoteOptionIndexValid;
 }

--- a/circuits/circom/utils/non-qv/stateLeafAndBallotTransformer.circom
+++ b/circuits/circom/utils/non-qv/stateLeafAndBallotTransformer.circom
@@ -66,9 +66,13 @@ template StateLeafAndBallotTransformerNonQv() {
     
     // True when the command is valid; otherwise false.
     signal output isValid;
+    // True if the state leaf index is valid
+    signal output isStateLeafIndexValid;
+    // True if the vote option index is valid
+    signal output isVoteOptionIndexValid;
 
     // Check if the command / message is valid.
-    var computedMessageValidator = MessageValidatorNonQv()(
+    var (computedMessageValidator, computedIsStateLeafIndexValid, computedIsVoteOptionIndexValid) = MessageValidatorNonQv()(
         cmdStateIndex,
         numSignUps,
         cmdVoteOptionIndex,
@@ -102,4 +106,6 @@ template StateLeafAndBallotTransformerNonQv() {
     newBallotNonce <== computedNewBallotNonceMux;
 
     isValid <== computedMessageValidator;
+    isStateLeafIndexValid <== computedIsStateLeafIndexValid;
+    isVoteOptionIndexValid <== computedIsVoteOptionIndexValid;
 }

--- a/circuits/circom/utils/qv/messageValidator.circom
+++ b/circuits/circom/utils/qv/messageValidator.circom
@@ -46,6 +46,10 @@ template MessageValidator() {
 
     // True when the command is valid; otherwise false.
     signal output isValid;
+    // True if the state leaf index is valid
+    signal output isStateLeafIndexValid;
+    // True if the vote option index is valid
+    signal output isVoteOptionIndexValid;
 
     // Check (1) - The state leaf index must be valid.
     // The check ensure that the stateTreeIndex < numSignUps as first validation.
@@ -94,5 +98,7 @@ template MessageValidator() {
     );
 
     isValid <== computedIsUpdateValid;
+    isStateLeafIndexValid <== computedIsStateLeafIndexValid;
+    isVoteOptionIndexValid <== computedIsVoteOptionIndexValid;
 }
 

--- a/circuits/circom/utils/qv/stateLeafAndBallotTransformer.circom
+++ b/circuits/circom/utils/qv/stateLeafAndBallotTransformer.circom
@@ -66,9 +66,13 @@ template StateLeafAndBallotTransformer() {
     
     // True when the command is valid; otherwise false.
     signal output isValid;
+    // True if the state leaf index is valid
+    signal output isStateLeafIndexValid;
+    // True if the vote option index is valid
+    signal output isVoteOptionIndexValid;
 
     // Check if the command / message is valid.
-    var computedMessageValidator = MessageValidator()(
+    var (computedMessageValidator, computedIsStateLeafIndexValid, computedIsVoteOptionIndexValid) = MessageValidator()(
         cmdStateIndex,
         numSignUps,
         cmdVoteOptionIndex,
@@ -102,5 +106,7 @@ template StateLeafAndBallotTransformer() {
     newBallotNonce <== computedNewBallotNonceMux;
 
     isValid <== computedMessageValidator;
+    isStateLeafIndexValid <== computedIsStateLeafIndexValid;
+    isVoteOptionIndexValid <== computedIsVoteOptionIndexValid;
 }
 

--- a/circuits/ts/__tests__/MessageValidator.test.ts
+++ b/circuits/ts/__tests__/MessageValidator.test.ts
@@ -30,7 +30,7 @@ describe("MessageValidator circuit", function test() {
         "slTimestamp",
         "pollEndTimestamp",
       ],
-      ["isValid"]
+      ["isValid", "isStateLeafIndexValid", "isVoteOptionIndexValid"]
     >;
 
     before(async () => {
@@ -80,6 +80,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("1");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the signature is invalid", async () => {
@@ -89,6 +93,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the pubkey is invalid", async () => {
@@ -98,6 +106,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if there are insufficient voice credits", async () => {
@@ -107,6 +119,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the nonce is invalid", async () => {
@@ -116,6 +132,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the state leaf index is invalid", async () => {
@@ -125,6 +145,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the vote option index is invalid", async () => {
@@ -134,6 +158,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("0");
     });
 
     it("should be invalid if the vote option index is invalid", async () => {
@@ -143,6 +171,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("0");
     });
 
     it("should be invalid if the state leaf timestamp is too high", async () => {
@@ -152,6 +184,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("0");
     });
   });
 
@@ -176,7 +212,7 @@ describe("MessageValidator circuit", function test() {
         "slTimestamp",
         "pollEndTimestamp",
       ],
-      ["isValid"]
+      ["isValid", "isStateLeafIndexValid", "isVoteOptionIndexValid"]
     >;
 
     before(async () => {
@@ -226,6 +262,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("1");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the signature is invalid", async () => {
@@ -235,6 +275,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the pubkey is invalid", async () => {
@@ -244,6 +288,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if there are insufficient voice credits", async () => {
@@ -253,6 +301,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the nonce is invalid", async () => {
@@ -262,6 +314,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("1");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the state leaf index is invalid", async () => {
@@ -271,6 +327,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("1");
     });
 
     it("should be invalid if the vote option index is invalid", async () => {
@@ -280,6 +340,10 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("0");
     });
 
     it("should be invalid if the vote option index is invalid", async () => {
@@ -289,15 +353,24 @@ describe("MessageValidator circuit", function test() {
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("0");
     });
 
     it("should be invalid if the state leaf timestamp is too high", async () => {
       const circuitInputs2 = circuitInputs;
       circuitInputs2.slTimestamp = 3n;
+
       const witness = await circuit.calculateWitness(circuitInputs2);
       await circuit.expectConstraintPass(witness);
       const isValid = await getSignal(circuit, witness, "isValid");
       expect(isValid.toString()).to.be.eq("0");
+      const isStateLeafIndexValid = await getSignal(circuit, witness, "isStateLeafIndexValid");
+      expect(isStateLeafIndexValid.toString()).to.be.eq("0");
+      const isVoteOptionIndexValid = await getSignal(circuit, witness, "isVoteOptionIndexValid");
+      expect(isVoteOptionIndexValid.toString()).to.be.eq("0");
     });
   });
 });

--- a/circuits/ts/__tests__/StateLeafAndBallotTransformer.test.ts
+++ b/circuits/ts/__tests__/StateLeafAndBallotTransformer.test.ts
@@ -54,7 +54,7 @@ describe("StateLeafAndBallotTransformer circuit", function test() {
       "cmdSigS",
       "packedCommand",
     ],
-    ["newSlPubKey", "newBallotNonce", "isValid"]
+    ["newSlPubKey", "newBallotNonce", "isValid", "isStateLeafIndexValid", "isVoteOptionIndexValid"]
   >;
 
   let circuitNonQv: WitnessTester<
@@ -78,7 +78,7 @@ describe("StateLeafAndBallotTransformer circuit", function test() {
       "cmdSigS",
       "packedCommand",
     ],
-    ["newSlPubKey", "newBallotNonce", "isValid"]
+    ["newSlPubKey", "newBallotNonce", "isValid", "isStateLeafIndexValid", "isVoteOptionIndexValid"]
   >;
 
   before(async () => {


### PR DESCRIPTION
# Description

Remove duplicate constraints on circuits by re-using signals and removing unnecessary checks.

## Related issue(s)

fix #305

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
