### PR TITLE
docs: add links to the smart contracts code in the docs

### DIFF
--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/AccQueue.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/AccQueue.md
@@ -5,6 +5,10 @@ sidebar_label: AccQueue
 sidebar_position: 1
 ---
 
+:::info
+Code location: [AccQueue.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/trees/AccQueue.sol)
+:::
+
 The AccQueue contract represents a Merkle Tree where each leaf insertion only updates a subtree. To obtain the main tree root, the subtrees must be merged together by the contract owner. This requires at least two operations, a `mergeSubRoots` and a `merge`.
 
 The contract can be initialized to work as a traditional Merkle Tree (2 leaves per node) or a Quinary Tree (5 leaves per node). This can be achieved by passing either two or five as parameter to the constructor (`_hashLength`). Any other values should not be accepted.

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Gatekeepers.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Gatekeepers.md
@@ -5,6 +5,10 @@ sidebar_label: Gatekeepers
 sidebar_position: 6
 ---
 
+:::info
+Code location: [Gatekeepers](https://github.com/privacy-scaling-explorations/maci/tree/dev/contracts/contracts/gatekeepers)
+:::
+
 MACI is composed of multiple smart contracts, which together with the zk-SNARK circuits, can be used to carry out on-chain voting. Start with an [overview of our smart contracts here](/docs/developers-references/smart-contracts/MACI).
 
 MACI uses a "gatekeeper" contract, which is used to configure and enforce the eligibility criteria of voters who can participate in MACI polls. In other words, it is a way to whitelist signups to the system. Operators of MACI can use the gatekeeper contract to configure signup eligibility and to protect against sybil attacks in their polls.

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/MACI.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/MACI.md
@@ -5,6 +5,10 @@ sidebar_label: MACI
 sidebar_position: 1
 ---
 
+:::info
+Code location: [MACI.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/MACI.sol)
+:::
+
 `MACI.sol` is the core contract of the project, as it provides the base layer for user signups and Polls to be created.
 
 The constructor shown below accepts several arguments:

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/MessageProcessor.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/MessageProcessor.md
@@ -5,5 +5,9 @@ sidebar_label: MessageProcessor
 sidebar_position: 4
 ---
 
+:::info
+Code location: [MessageProcessor.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/MessageProcessor.sol)
+:::
+
 This contract is used to prepare parameters for the zk-SNARK circuits as well as for verifying proofs. It should be deployed alongside a `Poll` and ownership assigned to the coordinator.
 It will process messages in batches, and after all batches have been processed, the `sbCommitment` can then be used for the `Tally` contract verification steps.

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Params.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Params.md
@@ -5,6 +5,10 @@ sidebar_label: Params
 sidebar_position: 9
 ---
 
+:::info
+Code location: [Params.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/utils/Params.sol)
+:::
+
 A contract holding three structs:
 
 ```c

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Poll.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Poll.md
@@ -5,6 +5,10 @@ sidebar_label: Poll
 sidebar_position: 2
 ---
 
+:::info
+Code location: [Poll.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/Poll.sol)
+:::
+
 This contract allows users to submit their votes.
 
 The main functions of the contract are as follows:

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/PollFactory.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/PollFactory.md
@@ -5,6 +5,10 @@ sidebar_label: PollFactory
 sidebar_position: 3
 ---
 
+:::info
+Code location: [PollFactory.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/PollFactory.sol)
+:::
+
 `PollFactory` is a smart contract that is used to deploy new Polls. This is used by MACI inside the `deployPoll` function.
 
 ```ts

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Tally.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/Tally.md
@@ -5,6 +5,10 @@ sidebar_label: Tally
 sidebar_position: 5
 ---
 
+:::info
+Code location: [Tally.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/Tally.sol)
+:::
+
 The `Tally` contract is used by the coordinator to submit commitments to the tally results via the `tallyVotes` function. This is done in batches and the final commitment can be used by the users to verify the validity of the results.
 
 This contract should be deployed alongside a `Poll` and ownership assigned to the coordinator.

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/VkRegistry.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/VkRegistry.md
@@ -5,6 +5,10 @@ sidebar_label: VkRegistry
 sidebar_position: 8
 ---
 
+:::info
+Code location: [VkRegistry.sol](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/VkRegistry.sol)
+:::
+
 The VkRegistry is a contract that holds the verifying keys for the zk-SNARK circuits. It holds two different sets of keys:
 
 - `processVks` - The keys for the processMessages circuit

--- a/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/VoiceCreditProxy.md
+++ b/website/versioned_docs/version-v2.0_alpha/developers-references/smart-contracts/VoiceCreditProxy.md
@@ -5,6 +5,10 @@ sidebar_label: VoiceCreditsProxy
 sidebar_position: 7
 ---
 
+:::info
+Code location: [InitialVoiceCreditProxy](https://github.com/privacy-scaling-explorations/maci/tree/dev/contracts/contracts/initialVoiceCreditProxy)
+:::
+
 The VoiceCreditProxy contract is used to assign voice credits to users. Whichever implementation should the MACI deployers use, this must implement a view function that returns the balance for a user, such as the one below:
 
 ```javascript


### PR DESCRIPTION
# Description

Add links to code inside the contracts documentation

## Related issue(s)

fix #1253 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
