### PR TITLE
fix(contracts): ensure we call setMaci when deploying semaphoreGatekeeper

### DIFF
--- a/contracts/tasks/deploy/maci/08-maci.ts
+++ b/contracts/tasks/deploy/maci/08-maci.ts
@@ -1,4 +1,10 @@
-import type { EASGatekeeper, GitcoinPassportGatekeeper, ZupassGatekeeper, MACI } from "../../../typechain-types";
+import type {
+  EASGatekeeper,
+  GitcoinPassportGatekeeper,
+  ZupassGatekeeper,
+  MACI,
+  SemaphoreGatekeeper,
+} from "../../../typechain-types";
 
 import { ContractStorage } from "../../helpers/ContractStorage";
 import { Deployment } from "../../helpers/Deployment";
@@ -87,6 +93,14 @@ deployment.deployTask("full:deploy-maci", "Deploy MACI contract").then((task) =>
         name: EContracts.ZupassGatekeeper,
         address: gatekeeperContractAddress,
       });
+      const maciInstanceAddress = await maciContract.getAddress();
+      await gatekeeperContract.setMaciInstance(maciInstanceAddress).then((tx) => tx.wait());
+    } else if (gatekeeper === EContracts.SemaphoreGatekeeper) {
+      const gatekeeperContract = await deployment.getContract<SemaphoreGatekeeper>({
+        name: EContracts.SemaphoreGatekeeper,
+        address: gatekeeperContractAddress,
+      });
+
       const maciInstanceAddress = await maciContract.getAddress();
       await gatekeeperContract.setMaciInstance(maciInstanceAddress).then((tx) => tx.wait());
     }


### PR DESCRIPTION
# Description

Ensure we set the maci contract on the gatekeeper

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
