### PR TITLE
feat(sdk): add function to get zupass gatekeeper data

### DIFF
--- a/cli/ts/commands/index.ts
+++ b/cli/ts/commands/index.ts
@@ -10,7 +10,13 @@ export { publish, publishBatch } from "./publish";
 export { setVerifyingKeys } from "./setVerifyingKeys";
 export { showContracts } from "./showContracts";
 export { timeTravel } from "./timeTravel";
-export { signup, isRegisteredUser, getGatekeeperTrait, getSemaphoreGatekeeperData } from "./signup";
+export {
+  signup,
+  isRegisteredUser,
+  getGatekeeperTrait,
+  getSemaphoreGatekeeperData,
+  getZupassGatekeeperData,
+} from "./signup";
 export { verify } from "./verify";
 export { genProofs } from "./genProofs";
 export { fundWallet } from "./fundWallet";

--- a/cli/ts/commands/signup.ts
+++ b/cli/ts/commands/signup.ts
@@ -3,6 +3,7 @@ import {
   MACI__factory as MACIFactory,
   SignUpGatekeeper__factory as SignUpGatekeeperFactory,
   SemaphoreGatekeeper__factory as SemaphoreGatekeeperFactory,
+  ZupassGatekeeper__factory as ZupassGatekeeperFactory,
 } from "maci-contracts/typechain-types";
 import { PubKey } from "maci-domainobjs";
 
@@ -12,8 +13,9 @@ import type {
   IRegisteredUserArgs,
   ISignupData,
   SignupArgs,
-  IGetSemaphoreGatekeeperDataArgs,
+  IGetGatekeeperDataArgs,
   ISemaphoreGatekeeperData,
+  IZupassGatekeeperData,
 } from "../utils/interfaces";
 
 import { banner } from "../utils/banner";
@@ -191,7 +193,7 @@ export const getGatekeeperTrait = async ({
 export const getSemaphoreGatekeeperData = async ({
   maciAddress,
   signer,
-}: IGetSemaphoreGatekeeperDataArgs): Promise<ISemaphoreGatekeeperData> => {
+}: IGetGatekeeperDataArgs): Promise<ISemaphoreGatekeeperData> => {
   const maciContract = MACIFactory.connect(maciAddress, signer);
 
   // get the address of the signup gatekeeper
@@ -208,5 +210,34 @@ export const getSemaphoreGatekeeperData = async ({
   return {
     address: semaphoreContractAddress,
     groupId: groupId.toString(),
+  };
+};
+
+/**
+ * Get the zupass gatekeeper data
+ * @param IGetGatekeeperDataArgs - The arguments for the get zupass gatekeeper data command
+ * @returns The zupass gatekeeper data
+ */
+export const getZupassGatekeeperData = async ({
+  maciAddress,
+  signer,
+}: IGetGatekeeperDataArgs): Promise<IZupassGatekeeperData> => {
+  const maciContract = MACIFactory.connect(maciAddress, signer);
+
+  // get the address of the signup gatekeeper
+  const gatekeeperContractAddress = await maciContract.signUpGatekeeper();
+
+  const gatekeeperContract = ZupassGatekeeperFactory.connect(gatekeeperContractAddress, signer);
+
+  const [validEventId, validSigner1, validSigner2] = await Promise.all([
+    gatekeeperContract.validEventId(),
+    gatekeeperContract.validSigner1(),
+    gatekeeperContract.validSigner2(),
+  ]);
+
+  return {
+    eventId: validEventId.toString(),
+    signer1: validSigner1.toString(),
+    signer2: validSigner2.toString(),
   };
 };

--- a/cli/ts/sdk/index.ts
+++ b/cli/ts/sdk/index.ts
@@ -5,7 +5,13 @@ import { mergeMessages } from "../commands/mergeMessages";
 import { mergeSignups } from "../commands/mergeSignups";
 import { getPoll } from "../commands/poll";
 import { publish, publishBatch } from "../commands/publish";
-import { signup, isRegisteredUser, getGatekeeperTrait, getSemaphoreGatekeeperData } from "../commands/signup";
+import {
+  signup,
+  isRegisteredUser,
+  getGatekeeperTrait,
+  getSemaphoreGatekeeperData,
+  getZupassGatekeeperData,
+} from "../commands/signup";
 import { verify } from "../commands/verify";
 
 export {
@@ -22,6 +28,7 @@ export {
   mergeMessages,
   getGatekeeperTrait,
   getSemaphoreGatekeeperData,
+  getZupassGatekeeperData,
 };
 
 export type { ISnarkJSVerificationKey } from "maci-circuits";
@@ -54,6 +61,7 @@ export type {
   IGenKeypairArgs,
   IPublishBatchData,
   IPublishMessage,
-  IGetSemaphoreGatekeeperDataArgs,
+  IGetGatekeeperDataArgs,
   ISemaphoreGatekeeperData,
+  IZupassGatekeeperData,
 } from "../utils";

--- a/cli/ts/utils/index.ts
+++ b/cli/ts/utils/index.ts
@@ -47,7 +47,8 @@ export type {
   IParseSignupEventsArgs,
   IGetGatekeeperTraitArgs,
   ISemaphoreGatekeeperData,
-  IGetSemaphoreGatekeeperDataArgs,
+  IGetGatekeeperDataArgs,
+  IZupassGatekeeperData,
 } from "./interfaces";
 export { GatekeeperTrait } from "./interfaces";
 export { compareVks } from "./vks";

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -1147,9 +1147,9 @@ export enum GatekeeperTrait {
 }
 
 /**
- * Interface for the arguments to the get semaphore gatekeeper data command
+ * Interface for the arguments to the get a gatekeeper's data command
  */
-export interface IGetSemaphoreGatekeeperDataArgs {
+export interface IGetGatekeeperDataArgs {
   /**
    * The address of the MACI contract
    */
@@ -1174,4 +1174,21 @@ export interface ISemaphoreGatekeeperData {
    * The group ID
    */
   groupId: string;
+}
+
+export interface IZupassGatekeeperData {
+  /**
+   * The event ID
+   */
+  eventId: string;
+
+  /**
+   * The first signer
+   */
+  signer1: string;
+
+  /**
+   * The second signer
+   */
+  signer2: string;
 }


### PR DESCRIPTION
# Description

Add a function to get zupass gatekeeper data

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
