### PR TITLE
fix(contracts): fix a deploy error in the hardhat task

### DIFF
--- a/.github/workflows/hardhat-tasks.yml
+++ b/.github/workflows/hardhat-tasks.yml
@@ -1,0 +1,51 @@
+name: Hardhat Tasks
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+
+jobs:
+  hardhat-tasks:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install
+        run: |
+          pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build
+        run: |
+          pnpm run build
+
+      - name: Run hardhat fork
+        run: |
+          cd contracts
+          pnpm run hardhat &
+          sleep 5
+
+      - name: Download zkeys
+        run: |
+          pnpm download-zkeys:test
+
+      - name: hardhat tasks
+        run: |
+          cd contracts
+          cp ./deploy-config-example.json ./deploy-config.json
+          pnpm deploy:localhost
+          pnpm deploy-poll:localhost
+
+      - name: Stop Hardhat
+        if: always()
+        run: kill $(lsof -t -i:8545)

--- a/contracts/deploy-config-example.json
+++ b/contracts/deploy-config-example.json
@@ -240,5 +240,67 @@
       "coordinatorPubkey": "macipk.9a59264310d95cfd8eb7083aebeba221b5c26e77427f12b7c0f50bc1cc35e621",
       "useQuadraticVoting": false
     }
+  },
+  "localhost": {
+    "ConstantInitialVoiceCreditProxy": {
+      "deploy": true,
+      "amount": 99
+    },
+    "FreeForAllGatekeeper": {
+      "deploy": true
+    },
+    "EASGatekeeper": {
+      "deploy": false,
+      "easAddress": "0xC2679fBD37d54388Ce493F1DB75320D236e1815e",
+      "schema": "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+      "attester": "the-attester-address"
+    },
+    "GitcoinPassportGatekeeper": {
+      "deploy": false,
+      "decoderAddress": "0xe53C60F8069C2f0c3a84F9B3DB5cf56f3100ba56",
+      "passingScore": 5
+    },
+    "ZupassGatekeeper": {
+      "deploy": false,
+      "signer1": "13908133709081944902758389525983124100292637002438232157513257158004852609027",
+      "signer2": "7654374482676219729919246464135900991450848628968334062174564799457623790084",
+      "eventId": "69c0caaa-c65d-5345-a20c-867774f18c67",
+      "zupassVerifier": "0x2272cdb3596617886d0F48524DA486044E0376d6"
+    },
+    "SemaphoreGatekeeper": {
+      "deploy": false,
+      "semaphoreContract": "0x0A09FB3f63c13F1C54F2fA41AFB1e7a98cffc774",
+      "groupId": 0
+    },
+    "MACI": {
+      "stateTreeDepth": 10,
+      "gatekeeper": "FreeForAllGatekeeper"
+    },
+    "VkRegistry": {
+      "stateTreeDepth": 10,
+      "intStateTreeDepth": 1,
+      "messageTreeDepth": 2,
+      "voteOptionTreeDepth": 2,
+      "messageBatchDepth": 1,
+      "zkeys": {
+        "qv": {
+          "processMessagesZkey": "../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey",
+          "tallyVotesZkey": "../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey",
+          "processWasm": "../cli/zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test_js/ProcessMessages_10-2-1-2_test.wasm",
+          "tallyWasm": "../cli/zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test_js/TallyVotes_10-1-2_test.wasm"
+        },
+        "nonQv": {
+          "processMessagesZkey": "../cli/zkeys/ProcessMessagesNonQv_10-2-1-2_test/ProcessMessagesNonQv_10-2-1-2_test.0.zkey",
+          "tallyVotesZkey": "../cli/zkeys/TallyVotesNonQv_10-1-2_test/TallyVotesNonQv_10-1-2_test.0.zkey",
+          "processWasm": "../cli/zkeys/ProcessMessagesNonQv_10-2-1-2_test/ProcessMessagesNonQv_10-2-1-2_test_js/ProcessMessagesNonQv_10-2-1-2_test.wasm",
+          "tallyWasm": "../cli/zkeys/TallyVotesNonQv_10-1-2_test/TallyVotesNonQv_10-1-2_test_js/TallyVotesNonQv_10-1-2_test.wasm"
+        }
+      }
+    },
+    "Poll": {
+      "pollDuration": 3600,
+      "coordinatorPubkey": "macipk.9a59264310d95cfd8eb7083aebeba221b5c26e77427f12b7c0f50bc1cc35e621",
+      "useQuadraticVoting": false
+    }
   }
 }

--- a/contracts/tasks/deploy/maci/08-maci.ts
+++ b/contracts/tasks/deploy/maci/08-maci.ts
@@ -119,7 +119,7 @@ deployment.deployTask("full:deploy-maci", "Deploy MACI contract").then((task) =>
         gatekeeperContractAddress,
         constantInitialVoiceCreditProxyContractAddress,
         stateTreeDepth,
-        emptyBallotRoots,
+        emptyBallotRoots.toString(),
       ],
       network: hre.network.name,
     });


### PR DESCRIPTION
# Description

This PR fixes the issue where the hardhat task in `maci-contracts` is unable to deploy the MACI contract due to it being outdated with the changes introduced in #1695 (see 'Additional Notes' below for the detailed error log).

Additionally, I added a CI job that executes the hardhat task so we can detect deployment errors earlier (see [this detaction example](https://github.com/baumstern/maci/actions/runs/10117090816/job/27981350744) of the new CI job).



## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->
### issue analysis

the error message: `ERROR: TypeError: Do not know how to serialize a BigInt`

cause of the error: `emptyBallotRoots` is `bigint[]` but `JSON.stringify()` can not handle `bigint[]` type

solution: casting `bigint[]` into `string[]`

detailed error log:


```
$ pnpm deploy:localhost

....

======================================================================
08 Deploy MACI contract
======================================================================

*** MACI ***

Network: localhost
contract address: 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
tx: 0xa2c6cdecc58c351e5db8b22942caa58d197d702f60e1468ea96c60cea8f4fbba
deployer address: 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
gas price: 1000000397
gas used: 30000000

******


=========================================================
ERROR: TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at ContractStorage.register (/home/runner/work/maci/maci/contracts/tasks/helpers/ContractStorage.ts:96:20)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async SimpleTaskDefinition.action (/home/runner/work/maci/maci/contracts/tasks/deploy/maci/08-maci.ts:112:5)
    at async Environment._runTaskDefinition (/home/runner/work/maci/maci/node_modules/.pnpm/hardhat@2.22.6_ts-node@10.9.2_@types+node@20.14.11_typescript@5.5.4__typescript@5.5.4/node_modules/hardhat/src/internal/core/runtime-environment.ts:359:14)
    at async Environment.run (/home/runner/work/maci/maci/node_modules/.pnpm/hardhat@2.22.6_ts-node@10.9.2_@types+node@20.14.11_typescript@5.5.4__typescript@5.5.4/node_modules/hardhat/src/internal/core/runtime-environment.ts:192:14)
    at async Deployment.runSteps (/home/runner/work/maci/maci/contracts/tasks/helpers/Deployment.ts:142:9)
    at async SimpleTaskDefinition.action (/home/runner/work/maci/maci/contracts/tasks/runner/deployFull.ts:29:7)
    at async Environment._runTaskDefinition (/home/runner/work/maci/maci/node_modules/.pnpm/hardhat@2.22.6_ts-node@10.9.2_@types+node@20.14.11_typescript@5.5.4__typescript@5.5.4/node_modules/hardhat/src/internal/core/runtime-environment.ts:359:14)
    at async Environment.run (/home/runner/work/maci/maci/node_modules/.pnpm/hardhat@2.22.6_ts-node@10.9.2_@types+node@20.14.11_typescript@5.5.4__typescript@5.5.4/node_modules/hardhat/src/internal/core/runtime-environment.ts:192:14) 

======================================================================
Deployer end balance:  9999.975515
Deploy expenses:  0.024484
======================================================================

Deployment has failed
 ELIFECYCLE  Command failed with exit code 1.
```

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
