### PR TITLE
fix(contracts): ensure `gasPrice` has sufficient value

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -9,13 +9,7 @@ import type { HardhatUserConfig } from "hardhat/config";
 
 // Don't forget to import new tasks here
 import "./tasks/deploy";
-import {
-  EChainId,
-  ESupportedChains,
-  NETWORKS_DEFAULT_GAS,
-  getEtherscanApiKeys,
-  getNetworkRpcUrls,
-} from "./tasks/helpers/constants";
+import { EChainId, ESupportedChains, getEtherscanApiKeys, getNetworkRpcUrls } from "./tasks/helpers/constants";
 import "./tasks/runner/deployFull";
 import "./tasks/runner/deployPoll";
 import "./tasks/runner/merge";
@@ -28,13 +22,14 @@ const DEFAULT_BLOCK_GAS_LIMIT = 30_000_000;
 const DEFAULT_GAS_MUL = 2;
 const TEST_MNEMONIC = "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
 const NETWORKS_RPC_URL = getNetworkRpcUrls();
+const GAS_PRICE: number | "auto" = process.env.GAS_PRICE ? Number(process.env.GAS_PRICE) : "auto";
 const ETHERSCAN_API_KEYS = getEtherscanApiKeys();
 
 const getCommonNetworkConfig = (networkName: ESupportedChains, chainId: number, mnemonic?: string) => ({
   url: NETWORKS_RPC_URL[networkName],
   blockGasLimit: DEFAULT_BLOCK_GAS_LIMIT,
   gasMultiplier: DEFAULT_GAS_MUL,
-  gasPrice: process.env.GAS_PRICE ? Number(process.env.GAS_PRICE) : NETWORKS_DEFAULT_GAS[networkName],
+  gasPrice: GAS_PRICE,
   saveDeployments: true,
   chainId,
   accounts: {
@@ -72,7 +67,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       blockGasLimit: DEFAULT_BLOCK_GAS_LIMIT,
       gasMultiplier: DEFAULT_GAS_MUL,
-      gasPrice: NETWORKS_DEFAULT_GAS[ESupportedChains.Hardhat],
+      gasPrice: "auto",
       chainId: EChainId.Hardhat,
       accounts: {
         mnemonic: TEST_MNEMONIC,

--- a/contracts/tasks/helpers/constants.ts
+++ b/contracts/tasks/helpers/constants.ts
@@ -28,32 +28,7 @@ export enum EChainId {
   Coverage = 1337,
 }
 
-const GWEI = 1e9;
-
 export const STATE_TREE_ARITY = 5;
-
-/**
- * Convert gas price from gweguari to wei
- *
- * @param value - gas price in gwei
- * @returns gas price in wei
- */
-const gasPrice = (value: number) => value * GWEI;
-
-/**
- * Gas price settings for supported network
- */
-export const NETWORKS_DEFAULT_GAS: Record<ESupportedChains, number | "auto"> = {
-  [ESupportedChains.Sepolia]: gasPrice(1),
-  [ESupportedChains.Optimism]: gasPrice(1),
-  [ESupportedChains.OptimismSepolia]: gasPrice(1),
-  [ESupportedChains.Scroll]: gasPrice(1),
-  [ESupportedChains.ScrollSepolia]: gasPrice(1),
-  [ESupportedChains.Coverage]: gasPrice(1),
-  [ESupportedChains.Hardhat]: gasPrice(1),
-  [ESupportedChains.Arbitrum]: gasPrice(1),
-  [ESupportedChains.ArbitrumSepolia]: gasPrice(1),
-};
 
 /**
  * Get network rpc urls object


### PR DESCRIPTION
# Description

This PR fixes the issue where deploying a Vk Registry to the Sepolia network using the Hardhat task is unsuccessful. The problem was due to the `gasPrice` being hardcoded to 1, which caused deployment failures. By configuring `gasPrice` to [`auto`](https://hardhat.org/hardhat-runner/docs/config#json-rpc-based-networks) it will automatically estimate a suitable gas price based on current network congestion.

(I tried five times with current configuration, but the CLI process kept hanging indefinitely. Setting the `gasPrice` to `auto` resolved the issue.)

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
