### PR TITLE
chore(subgraph): configure maci-subgraph to be a public npm package

### DIFF
--- a/coordinator/.env.example
+++ b/coordinator/.env.example
@@ -43,6 +43,4 @@ SUBGRAPH_PROVIDER_URL=https://api.studio.thegraph.com/deploy/
 SUBGRAPH_DEPLOY_KEY=
 
 # Subgraph project folder
-SUBGRAPH_FOLDER=../subgraph
-
-
+SUBGRAPH_FOLDER=./node_modules/maci-subgraph

--- a/coordinator/package.json
+++ b/coordinator/package.json
@@ -41,6 +41,7 @@
     "maci-cli": "2.0.0-alpha",
     "maci-contracts": "2.0.0-alpha",
     "maci-domainobjs": "2.0.0-alpha",
+    "maci-subgraph": "2.0.0-alpha",
     "mustache": "^4.2.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       maci-domainobjs:
         specifier: 2.0.0-alpha
         version: link:../domainobjs
+      maci-subgraph:
+        specifier: 2.0.0-alpha
+        version: link:../subgraph
       mustache:
         specifier: ^4.2.0
         version: 4.2.0

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -2,9 +2,12 @@
   "name": "maci-subgraph",
   "version": "2.0.0-alpha",
   "description": "A subgraph to index data from MACI protocol to serve as data layer for frontend integration",
-  "private": true,
+  "private": false,
   "files": [
     "build",
+    "schemas",
+    "config",
+    "templates",
     "README.md"
   ],
   "scripts": {

--- a/subgraph/tsconfig.build.json
+++ b/subgraph/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extend": "./node_modules/@graphprotocol/graph-ts/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build",
+    "strictNullChecks": true,
+    "skipLibCheck": true,
+    "typeRoots": ["./src/@types/global.d.ts"]
+  },
+  "include": ["./src", "./generated"]
+}


### PR DESCRIPTION
# Description

Allow maci-subgraph to be published on npm and import inside maci-coordinator

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
