### PR TITLE
feat(contracts): added message processor and tally addresses to the maci contract

### DIFF
--- a/cli/tests/ceremony-params/ceremonyParams.test.ts
+++ b/cli/tests/ceremony-params/ceremonyParams.test.ts
@@ -291,7 +291,6 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
           ...verifyArgs(),
           tallyData: tallyFileData,
           maciAddress: tallyFileData.maci,
-          tallyAddress: tallyFileData.tallyAddress,
           signer,
         });
       });
@@ -348,7 +347,6 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
           ...verifyArgs(),
           tallyData: tallyFileData,
           maciAddress: tallyFileData.maci,
-          tallyAddress: tallyFileData.tallyAddress,
           signer,
         });
       });

--- a/cli/tests/constants.ts
+++ b/cli/tests/constants.ts
@@ -143,7 +143,6 @@ export const verifyArgs = (): Omit<VerifyArgs, "signer"> => {
     pollId: 0n,
     tallyData,
     maciAddress: tallyData.maci,
-    tallyAddress: tallyData.tallyAddress,
   };
 };
 

--- a/cli/tests/e2e/e2e.nonQv.test.ts
+++ b/cli/tests/e2e/e2e.nonQv.test.ts
@@ -125,7 +125,6 @@ describe("e2e tests with non quadratic voting", function test() {
         ...verifyArgs(),
         tallyData: tallyFileData,
         maciAddress: tallyFileData.maci,
-        tallyAddress: tallyFileData.tallyAddress,
         signer,
       });
     });

--- a/cli/tests/e2e/e2e.test.ts
+++ b/cli/tests/e2e/e2e.test.ts
@@ -25,7 +25,7 @@ import {
   isRegisteredUser,
   getGatekeeperTrait,
 } from "../../ts/commands";
-import { DeployedContracts, GatekeeperTrait, GenProofsArgs, PollContracts } from "../../ts/utils";
+import { DeployedContracts, GatekeeperTrait, GenProofsArgs } from "../../ts/utils";
 import {
   deployPollArgs,
   checkVerifyingKeysArgs,
@@ -68,7 +68,6 @@ describe("e2e tests", function test() {
   this.timeout(900000);
 
   let maciAddresses: DeployedContracts;
-  let pollAddresses: PollContracts;
   let signer: Signer;
 
   const genProofsArgs: Omit<GenProofsArgs, "signer"> = {
@@ -110,7 +109,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer, useQuadraticVoting: true });
+      await deployPoll({ ...deployPollArgs, signer, useQuadraticVoting: true });
     });
 
     it("should get the correct gatekeeper trait", async () => {
@@ -162,7 +161,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should signup one user", async () => {
@@ -195,7 +194,6 @@ describe("e2e tests", function test() {
         ...verifyArgs(),
         tallyData: tallyFileData,
         maciAddress: tallyFileData.maci,
-        tallyAddress: tallyFileData.tallyAddress,
         signer,
       });
     });
@@ -212,7 +210,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should signup four users", async () => {
@@ -353,7 +351,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should signup nine users", async () => {
@@ -400,7 +398,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should signup eight users (same pub key)", async () => {
@@ -449,7 +447,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should signup thirty users", async () => {
@@ -546,7 +544,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
       // signup
       await signup({ maciAddress: maciAddresses.maciAddress, maciPubKey: user.pubKey.serialize(), signer });
       // publish
@@ -574,7 +572,7 @@ describe("e2e tests", function test() {
     });
 
     it("should deploy a new poll", async () => {
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should publish a new message", async () => {
@@ -613,7 +611,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
       // signup
       await signup({ maciAddress: maciAddresses.maciAddress, maciPubKey: users[0].pubKey.serialize(), signer });
       // publish
@@ -644,7 +642,7 @@ describe("e2e tests", function test() {
     });
 
     it("should deploy a new poll", async () => {
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should signup four new users", async () => {
@@ -705,8 +703,6 @@ describe("e2e tests", function test() {
       new Keypair(),
     ];
 
-    let secondPollAddresses: PollContracts;
-
     after(() => {
       clean();
     });
@@ -718,7 +714,7 @@ describe("e2e tests", function test() {
 
     it("should run the first poll", async () => {
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
 
       // signup
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
@@ -764,8 +760,8 @@ describe("e2e tests", function test() {
 
     it("should deploy two more polls", async () => {
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
-      secondPollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should publish messages to the second poll", async () => {
@@ -859,8 +855,6 @@ describe("e2e tests", function test() {
         ...proveOnChainArgs,
         pollId: 1n,
         maciAddress: maciAddresses.maciAddress,
-        messageProcessorAddress: pollAddresses.messageProcessor,
-        tallyAddress: pollAddresses.tally,
         signer,
       });
       await verify({
@@ -868,7 +862,6 @@ describe("e2e tests", function test() {
         pollId: 1n,
         tallyData,
         maciAddress: maciAddresses.maciAddress,
-        tallyAddress: pollAddresses.tally,
         signer,
       });
       clean();
@@ -882,8 +875,6 @@ describe("e2e tests", function test() {
         ...proveOnChainArgs,
         pollId: 2n,
         maciAddress: maciAddresses.maciAddress,
-        messageProcessorAddress: secondPollAddresses.messageProcessor,
-        tallyAddress: secondPollAddresses.tally,
         signer,
       });
       await verify({
@@ -891,7 +882,6 @@ describe("e2e tests", function test() {
         pollId: 2n,
         tallyData,
         maciAddress: maciAddresses.maciAddress,
-        tallyAddress: secondPollAddresses.tally,
         signer,
       });
     });
@@ -914,7 +904,7 @@ describe("e2e tests", function test() {
       // deploy the smart contracts
       maciAddresses = await deploy({ ...deployArgs, signer });
       // deploy a poll contract
-      pollAddresses = await deployPoll({ ...deployPollArgs, signer });
+      await deployPoll({ ...deployPollArgs, signer });
     });
 
     it("should signup one user", async () => {

--- a/cli/ts/commands/genLocalState.ts
+++ b/cli/ts/commands/genLocalState.ts
@@ -65,12 +65,12 @@ export const genLocalState = async ({
   const coordinatorKeypair = new Keypair(coordinatorMaciPrivKey);
 
   const maciContract = MACIFactory.connect(maciContractAddress, signer);
-  const pollAddr = await maciContract.polls(pollId);
+  const pollContracts = await maciContract.polls(pollId);
 
-  if (!(await contractExists(signer.provider!, pollAddr))) {
+  if (!(await contractExists(signer.provider!, pollContracts.poll))) {
     logError("Poll contract does not exist");
   }
-  const pollContract = PollFactory.connect(pollAddr, signer);
+  const pollContract = PollFactory.connect(pollContracts.poll, signer);
 
   const [{ messageAq }, { messageTreeDepth }] = await Promise.all([
     pollContract.extContracts(),

--- a/cli/ts/commands/mergeMessages.ts
+++ b/cli/ts/commands/mergeMessages.ts
@@ -40,13 +40,13 @@ export const mergeMessages = async ({
   }
 
   const maciContract = MACIFactory.connect(maciContractAddress, signer);
-  const pollAddress = await maciContract.polls(pollId);
+  const pollContracts = await maciContract.polls(pollId);
 
-  if (!(await contractExists(signer.provider!, pollAddress))) {
+  if (!(await contractExists(signer.provider!, pollContracts.poll))) {
     logError("Poll contract does not exist");
   }
 
-  const pollContract = PollFactory.connect(pollAddress, signer);
+  const pollContract = PollFactory.connect(pollContracts.poll, signer);
   const extContracts = await pollContract.extContracts();
   const messageAqContractAddr = extContracts.messageAq;
 

--- a/cli/ts/commands/mergeSignups.ts
+++ b/cli/ts/commands/mergeSignups.ts
@@ -31,13 +31,13 @@ export const mergeSignups = async ({ pollId, maciAddress, signer, quiet = true }
   }
 
   const maciContract = MACIFactory.connect(maciContractAddress, signer);
-  const pollAddress = await maciContract.polls(pollId);
+  const pollContracts = await maciContract.polls(pollId);
 
-  if (!(await contractExists(signer.provider!, pollAddress))) {
+  if (!(await contractExists(signer.provider!, pollContracts.poll))) {
     logError("Poll contract does not exist");
   }
 
-  const pollContract = PollFactory.connect(pollAddress, signer);
+  const pollContract = PollFactory.connect(pollContracts.poll, signer);
 
   // check if it's time to merge the message AQ
   const dd = await pollContract.getDeployTimeAndDuration();

--- a/cli/ts/commands/poll.ts
+++ b/cli/ts/commands/poll.ts
@@ -32,7 +32,7 @@ export const getPoll = async ({
     logError(`Invalid poll id ${id}`);
   }
 
-  const pollAddress = await maciContract.polls(id);
+  const { poll: pollAddress } = await maciContract.polls(id);
 
   if (pollAddress === ZeroAddress) {
     logError(`MACI contract doesn't have any deployed poll ${id}`);

--- a/cli/ts/commands/publish.ts
+++ b/cli/ts/commands/publish.ts
@@ -78,13 +78,13 @@ export const publish = async ({
   }
 
   const maciContract = MACIFactory.connect(maciAddress, signer);
-  const pollAddress = await maciContract.getPoll(pollId);
+  const pollContracts = await maciContract.getPoll(pollId);
 
-  if (!(await contractExists(signer.provider!, pollAddress))) {
+  if (!(await contractExists(signer.provider!, pollContracts.poll))) {
     logError("Poll contract does not exist");
   }
 
-  const pollContract = PollFactory.connect(pollAddress, signer);
+  const pollContract = PollFactory.connect(pollContracts.poll, signer);
 
   const maxValues = await pollContract.maxValues();
   const coordinatorPubKeyResult = await pollContract.coordinatorPubKey();
@@ -168,9 +168,9 @@ export const publishBatch = async ({
   const userMaciPubKey = PubKey.deserialize(publicKey);
   const userMaciPrivKey = PrivKey.deserialize(privateKey);
   const maciContract = MACIFactory.connect(maciAddress, signer);
-  const pollAddress = await maciContract.getPoll(pollId);
+  const pollContracts = await maciContract.getPoll(pollId);
 
-  const pollContract = PollFactory.connect(pollAddress, signer);
+  const pollContract = PollFactory.connect(pollContracts.poll, signer);
 
   const [maxValues, coordinatorPubKeyResult] = await Promise.all([
     pollContract.maxValues(),

--- a/cli/ts/commands/verify.ts
+++ b/cli/ts/commands/verify.ts
@@ -16,29 +16,11 @@ import { verifyPerVOSpentVoiceCredits, verifyTallyResults } from "../utils/verif
  * Verify the results of a poll on-chain
  * @param VerifyArgs - The arguments for the verify command
  */
-export const verify = async ({
-  pollId,
-  tallyData,
-  maciAddress,
-  tallyAddress,
-  signer,
-  quiet = true,
-}: VerifyArgs): Promise<void> => {
+export const verify = async ({ pollId, tallyData, maciAddress, signer, quiet = true }: VerifyArgs): Promise<void> => {
   banner(quiet);
 
   const tallyResults = tallyData;
   const useQv = tallyResults.isQuadratic;
-
-  // we prioritize the tally file data
-  const tallyContractAddress = tallyResults.tallyAddress || tallyAddress;
-
-  if (!tallyContractAddress) {
-    logError("Tally contract address is empty");
-  }
-
-  if (!(await contractExists(signer.provider!, tallyContractAddress))) {
-    logError(`Error: there is no Tally contract deployed at ${tallyContractAddress}.`);
-  }
 
   // prioritize the tally file data
   const maciContractAddress = tallyResults.maci || maciAddress;
@@ -54,11 +36,11 @@ export const verify = async ({
 
   // get the contract objects
   const maciContract = MACIFactory.connect(maciContractAddress, signer);
-  const pollAddr = await maciContract.polls(pollId);
+  const pollContracts = await maciContract.polls(pollId);
 
-  const pollContract = PollFactory.connect(pollAddr, signer);
+  const pollContract = PollFactory.connect(pollContracts.poll, signer);
 
-  const tallyContract = TallyFactory.connect(tallyContractAddress, signer);
+  const tallyContract = TallyFactory.connect(pollContracts.tally, signer);
 
   // verification
   const onChainTallyCommitment = BigInt(await tallyContract.tallyCommitment());

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -500,7 +500,6 @@ program
     "the tally file with results, per vote option spent credits, spent voice credits total",
   )
   .option("-x, --maci-address <maciAddress>", "the MACI contract address")
-  .option("-tc, --tally-contract <tallyContract>", "the tally contract address")
   .option("-q, --quiet <quiet>", "whether to print values to the console", (value) => value === "true", false)
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .action(async (cmdObj) => {
@@ -516,14 +515,11 @@ program
       const tallyData = JSON.parse(fs.readFileSync(cmdObj.tallyFile, { encoding: "utf8" })) as TallyData;
 
       const maciAddress = tallyData.maci || cmdObj.maciAddress || readContractAddress("MACI", network?.name);
-      const tallyAddress =
-        tallyData.tallyAddress || cmdObj.tallyContract || readContractAddress(`Tally-${cmdObj.pollId}`, network?.name);
 
       await verify({
         tallyData,
         pollId: cmdObj.pollId,
         maciAddress,
-        tallyAddress,
         quiet: cmdObj.quiet,
         signer,
       });
@@ -541,7 +537,6 @@ program
     "-t, --tally-file <tallyFile>",
     "the tally file with results, per vote option spent credits, spent voice credits total",
   )
-  .option("-ta, --tally-address <tallyAddress>", "the tally contract address")
   .option("-r, --rapidsnark <rapidsnark>", "the path to the rapidsnark binary")
   .option("-wp, --process-witnessgen <processWitnessgen>", "the path to the process witness generation binary")
   .option("-pd, --process-witnessdat <processWitnessdat>", "the path to the process witness dat file")
@@ -591,7 +586,6 @@ program
         startBlock: cmdObj.startBlock,
         endBlock: cmdObj.endBlock,
         blocksPerBatch: cmdObj.blocksPerBatch,
-        tallyAddress: cmdObj.tallyAddress,
         useQuadraticVoting: cmdObj.useQuadraticVoting,
         quiet: cmdObj.quiet,
         signer,
@@ -643,8 +637,6 @@ program
   .option("-q, --quiet <quiet>", "whether to print values to the console", (value) => value === "true", false)
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .option("-x, --maci-address <maciAddress>", "the MACI contract address")
-  .option("-p, --message-processor-address <messageProcessorAddress>", "the message processor contract address")
-  .option("-t, --tally-contract <tallyContract>", "the tally contract address")
   .requiredOption("-f, --proof-dir <proofDir>", "the proof output directory from the genProofs subcommand")
   .action(async (cmdObj) => {
     try {
@@ -654,8 +646,6 @@ program
         pollId: cmdObj.pollId,
         proofDir: cmdObj.proofDir,
         maciAddress: cmdObj.maciAddress,
-        messageProcessorAddress: cmdObj.messageProcessorAddress,
-        tallyAddress: cmdObj.tallyContract,
         quiet: cmdObj.quiet,
         signer,
       });

--- a/cli/ts/utils/interfaces.ts
+++ b/cli/ts/utils/interfaces.ts
@@ -509,11 +509,6 @@ export interface GenProofsArgs {
    * Whether to use quadratic voting or not
    */
   useQuadraticVoting?: boolean;
-
-  /**
-   * The address of the Tally contract
-   */
-  tallyAddress?: string;
 }
 
 /**
@@ -599,16 +594,6 @@ export interface ProveOnChainArgs {
    * The address of the MACI contract
    */
   maciAddress?: string;
-
-  /**
-   * The address of the MessageProcessor contract
-   */
-  messageProcessorAddress?: string;
-
-  /**
-   * The address of the Tally contract
-   */
-  tallyAddress?: string;
 
   /**
    * Whether to log the output
@@ -979,11 +964,6 @@ export interface VerifyArgs {
    * The address of the MACI contract
    */
   maciAddress: string;
-
-  /**
-   * The address of the Tally contract
-   */
-  tallyAddress: string;
 
   /**
    * Whether to log the output

--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -40,7 +40,7 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
   uint256 public nextPollId;
 
   /// @notice A mapping of poll IDs to Poll contracts.
-  mapping(uint256 => address) public polls;
+  mapping(uint256 => PollContracts) public polls;
 
   /// @notice Factory contract that deploy a Poll contract
   IPollFactory public immutable pollFactory;
@@ -216,10 +216,10 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
     address mp = messageProcessorFactory.deploy(_verifier, _vkRegistry, p, msg.sender, _mode);
     address tally = tallyFactory.deploy(_verifier, _vkRegistry, p, mp, msg.sender, _mode);
 
-    polls[pollId] = p;
-
     // store the addresses in a struct so they can be returned
     pollAddr = PollContracts({ poll: p, messageProcessor: mp, tally: tally });
+
+    polls[pollId] = pollAddr;
 
     emit DeployPoll(pollId, _coordinatorPubKey.x, _coordinatorPubKey.y, pollAddr, _mode);
   }
@@ -231,10 +231,10 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
 
   /// @notice Get the Poll details
   /// @param _pollId The identifier of the Poll to retrieve
-  /// @return poll The Poll contract object
-  function getPoll(uint256 _pollId) public view returns (address poll) {
+  /// @return pollContracts The Poll contract object
+  function getPoll(uint256 _pollId) public view returns (PollContracts memory pollContracts) {
     if (_pollId >= nextPollId) revert PollDoesNotExist(_pollId);
-    poll = polls[_pollId];
+    pollContracts = polls[_pollId];
   }
 
   /// @inheritdoc IMACI

--- a/contracts/tasks/runner/merge.ts
+++ b/contracts/tasks/runner/merge.ts
@@ -26,8 +26,8 @@ task("merge", "Merge signups and messages")
 
     const maciContract = await deployment.getContract<MACI>({ name: EContracts.MACI });
 
-    const pollContractAddress = await maciContract.polls(poll);
-    const pollContract = await deployment.getContract<Poll>({ name: EContracts.Poll, address: pollContractAddress });
+    const pollContracts = await maciContract.polls(poll);
+    const pollContract = await deployment.getContract<Poll>({ name: EContracts.Poll, address: pollContracts.poll });
     const [, messageAccQueueContractAddress] = await pollContract.extContracts();
 
     const messageAccQueueContract = await deployment.getContract<AccQueue>({
@@ -35,7 +35,7 @@ task("merge", "Merge signups and messages")
       address: messageAccQueueContractAddress,
     });
 
-    if (!pollContractAddress || pollContractAddress === ZeroAddress) {
+    if (pollContracts.poll === ZeroAddress) {
       throw new Error(`No poll ${poll} found`);
     }
 

--- a/contracts/tests/MACI.test.ts
+++ b/contracts/tests/MACI.test.ts
@@ -298,8 +298,8 @@ describe("MACI", function test() {
     let pollContract: PollContract;
 
     before(async () => {
-      const pollContractAddress = await maciContract.getPoll(pollId);
-      pollContract = PollFactory.connect(pollContractAddress, signer);
+      const pollContracts = await maciContract.getPoll(pollId);
+      pollContract = PollFactory.connect(pollContracts.poll, signer);
     });
 
     it("should allow a Poll contract to merge the state tree (calculate the state root)", async () => {

--- a/contracts/tests/MessageProcessor.test.ts
+++ b/contracts/tests/MessageProcessor.test.ts
@@ -90,8 +90,8 @@ describe("MessageProcessor", () => {
     };
     pollId = event.args._pollId;
 
-    const pollContractAddress = await maciContract.getPoll(pollId);
-    pollContract = PollFactory.connect(pollContractAddress, signer);
+    const pollContracts = await maciContract.getPoll(pollId);
+    pollContract = PollFactory.connect(pollContracts.poll, signer);
 
     mpContract = MessageProcessorFactory.connect(event.args.pollAddr.messageProcessor, signer);
 

--- a/contracts/tests/Poll.test.ts
+++ b/contracts/tests/Poll.test.ts
@@ -76,8 +76,8 @@ describe("Poll", () => {
       };
       pollId = event.args._pollId;
 
-      const pollContractAddress = await maciContract.getPoll(pollId);
-      pollContract = PollFactory.connect(pollContractAddress, signer);
+      const pollContracts = await maciContract.getPoll(pollId);
+      pollContract = PollFactory.connect(pollContracts.poll, signer);
 
       // deploy local poll
       const p = maciState.deployPoll(

--- a/contracts/tests/Tally.test.ts
+++ b/contracts/tests/Tally.test.ts
@@ -106,8 +106,8 @@ describe("TallyVotes", () => {
 
     pollId = event.args._pollId;
 
-    const pollContractAddress = await maciContract.getPoll(pollId);
-    pollContract = PollFactory.connect(pollContractAddress, signer);
+    const pollContracts = await maciContract.getPoll(pollId);
+    pollContract = PollFactory.connect(pollContracts.poll, signer);
     mpContract = MessageProcessorFactory.connect(event.args.pollAddr.messageProcessor, signer);
     tallyContract = TallyFactory.connect(event.args.pollAddr.tally, signer);
 
@@ -287,8 +287,8 @@ describe("TallyVotes", () => {
 
       pollId = event.args._pollId;
 
-      const pollContractAddress = await maciContract.getPoll(pollId);
-      pollContract = PollFactory.connect(pollContractAddress, signer);
+      const pollContracts = await maciContract.getPoll(pollId);
+      pollContract = PollFactory.connect(pollContracts.poll, signer);
       mpContract = MessageProcessorFactory.connect(event.args.pollAddr.messageProcessor, signer);
       tallyContract = TallyFactory.connect(event.args.pollAddr.tally, signer);
 
@@ -432,8 +432,8 @@ describe("TallyVotes", () => {
 
       pollId = event.args._pollId;
 
-      const pollContractAddress = await maciContract.getPoll(pollId);
-      pollContract = PollFactory.connect(pollContractAddress, signer);
+      const pollContracts = await maciContract.getPoll(pollId);
+      pollContract = PollFactory.connect(pollContracts.poll, signer);
       mpContract = MessageProcessorFactory.connect(event.args.pollAddr.messageProcessor, signer);
       tallyContract = TallyFactory.connect(event.args.pollAddr.tally, signer);
 

--- a/contracts/tests/TallyNonQv.test.ts
+++ b/contracts/tests/TallyNonQv.test.ts
@@ -105,8 +105,8 @@ describe("TallyVotesNonQv", () => {
 
     pollId = event.args._pollId;
 
-    const pollContractAddress = await maciContract.getPoll(pollId);
-    pollContract = PollFactory.connect(pollContractAddress, signer);
+    const pollContracts = await maciContract.getPoll(pollId);
+    pollContract = PollFactory.connect(pollContracts.poll, signer);
     mpContract = MessageProcessorFactory.connect(event.args.pollAddr.messageProcessor, signer);
     tallyContract = TallyFactory.connect(event.args.pollAddr.tally, signer);
 

--- a/coordinator/ts/proof/__tests__/proof.service.test.ts
+++ b/coordinator/ts/proof/__tests__/proof.service.test.ts
@@ -73,7 +73,9 @@ describe("ProofGeneratorService", () => {
 
   beforeEach(() => {
     mockContract = {
-      polls: jest.fn(() => Promise.resolve(ZeroAddress.replace("0x0", "0x1"))),
+      polls: jest.fn(() =>
+        Promise.resolve({ poll: ZeroAddress.replace("0x0", "0x1"), messageProcessor: ZeroAddress, tally: ZeroAddress }),
+      ),
       getMainRoot: jest.fn(() => Promise.resolve(1n)),
       treeDepths: jest.fn(() => Promise.resolve([1, 2, 3])),
       extContracts: jest.fn(() => Promise.resolve({ messageAq: ZeroAddress })),
@@ -144,7 +146,7 @@ describe("ProofGeneratorService", () => {
   });
 
   test("should throw error if poll is not found in maci contract", async () => {
-    mockContract.polls.mockResolvedValue(ZeroAddress);
+    mockContract.polls.mockResolvedValue({ poll: ZeroAddress });
     const service = new ProofGeneratorService(defaultCryptoService, fileService);
 
     await expect(service.generate({ ...defaultArgs, poll: 2 })).rejects.toThrow(ErrorCodes.POLL_NOT_FOUND);

--- a/coordinator/ts/proof/proof.service.ts
+++ b/coordinator/ts/proof/proof.service.ts
@@ -73,14 +73,17 @@ export class ProofGeneratorService {
         address: maciContractAddress,
       });
 
-      const [signer, pollAddress] = await Promise.all([this.deployment.getDeployer(), maciContract.polls(poll)]);
+      const [signer, pollContracts] = await Promise.all([this.deployment.getDeployer(), maciContract.polls(poll)]);
 
-      if (pollAddress.toLowerCase() === ZeroAddress.toLowerCase()) {
+      if (pollContracts.poll.toLowerCase() === ZeroAddress.toLowerCase()) {
         this.logger.error(`Error: ${ErrorCodes.POLL_NOT_FOUND}, Poll ${poll} not found`);
         throw new Error(ErrorCodes.POLL_NOT_FOUND);
       }
 
-      const pollContract = await this.deployment.getContract<Poll>({ name: EContracts.Poll, address: pollAddress });
+      const pollContract = await this.deployment.getContract<Poll>({
+        name: EContracts.Poll,
+        address: pollContracts.poll,
+      });
       const [{ messageAq: messageAqAddress }, coordinatorPublicKey, isStateAqMerged, messageTreeDepth] =
         await Promise.all([
           pollContract.extContracts(),

--- a/integrationTests/ts/__tests__/integration.test.ts
+++ b/integrationTests/ts/__tests__/integration.test.ts
@@ -16,7 +16,6 @@ import {
   timeTravel,
   verify,
   DeployedContracts,
-  PollContracts,
 } from "maci-cli";
 import { getDefaultSigner } from "maci-contracts";
 import { MaciState, MaxValues, TreeDepths } from "maci-core";
@@ -61,7 +60,6 @@ describe("Integration tests", function test() {
   // global variables we need shared between tests
   let maciState: MaciState;
   let contracts: DeployedContracts;
-  let pollContracts: PollContracts;
   let pollId: bigint;
   let signer: Signer;
   const coordinatorKeypair = new Keypair();
@@ -113,7 +111,7 @@ describe("Integration tests", function test() {
     };
 
     // 4. create a poll
-    pollContracts = await deployPoll({
+    await deployPoll({
       pollDuration: duration,
       intStateTreeDepth: INT_STATE_TREE_DEPTH,
       messageTreeSubDepth: MSG_BATCH_DEPTH,
@@ -314,8 +312,6 @@ describe("Integration tests", function test() {
           pollId,
           proofDir: path.resolve(__dirname, "../../../cli/proofs"),
           maciAddress: contracts.maciAddress,
-          messageProcessorAddress: pollContracts.messageProcessor,
-          tallyAddress: pollContracts.tally,
           signer,
         }),
       ).to.not.be.rejected;
@@ -326,7 +322,6 @@ describe("Integration tests", function test() {
           pollId,
           tallyData,
           maciAddress: contracts.maciAddress,
-          tallyAddress: pollContracts.tally,
           signer,
         }),
       ).to.not.be.rejected;

--- a/integrationTests/ts/__tests__/maci-keys.test.ts
+++ b/integrationTests/ts/__tests__/maci-keys.test.ts
@@ -96,7 +96,7 @@ describe("integration tests private/public/keypair", () => {
       );
 
       // we know it's the first poll so id is 0
-      pollContract = PollFactory.connect(await maci.polls(0), signer);
+      pollContract = PollFactory.connect((await maci.polls(0)).poll, signer);
     });
 
     it("should have the correct coordinator pub key set on chain", async () => {

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -2,9 +2,12 @@
   "name": "maci-subgraph",
   "version": "2.0.0-alpha",
   "description": "A subgraph to index data from MACI protocol to serve as data layer for frontend integration",
-  "private": true,
+  "private": false,
   "files": [
     "build",
+    "schemas",
+    "config",
+    "templates",
     "README.md"
   ],
   "scripts": {

--- a/subgraph/tsconfig.build.json
+++ b/subgraph/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extend": "./node_modules/@graphprotocol/graph-ts/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build",
+    "strictNullChecks": true,
+    "skipLibCheck": true,
+    "typeRoots": ["./src/@types/global.d.ts"]
+  },
+  "include": ["./src", "./generated"]
+}


### PR DESCRIPTION
# Description
Changed the polls mapping to return the PollContracts struct instead of the poll address, it will now return the message processor address, tally contract address and poll contract address, when we will fetch the poll from the polls mapping and the getPoll function.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
