### PR TITLE
refactor(contracts): do not return contract addresses on poll deploy

### DIFF
--- a/cli/ts/commands/deployPoll.ts
+++ b/cli/ts/commands/deployPoll.ts
@@ -124,11 +124,6 @@ export const deployPoll = async ({
     const log = iface.parseLog(receiptLog as unknown as { topics: string[]; data: string }) as unknown as {
       args: {
         _pollId: bigint;
-        pollAddr: {
-          poll: string;
-          messageProcessor: string;
-          tally: string;
-        };
       };
       name: string;
     };
@@ -141,9 +136,10 @@ export const deployPoll = async ({
 
     // eslint-disable-next-line no-underscore-dangle
     const pollId = log.args._pollId;
-    pollAddr = log.args.pollAddr.poll;
-    messageProcessorContractAddress = log.args.pollAddr.messageProcessor;
-    tallyContractAddress = log.args.pollAddr.tally;
+    const pollContracts = await maciContract.getPoll(pollId);
+    pollAddr = pollContracts.poll;
+    messageProcessorContractAddress = pollContracts.messageProcessor;
+    tallyContractAddress = pollContracts.tally;
 
     logGreen(quiet, info(`Poll ID: ${pollId.toString()}`));
     logGreen(quiet, info(`Poll contract: ${pollAddr}`));

--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -27,7 +27,6 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
   uint256 public immutable maxSignups;
 
   uint8 internal constant TREE_ARITY = 2;
-  uint8 internal constant MESSAGE_TREE_ARITY = 5;
 
   /// @notice The hash of a blank state leaf
   uint256 internal constant BLANK_STATE_LEAF_HASH =
@@ -82,7 +81,6 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
     uint256 _pollId,
     uint256 indexed _coordinatorPubKeyX,
     uint256 indexed _coordinatorPubKeyY,
-    PollContracts pollAddr,
     Mode _mode
   );
 
@@ -174,7 +172,6 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
   /// @param _verifier The Verifier Contract
   /// @param _vkRegistry The VkRegistry Contract
   /// @param _mode Voting mode
-  /// @return pollAddr a new Poll contract address
   function deployPoll(
     uint256 _duration,
     TreeDepths memory _treeDepths,
@@ -182,7 +179,7 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
     address _verifier,
     address _vkRegistry,
     Mode _mode
-  ) public virtual returns (PollContracts memory pollAddr) {
+  ) public virtual {
     // cache the poll to a local variable so we can increment it
     uint256 pollId = nextPollId;
 
@@ -211,11 +208,11 @@ contract MACI is IMACI, DomainObjs, Params, Utilities {
     address tally = tallyFactory.deploy(_verifier, _vkRegistry, p, mp, msg.sender, _mode);
 
     // store the addresses in a struct so they can be returned
-    pollAddr = PollContracts({ poll: p, messageProcessor: mp, tally: tally });
+    PollContracts memory pollAddr = PollContracts({ poll: p, messageProcessor: mp, tally: tally });
 
     polls[pollId] = pollAddr;
 
-    emit DeployPoll(pollId, _coordinatorPubKey.x, _coordinatorPubKey.y, pollAddr, _mode);
+    emit DeployPoll(pollId, _coordinatorPubKey.x, _coordinatorPubKey.y, _mode);
   }
 
   /// @inheritdoc IMACI

--- a/contracts/contracts/MessageProcessor.sol
+++ b/contracts/contracts/MessageProcessor.sol
@@ -144,7 +144,7 @@ contract MessageProcessor is Ownable, SnarkCommon, Hasher, CommonUtilities, IMes
     uint256 _currentMessageBatchIndex,
     uint256 _newSbCommitment
   ) public view override returns (uint256[] memory publicInputs) {
-    (, uint8 messageTreeSubDepth, uint8 messageTreeDepth, uint8 voteOptionTreeDepth) = poll.treeDepths();
+    (, uint8 messageTreeSubDepth, uint8 messageTreeDepth, ) = poll.treeDepths();
     (, AccQueue messageAq) = poll.extContracts();
     uint256 coordinatorPubKeyHash = poll.coordinatorPubKeyHash();
     uint256 messageBatchSize = TREE_ARITY ** messageTreeSubDepth;

--- a/contracts/tasks/deploy/poll/01-poll.ts
+++ b/contracts/tasks/deploy/poll/01-poll.ts
@@ -49,21 +49,6 @@ deployment.deployTask("poll:deploy-poll", "Deploy poll").then((task) =>
     const unserializedKey = PubKey.deserialize(coordinatorPubkey);
     const mode = useQuadraticVoting ? EMode.QV : EMode.NON_QV;
 
-    const [pollContractAddress, messageProcessorContractAddress, tallyContractAddress] =
-      await maciContract.deployPoll.staticCall(
-        pollDuration,
-        {
-          intStateTreeDepth,
-          messageTreeSubDepth,
-          messageTreeDepth,
-          voteOptionTreeDepth,
-        },
-        unserializedKey.asContractParam(),
-        verifierContractAddress,
-        vkRegistryContractAddress,
-        mode,
-      );
-
     const tx = await maciContract.deployPoll(
       pollDuration,
       {
@@ -83,6 +68,11 @@ deployment.deployTask("poll:deploy-poll", "Deploy poll").then((task) =>
     if (receipt?.status !== 1) {
       throw new Error("Deploy poll transaction is failed");
     }
+
+    const pollContracts = await maciContract.getPoll(pollId);
+    const pollContractAddress = pollContracts.poll;
+    const messageProcessorContractAddress = pollContracts.messageProcessor;
+    const tallyContractAddress = pollContracts.tally;
 
     const pollContract = await deployment.getContract<Poll>({ name: EContracts.Poll, address: pollContractAddress });
     const extContracts = await pollContract.extContracts();

--- a/subgraph/templates/subgraph.template.yaml
+++ b/subgraph/templates/subgraph.template.yaml
@@ -29,7 +29,7 @@ dataSources:
         - name: Poll
           file: ./node_modules/maci-contracts/build/artifacts/contracts/Poll.sol/Poll.json
       eventHandlers:
-        - event: DeployPoll(uint256,indexed uint256,indexed uint256,(address,address,address),uint8)
+        - event: DeployPoll(uint256,indexed uint256,indexed uint256,uint8)
           handler: handleDeployPoll
         - event: SignUp(uint256,indexed uint256,indexed uint256,uint256,uint256)
           handler: handleSignUp

--- a/subgraph/tests/common.ts
+++ b/subgraph/tests/common.ts
@@ -1,4 +1,4 @@
-import { Address, ethereum } from "@graphprotocol/graph-ts";
+import { Address, ethereum, BigInt } from "@graphprotocol/graph-ts";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createMockedFunction } from "matchstick-as";
 
@@ -21,4 +21,22 @@ export function mockPollContract(): void {
     "getDeployTimeAndDuration",
     "getDeployTimeAndDuration():(uint256,uint256)",
   ).returns([ethereum.Value.fromI32(30), ethereum.Value.fromI32(40)]);
+}
+
+export function mockMaciContract(): void {
+  createMockedFunction(
+    Address.fromString("0xA16081F360e3847006dB660bae1c6d1b2e17eC2A"),
+    "getPoll",
+    "getPoll(uint256):((address,address,address))",
+  )
+    .withArgs([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1))])
+    .returns([
+      ethereum.Value.fromTuple(
+        changetype<ethereum.Tuple>([
+          ethereum.Value.fromAddress(DEFAULT_POLL_ADDRESS),
+          ethereum.Value.fromAddress(DEFAULT_MESSAGE_PROCESSOR_ADDRESS),
+          ethereum.Value.fromAddress(DEFAULT_TALLY_ADDRESS),
+        ]),
+      ),
+    ]);
 }

--- a/subgraph/tests/maci/maci.test.ts
+++ b/subgraph/tests/maci/maci.test.ts
@@ -4,12 +4,7 @@ import { test, describe, afterEach, clearStore, assert, beforeAll } from "matchs
 
 import { Account, MACI, Poll, User } from "../../generated/schema";
 import { handleSignUp, handleDeployPoll } from "../../src/maci";
-import {
-  DEFAULT_MESSAGE_PROCESSOR_ADDRESS,
-  DEFAULT_POLL_ADDRESS,
-  DEFAULT_TALLY_ADDRESS,
-  mockPollContract,
-} from "../common";
+import { DEFAULT_POLL_ADDRESS, mockMaciContract, mockPollContract } from "../common";
 
 import { createSignUpEvent, createDeployPollEvent } from "./utils";
 
@@ -17,6 +12,7 @@ export { handleSignUp, handleDeployPoll };
 
 describe("MACI", () => {
   beforeAll(() => {
+    mockMaciContract();
     mockPollContract();
   });
 
@@ -52,15 +48,7 @@ describe("MACI", () => {
   });
 
   test("should handle deploy poll properly (qv)", () => {
-    const event = createDeployPollEvent(
-      BigInt.fromI32(1),
-      BigInt.fromI32(1),
-      BigInt.fromI32(1),
-      DEFAULT_POLL_ADDRESS,
-      DEFAULT_MESSAGE_PROCESSOR_ADDRESS,
-      DEFAULT_TALLY_ADDRESS,
-      BigInt.fromI32(0),
-    );
+    const event = createDeployPollEvent(BigInt.fromI32(1), BigInt.fromI32(1), BigInt.fromI32(1), BigInt.fromI32(0));
 
     handleDeployPoll(event);
 
@@ -77,15 +65,7 @@ describe("MACI", () => {
   });
 
   test("should handle deploy poll properly (non-qv)", () => {
-    const event = createDeployPollEvent(
-      BigInt.fromI32(1),
-      BigInt.fromI32(1),
-      BigInt.fromI32(1),
-      DEFAULT_POLL_ADDRESS,
-      DEFAULT_MESSAGE_PROCESSOR_ADDRESS,
-      DEFAULT_TALLY_ADDRESS,
-      BigInt.fromI32(1),
-    );
+    const event = createDeployPollEvent(BigInt.fromI32(1), BigInt.fromI32(1), BigInt.fromI32(1), BigInt.fromI32(1));
 
     handleDeployPoll(event);
 
@@ -106,9 +86,6 @@ describe("MACI", () => {
       BigInt.fromI32(1),
       BigInt.fromI32(1),
       BigInt.fromI32(1),
-      DEFAULT_POLL_ADDRESS,
-      DEFAULT_MESSAGE_PROCESSOR_ADDRESS,
-      DEFAULT_TALLY_ADDRESS,
       BigInt.fromI32(0),
     );
 

--- a/subgraph/tests/maci/utils.ts
+++ b/subgraph/tests/maci/utils.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt as GraphBN, ethereum } from "@graphprotocol/graph-ts";
+import { BigInt as GraphBN, ethereum } from "@graphprotocol/graph-ts";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { newMockEvent } from "matchstick-as";
 
@@ -28,9 +28,6 @@ export function createDeployPollEvent(
   pollId: GraphBN,
   coordinatorPubKeyX: GraphBN,
   coordinatorPubKeyY: GraphBN,
-  poll: Address,
-  messageProcessor: Address,
-  tally: Address,
   mode: GraphBN,
 ): DeployPoll {
   const event = changetype<DeployPoll>(newMockEvent());
@@ -41,18 +38,6 @@ export function createDeployPollEvent(
   );
   event.parameters.push(
     new ethereum.EventParam("_coordinatorPubKeyY", ethereum.Value.fromUnsignedBigInt(coordinatorPubKeyY)),
-  );
-  event.parameters.push(
-    new ethereum.EventParam(
-      "pollAddr",
-      ethereum.Value.fromTuple(
-        changetype<ethereum.Tuple>([
-          ethereum.Value.fromAddress(poll),
-          ethereum.Value.fromAddress(messageProcessor),
-          ethereum.Value.fromAddress(tally),
-        ]),
-      ),
-    ),
   );
   event.parameters.push(new ethereum.EventParam("mode", ethereum.Value.fromUnsignedBigInt(mode)));
 

--- a/subgraph/tests/poll/poll.test.ts
+++ b/subgraph/tests/poll/poll.test.ts
@@ -10,12 +10,7 @@ import {
   handleMergeMessageAqSubRoots,
   handlePublishMessage,
 } from "../../src/poll";
-import {
-  DEFAULT_MESSAGE_PROCESSOR_ADDRESS,
-  DEFAULT_POLL_ADDRESS,
-  DEFAULT_TALLY_ADDRESS,
-  mockPollContract,
-} from "../common";
+import { DEFAULT_POLL_ADDRESS, mockMaciContract, mockPollContract } from "../common";
 import { createDeployPollEvent } from "../maci/utils";
 
 import {
@@ -29,18 +24,11 @@ export { handleMergeMaciState, handleMergeMessageAq, handleMergeMessageAqSubRoot
 
 describe("Poll", () => {
   beforeEach(() => {
+    mockMaciContract();
     mockPollContract();
 
     // mock the deploy poll event with non qv mode set
-    const event = createDeployPollEvent(
-      BigInt.fromI32(1),
-      BigInt.fromI32(1),
-      BigInt.fromI32(1),
-      DEFAULT_POLL_ADDRESS,
-      DEFAULT_MESSAGE_PROCESSOR_ADDRESS,
-      DEFAULT_TALLY_ADDRESS,
-      BigInt.fromI32(1),
-    );
+    const event = createDeployPollEvent(BigInt.fromI32(1), BigInt.fromI32(1), BigInt.fromI32(1), BigInt.fromI32(1));
 
     handleDeployPoll(event);
   });


### PR DESCRIPTION
# Description

Do not return poll/mp/tally addresses as they are already saved to state

## Related issue(s)

fix #1724 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
