### PR TITLE
chore: use async fs instead of sync version

### DIFF
--- a/.github/scripts/downloadZkeys.ts
+++ b/.github/scripts/downloadZkeys.ts
@@ -18,7 +18,9 @@ export async function downloadZkeys(): Promise<void> {
     throw new Error(`${type} doesn't exist`);
   }
 
-  if (!fs.existsSync(ZKEY_PATH)) {
+  const isExists = fs.existsSync(ZKEY_PATH);
+
+  if (!isExists) {
     await fs.promises.mkdir(ZKEY_PATH);
   }
 

--- a/circuits/ts/genZkeys.ts
+++ b/circuits/ts/genZkeys.ts
@@ -17,12 +17,11 @@ import { cleanThreads } from "./utils";
 export const generateZkeys = async (outputPath?: string): Promise<void> => {
   // read circomkit config files
   const configFilePath = path.resolve(__dirname, "..", "circomkit.json");
-  const circomKitConfig = JSON.parse(fs.readFileSync(configFilePath, "utf-8")) as CircomkitConfig;
+  const circomKitConfig = JSON.parse(await fs.promises.readFile(configFilePath, "utf-8")) as CircomkitConfig;
   const circuitsConfigPath = path.resolve(__dirname, "..", "circom", "circuits.json");
-  const circuitsConfigContent = JSON.parse(fs.readFileSync(circuitsConfigPath, "utf-8")) as unknown as Record<
-    string,
-    CircuitConfig
-  >;
+  const circuitsConfigContent = JSON.parse(
+    await fs.promises.readFile(circuitsConfigPath, "utf-8"),
+  ) as unknown as Record<string, CircuitConfig>;
   const circuitsConfigs: CircuitConfigWithName[] = Object.entries(circuitsConfigContent).map(([name, config]) => ({
     name,
     ...config,
@@ -52,7 +51,8 @@ export const generateZkeys = async (outputPath?: string): Promise<void> => {
     const { proverKeyPath } = await circomkitInstance.setup(circuit.name);
     // rename the zkey
     const zkeyPath = path.resolve(circomKitConfig.dirBuild, circuit.name, `${circuit.name}.0.zkey`);
-    fs.renameSync(proverKeyPath, zkeyPath);
+    // eslint-disable-next-line no-await-in-loop
+    await fs.promises.rename(proverKeyPath, zkeyPath);
   }
 
   // clean up the threads so we can exit

--- a/cli/tests/ceremony-params/ceremonyParams.test.ts
+++ b/cli/tests/ceremony-params/ceremonyParams.test.ts
@@ -123,8 +123,8 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
     });
 
     describe("1 user, 2 messages", () => {
-      after(() => {
-        clean();
+      after(async () => {
+        await clean();
       });
 
       before(async () => {
@@ -165,13 +165,13 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
         await mergeSignups({ ...mergeSignupsArgs, signer });
         await genProofs({ ...genProofsCeremonyArgs, signer });
         await proveOnChain({ ...proveOnChainArgs, signer });
-        await verify({ ...verifyArgs(), signer });
+        await verify({ ...(await verifyArgs()), signer });
       });
     });
 
     describe("25 signups, 100 messages", () => {
-      after(() => {
-        clean();
+      after(async () => {
+        await clean();
       });
 
       before(async () => {
@@ -216,7 +216,7 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
         await mergeSignups({ ...mergeSignupsArgs, signer });
         await genProofs({ ...genProofsCeremonyArgs, signer });
         await proveOnChain({ ...proveOnChainArgs, signer });
-        await verify({ ...verifyArgs(), signer });
+        await verify({ ...(await verifyArgs()), signer });
       });
     });
   });
@@ -251,8 +251,8 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
     });
 
     describe("1 signup, 1 message", () => {
-      after(() => {
-        clean();
+      after(async () => {
+        await clean();
       });
 
       before(async () => {
@@ -288,7 +288,7 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
         const tallyFileData = await genProofs({ ...genProofsArgs, signer, useQuadraticVoting: false });
         await proveOnChain({ ...proveOnChainArgs, signer });
         await verify({
-          ...verifyArgs(),
+          ...(await verifyArgs()),
           tallyData: tallyFileData,
           maciAddress: tallyFileData.maci,
           signer,
@@ -297,8 +297,8 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
     });
 
     describe("25 signups, 100 messages", () => {
-      after(() => {
-        clean();
+      after(async () => {
+        await clean();
       });
 
       before(async () => {
@@ -344,7 +344,7 @@ describe("Stress tests with ceremony params (6,9,2,3)", function test() {
         const tallyFileData = await genProofs({ ...genProofsArgs, signer, useQuadraticVoting: false });
         await proveOnChain({ ...proveOnChainArgs, signer });
         await verify({
-          ...verifyArgs(),
+          ...(await verifyArgs()),
           tallyData: tallyFileData,
           maciAddress: tallyFileData.maci,
           signer,

--- a/cli/tests/constants.ts
+++ b/cli/tests/constants.ts
@@ -136,8 +136,8 @@ export const proveOnChainArgs: Omit<ProveOnChainArgs, "signer"> = {
   proofDir: testProofsDirPath,
 };
 
-export const verifyArgs = (): Omit<VerifyArgs, "signer"> => {
-  const tallyData = readJSONFile(testTallyFilePath) as unknown as TallyData;
+export const verifyArgs = async (): Promise<Omit<VerifyArgs, "signer">> => {
+  const tallyData = (await readJSONFile(testTallyFilePath)) as unknown as TallyData;
 
   return {
     pollId: 0n,

--- a/cli/tests/e2e/e2e.nonQv.test.ts
+++ b/cli/tests/e2e/e2e.nonQv.test.ts
@@ -83,8 +83,8 @@ describe("e2e tests with non quadratic voting", function test() {
   });
 
   describe("1 signup, 1 message", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const user = new Keypair();
@@ -122,7 +122,7 @@ describe("e2e tests with non quadratic voting", function test() {
       const tallyFileData = await genProofs({ ...genProofsArgs, signer, useQuadraticVoting: false });
       await proveOnChain({ ...proveOnChainArgs, signer });
       await verify({
-        ...verifyArgs(),
+        ...(await verifyArgs()),
         tallyData: tallyFileData,
         maciAddress: tallyFileData.maci,
         signer,

--- a/cli/tests/e2e/e2e.test.ts
+++ b/cli/tests/e2e/e2e.test.ts
@@ -99,8 +99,8 @@ describe("e2e tests", function test() {
   });
 
   describe("1 signup, 1 message", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const user = new Keypair();
@@ -143,7 +143,7 @@ describe("e2e tests", function test() {
       const tallyFileData = await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
       await verify({
-        ...verifyArgs(),
+        ...(await verifyArgs()),
         tallyData: tallyFileData,
         signer,
       });
@@ -151,8 +151,8 @@ describe("e2e tests", function test() {
   });
 
   describe("2 signups (1 after stateAq is merged and logs are fetched), 1 message", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const user = new Keypair();
@@ -191,7 +191,7 @@ describe("e2e tests", function test() {
       await signup({ maciAddress: maciAddresses.maciAddress, maciPubKey: user.pubKey.serialize(), signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
       await verify({
-        ...verifyArgs(),
+        ...(await verifyArgs()),
         tallyData: tallyFileData,
         maciAddress: tallyFileData.maci,
         signer,
@@ -200,8 +200,8 @@ describe("e2e tests", function test() {
   });
 
   describe("4 signups, 8 messages", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const users = [new Keypair(), new Keypair(), new Keypair(), new Keypair()];
@@ -326,13 +326,13 @@ describe("e2e tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), signer });
+      await verify({ ...(await verifyArgs()), signer });
     });
   });
 
   describe("5 signups, 1 message", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const users = [
@@ -383,13 +383,13 @@ describe("e2e tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       const tallyFileData = await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), tallyData: tallyFileData, signer });
+      await verify({ ...(await verifyArgs()), tallyData: tallyFileData, signer });
     });
   });
 
   describe("8 signups (same key), 12 messages (same message)", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const user = new Keypair();
@@ -432,13 +432,13 @@ describe("e2e tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), signer });
+      await verify({ ...(await verifyArgs()), signer });
     });
   });
 
   describe("30 signups (31 ballots), 4 messages", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const users = Array.from({ length: 30 }, () => new Keypair());
@@ -519,7 +519,7 @@ describe("e2e tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       const tallyFileData = await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), tallyData: tallyFileData, signer });
+      await verify({ ...(await verifyArgs()), tallyData: tallyFileData, signer });
     });
   });
 
@@ -534,8 +534,8 @@ describe("e2e tests", function test() {
   });
 
   describe("multiplePolls1", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const user = new Keypair();
@@ -567,8 +567,8 @@ describe("e2e tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       const tallyFileData = await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), tallyData: tallyFileData, signer });
-      clean();
+      await verify({ ...(await verifyArgs()), tallyData: tallyFileData, signer });
+      await clean();
     });
 
     it("should deploy a new poll", async () => {
@@ -596,13 +596,13 @@ describe("e2e tests", function test() {
       await mergeSignups({ pollId: 1n, signer });
       await genProofs({ ...genProofsArgs, pollId: 1n, signer });
       await proveOnChain({ ...proveOnChainArgs, pollId: 1n, signer });
-      await verify({ ...verifyArgs(), pollId: 1n, signer });
+      await verify({ ...(await verifyArgs()), pollId: 1n, signer });
     });
   });
 
   describe("multiplePolls with new signups", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const users = Array.from({ length: 4 }, () => new Keypair());
@@ -637,8 +637,8 @@ describe("e2e tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       const tallyFileData = await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), tallyData: tallyFileData, signer });
-      clean();
+      await verify({ ...(await verifyArgs()), tallyData: tallyFileData, signer });
+      await clean();
     });
 
     it("should deploy a new poll", async () => {
@@ -688,7 +688,7 @@ describe("e2e tests", function test() {
       await mergeSignups({ pollId: 1n, signer });
       await genProofs({ ...genProofsArgs, pollId: 1n, signer });
       await proveOnChain({ ...proveOnChainArgs, pollId: 1n, signer });
-      await verify({ ...verifyArgs(), pollId: 1n, signer });
+      await verify({ ...(await verifyArgs()), pollId: 1n, signer });
     });
   });
 
@@ -703,8 +703,8 @@ describe("e2e tests", function test() {
       new Keypair(),
     ];
 
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     before(async () => {
@@ -754,8 +754,8 @@ describe("e2e tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), signer });
-      clean();
+      await verify({ ...(await verifyArgs()), signer });
+      await clean();
     });
 
     it("should deploy two more polls", async () => {
@@ -858,13 +858,13 @@ describe("e2e tests", function test() {
         signer,
       });
       await verify({
-        ...verifyArgs(),
+        ...(await verifyArgs()),
         pollId: 1n,
         tallyData,
         maciAddress: maciAddresses.maciAddress,
         signer,
       });
-      clean();
+      await clean();
     });
 
     it("should complete the third poll", async () => {
@@ -878,7 +878,7 @@ describe("e2e tests", function test() {
         signer,
       });
       await verify({
-        ...verifyArgs(),
+        ...(await verifyArgs()),
         pollId: 2n,
         tallyData,
         maciAddress: maciAddresses.maciAddress,
@@ -892,11 +892,11 @@ describe("e2e tests", function test() {
 
     const user = new Keypair();
 
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
 
       if (fs.existsSync(stateOutPath)) {
-        fs.unlinkSync(stateOutPath);
+        await fs.promises.unlink(stateOutPath);
       }
     });
 
@@ -943,7 +943,7 @@ describe("e2e tests", function test() {
         signer,
       });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), signer });
+      await verify({ ...(await verifyArgs()), signer });
     });
   });
 });

--- a/cli/tests/e2e/keyChange.test.ts
+++ b/cli/tests/e2e/keyChange.test.ts
@@ -84,8 +84,8 @@ describe("keyChange tests", function test() {
   });
 
   describe("keyChange and new vote (new vote has same nonce)", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const keypair1 = new Keypair();
@@ -143,19 +143,21 @@ describe("keyChange tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), signer });
+      await verify({ ...(await verifyArgs()), signer });
     });
 
-    it("should confirm the tally is correct", () => {
-      const tallyData = JSON.parse(fs.readFileSync(testTallyFilePath).toString()) as TallyData;
+    it("should confirm the tally is correct", async () => {
+      const tallyData = JSON.parse(
+        await fs.promises.readFile(testTallyFilePath).then((res) => res.toString()),
+      ) as TallyData;
       expect(tallyData.results.tally[0]).to.equal(expectedTally.toString());
       expect(tallyData.perVOSpentVoiceCredits?.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
     });
   });
 
   describe("keyChange and new vote (new vote has greater nonce and different vote option)", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const keypair1 = new Keypair();
@@ -213,19 +215,21 @@ describe("keyChange tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), signer });
+      await verify({ ...(await verifyArgs()), signer });
     });
 
-    it("should confirm the tally is correct", () => {
-      const tallyData = JSON.parse(fs.readFileSync(testTallyFilePath).toString()) as TallyData;
+    it("should confirm the tally is correct", async () => {
+      const tallyData = JSON.parse(
+        await fs.promises.readFile(testTallyFilePath).then((res) => res.toString()),
+      ) as TallyData;
       expect(tallyData.results.tally[0]).to.equal(expectedTally.toString());
       expect(tallyData.perVOSpentVoiceCredits?.tally[0]).to.equal(expectedPerVoteOptionTally.toString());
     });
   });
 
   describe("keyChange and new vote (new vote has same nonce and different vote option)", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     const keypair1 = new Keypair();
@@ -283,11 +287,13 @@ describe("keyChange tests", function test() {
       await mergeSignups({ ...mergeSignupsArgs, signer });
       await genProofs({ ...genProofsArgs, signer });
       await proveOnChain({ ...proveOnChainArgs, signer });
-      await verify({ ...verifyArgs(), signer });
+      await verify({ ...(await verifyArgs()), signer });
     });
 
-    it("should confirm the tally is correct", () => {
-      const tallyData = JSON.parse(fs.readFileSync(testTallyFilePath).toString()) as TallyData;
+    it("should confirm the tally is correct", async () => {
+      const tallyData = JSON.parse(
+        await fs.promises.readFile(testTallyFilePath).then((res) => res.toString()),
+      ) as TallyData;
       expect(tallyData.results.tally[2]).to.equal(expectedTally.toString());
       expect(tallyData.perVOSpentVoiceCredits?.tally[2]).to.equal(expectedPerVoteOptionTally.toString());
     });

--- a/cli/tests/unit/poll.test.ts
+++ b/cli/tests/unit/poll.test.ts
@@ -33,8 +33,8 @@ describe("poll", () => {
   });
 
   describe("check deploy and get poll", () => {
-    after(() => {
-      clean();
+    after(async () => {
+      await clean();
     });
 
     before(async () => {

--- a/cli/tests/utils.ts
+++ b/cli/tests/utils.ts
@@ -6,15 +6,13 @@ import path from "path";
  * Test utility to clean up the proofs directory
  * and the tally.json file
  */
-export const clean = (): void => {
-  const files = fs.readdirSync("./proofs");
+export const clean = async (): Promise<void> => {
+  const files = await fs.promises.readdir("./proofs");
 
-  files.forEach((file) => {
-    fs.rmSync(path.resolve("./proofs", file));
-  });
+  await Promise.all(files.map((file) => fs.promises.rm(path.resolve("./proofs", file))));
 
   if (fs.existsSync("./tally.json")) {
-    fs.rmSync("./tally.json");
+    await fs.promises.rm("./tally.json");
   }
 };
 

--- a/cli/ts/commands/checkVerifyingKeys.ts
+++ b/cli/ts/commands/checkVerifyingKeys.ts
@@ -41,11 +41,11 @@ export const checkVerifyingKeys = async ({
   const network = await signer.provider?.getNetwork();
 
   // ensure we have the contract addresses that we need
-  if (!readContractAddress("VkRegistry", network?.name) && !vkRegistry) {
+  const vkContractAddress = vkRegistry || (await readContractAddress("VkRegistry", network?.name));
+
+  if (!vkContractAddress) {
     logError("Please provide a VkRegistry contract address");
   }
-
-  const vkContractAddress = vkRegistry || readContractAddress("VkRegistry", network?.name);
 
   if (!(await contractExists(signer.provider!, vkContractAddress))) {
     logError("The VkRegistry contract does not exist");
@@ -54,11 +54,15 @@ export const checkVerifyingKeys = async ({
   const vkRegistryContractInstance = VkRegistryFactory.connect(vkContractAddress, signer);
 
   // we need to ensure that the zkey files exist
-  if (!fs.existsSync(processMessagesZkeyPath)) {
+  const isProcessMessagesZkeyPathExists = fs.existsSync(processMessagesZkeyPath);
+
+  if (!isProcessMessagesZkeyPathExists) {
     logError("The provided Process messages zkey does not exist");
   }
 
-  if (!fs.existsSync(tallyVotesZkeyPath)) {
+  const isTallyVotesZkeyPathExists = fs.existsSync(tallyVotesZkeyPath);
+
+  if (!isTallyVotesZkeyPathExists) {
     logError("The provided Tally votes zkey does not exist");
   }
 

--- a/cli/ts/commands/deploy.ts
+++ b/cli/ts/commands/deploy.ts
@@ -42,14 +42,14 @@ export const deploy = async ({
 
   const network = await signer.provider?.getNetwork();
 
-  const poseidonT3 = poseidonT3Address || readContractAddress("PoseidonT3", network?.name);
-  const poseidonT4 = poseidonT4Address || readContractAddress("PoseidonT4", network?.name);
-  const poseidonT5 = poseidonT5Address || readContractAddress("PoseidonT5", network?.name);
-  const poseidonT6 = poseidonT6Address || readContractAddress("PoseidonT6", network?.name);
+  const poseidonT3 = poseidonT3Address || (await readContractAddress("PoseidonT3", network?.name));
+  const poseidonT4 = poseidonT4Address || (await readContractAddress("PoseidonT4", network?.name));
+  const poseidonT5 = poseidonT5Address || (await readContractAddress("PoseidonT5", network?.name));
+  const poseidonT6 = poseidonT6Address || (await readContractAddress("PoseidonT6", network?.name));
 
   // if we did not deploy it before, then deploy it now
   let initialVoiceCreditProxyContractAddress: string | undefined =
-    initialVoiceCreditsProxyAddress || readContractAddress("InitialVoiceCreditProxy", network?.name);
+    initialVoiceCreditsProxyAddress || (await readContractAddress("InitialVoiceCreditProxy", network?.name));
 
   if (!initialVoiceCreditsProxyAddress) {
     const contract = await deployConstantInitialVoiceCreditProxy(
@@ -63,7 +63,7 @@ export const deploy = async ({
 
   // check if we have a signupGatekeeper already deployed or passed as arg
   let signupGatekeeperContractAddress =
-    signupGatekeeperAddress || readContractAddress("SignUpGatekeeper", network?.name);
+    signupGatekeeperAddress || (await readContractAddress("SignUpGatekeeper", network?.name));
 
   if (!signupGatekeeperContractAddress) {
     const contract = await deployFreeForAllSignUpGatekeeper(signer, true);
@@ -96,15 +96,15 @@ export const deploy = async ({
   ]);
 
   // save to the JSON File
-  storeContractAddress("InitialVoiceCreditProxy", initialVoiceCreditProxyContractAddress, network?.name);
-  storeContractAddress("SignUpGatekeeper", signupGatekeeperContractAddress, network?.name);
-  storeContractAddress("Verifier", verifierContractAddress, network?.name);
-  storeContractAddress("MACI", maciContractAddress, network?.name);
-  storeContractAddress("PollFactory", pollFactoryContractAddress, network?.name);
-  storeContractAddress("PoseidonT3", poseidonAddrs.poseidonT3, network?.name);
-  storeContractAddress("PoseidonT4", poseidonAddrs.poseidonT4, network?.name);
-  storeContractAddress("PoseidonT5", poseidonAddrs.poseidonT5, network?.name);
-  storeContractAddress("PoseidonT6", poseidonAddrs.poseidonT6, network?.name);
+  await storeContractAddress("InitialVoiceCreditProxy", initialVoiceCreditProxyContractAddress, network?.name);
+  await storeContractAddress("SignUpGatekeeper", signupGatekeeperContractAddress, network?.name);
+  await storeContractAddress("Verifier", verifierContractAddress, network?.name);
+  await storeContractAddress("MACI", maciContractAddress, network?.name);
+  await storeContractAddress("PollFactory", pollFactoryContractAddress, network?.name);
+  await storeContractAddress("PoseidonT3", poseidonAddrs.poseidonT3, network?.name);
+  await storeContractAddress("PoseidonT4", poseidonAddrs.poseidonT4, network?.name);
+  await storeContractAddress("PoseidonT5", poseidonAddrs.poseidonT5, network?.name);
+  await storeContractAddress("PoseidonT6", poseidonAddrs.poseidonT6, network?.name);
 
   logGreen(quiet, success(`MACI deployed at:  ${maciContractAddress}`));
 

--- a/cli/ts/commands/deployPoll.ts
+++ b/cli/ts/commands/deployPoll.ts
@@ -36,14 +36,14 @@ export const deployPoll = async ({
   const network = await signer.provider?.getNetwork();
 
   // check if we have a vkRegistry already deployed or passed as arg
-  const vkRegistryContractAddress = readContractAddress("VkRegistry", network?.name);
+  const vkRegistryContractAddress = await readContractAddress("VkRegistry", network?.name);
   if (!vkRegistryContractAddress && !vkRegistryAddress) {
     logError("Please provide a VkRegistry contract address");
   }
 
   const vkRegistry = vkRegistryAddress || vkRegistryContractAddress;
 
-  const maciContractAddress = readContractAddress("MACI", network?.name);
+  const maciContractAddress = await readContractAddress("MACI", network?.name);
   if (!maciContractAddress && !maciAddress) {
     logError("Please provide a MACI contract address");
   }
@@ -85,7 +85,7 @@ export const deployPoll = async ({
   const unserializedKey = PubKey.deserialize(coordinatorPubkey);
 
   // get the verifier contract
-  const verifierContractAddress = readContractAddress("Verifier", network?.name);
+  const verifierContractAddress = await readContractAddress("Verifier", network?.name);
 
   const maciContract = MACIFactory.connect(maci, signer);
 
@@ -147,9 +147,9 @@ export const deployPoll = async ({
     logGreen(quiet, info(`Tally contract: ${tallyContractAddress}`));
 
     // store the address
-    storeContractAddress(`MessageProcessor-${pollId.toString()}`, messageProcessorContractAddress, network?.name);
-    storeContractAddress(`Tally-${pollId.toString()}`, tallyContractAddress, network?.name);
-    storeContractAddress(`Poll-${pollId.toString()}`, pollAddr, network?.name);
+    await storeContractAddress(`MessageProcessor-${pollId.toString()}`, messageProcessorContractAddress, network?.name);
+    await storeContractAddress(`Tally-${pollId.toString()}`, tallyContractAddress, network?.name);
+    await storeContractAddress(`Poll-${pollId.toString()}`, pollAddr, network?.name);
   } catch (error) {
     logError((error as Error).message);
   }

--- a/cli/ts/commands/deployVkRegistry.ts
+++ b/cli/ts/commands/deployVkRegistry.ts
@@ -20,16 +20,18 @@ import {
 export const deployVkRegistryContract = async ({ signer, quiet = true }: DeployVkRegistryArgs): Promise<string> => {
   banner(quiet);
   // assume that the vkRegistry contract is the first one to be deployed
-  if (fs.existsSync(contractAddressesStore)) {
-    fs.renameSync(contractAddressesStore, oldContractAddressesStore);
-    resetContractAddresses();
+  const isContractAddressesStoreExists = fs.existsSync(contractAddressesStore);
+
+  if (isContractAddressesStoreExists) {
+    await fs.promises.rename(contractAddressesStore, oldContractAddressesStore);
+    await resetContractAddresses();
   }
 
   const network = await signer.provider?.getNetwork();
   // deploy and store the address
   const vkRegistry = await deployVkRegistry(signer, true);
   const vkRegistryAddress = await vkRegistry.getAddress();
-  storeContractAddress("VkRegistry", vkRegistryAddress, network?.name);
+  await storeContractAddress("VkRegistry", vkRegistryAddress, network?.name);
 
   logGreen(quiet, success(`VkRegistry deployed at: ${vkRegistryAddress}`));
   return vkRegistryAddress;

--- a/cli/ts/commands/genLocalState.ts
+++ b/cli/ts/commands/genLocalState.ts
@@ -45,11 +45,11 @@ export const genLocalState = async ({
   const network = await signer.provider?.getNetwork();
 
   // validation of the maci contract address
-  if (!readContractAddress("MACI", network?.name) && !maciAddress) {
+  const maciContractAddress = maciAddress || (await readContractAddress("MACI", network?.name));
+
+  if (!maciContractAddress) {
     logError("MACI contract address is empty");
   }
-
-  const maciContractAddress = maciAddress || readContractAddress("MACI", network?.name);
 
   if (!(await contractExists(signer.provider!, maciContractAddress))) {
     logError("MACI contract does not exist");
@@ -132,7 +132,7 @@ export const genLocalState = async ({
 
   // write the state to a file
   const serializedState = maciState.toJSON();
-  fs.writeFileSync(outputPath, JSON.stringify(serializedState, null, 4));
+  await fs.promises.writeFile(outputPath, JSON.stringify(serializedState, null, 4));
 
   logGreen(quiet, success(`The state has been written to ${outputPath}`));
 };

--- a/cli/ts/commands/mergeMessages.ts
+++ b/cli/ts/commands/mergeMessages.ts
@@ -27,10 +27,12 @@ export const mergeMessages = async ({
   const network = await signer.provider?.getNetwork();
 
   // maci contract validation
-  if (!readContractAddress("MACI", network?.name) && !maciAddress) {
+  const maciContractAddress = maciAddress || (await readContractAddress("MACI", network?.name));
+
+  if (!maciContractAddress) {
     logError("Could not read contracts");
   }
-  const maciContractAddress = maciAddress || readContractAddress("MACI", network?.name);
+
   if (!(await contractExists(signer.provider!, maciContractAddress))) {
     logError("MACI contract does not exist");
   }

--- a/cli/ts/commands/mergeSignups.ts
+++ b/cli/ts/commands/mergeSignups.ts
@@ -16,11 +16,11 @@ export const mergeSignups = async ({ pollId, maciAddress, signer, quiet = true }
   const network = await signer.provider?.getNetwork();
 
   // maci contract validation
-  if (!readContractAddress("MACI", network?.name) && !maciAddress) {
+  const maciContractAddress = maciAddress || (await readContractAddress("MACI", network?.name));
+
+  if (!maciContractAddress) {
     logError("Could not read contracts");
   }
-
-  const maciContractAddress = maciAddress || readContractAddress("MACI", network?.name);
 
   if (!(await contractExists(signer.provider!, maciContractAddress))) {
     logError("MACI contract does not exist");

--- a/cli/ts/commands/setVerifyingKeys.ts
+++ b/cli/ts/commands/setVerifyingKeys.ts
@@ -44,26 +44,38 @@ export const setVerifyingKeys = async ({
   const network = await signer.provider?.getNetwork();
 
   // we must either have the contract as param or stored to file
-  if (!readContractAddress("VkRegistry", network?.name) && !vkRegistry) {
+  const vkRegistryAddress = vkRegistry || (await readContractAddress("VkRegistry", network?.name));
+
+  if (!vkRegistryAddress) {
     logError("vkRegistry contract address is empty");
   }
 
-  const vkRegistryAddress = vkRegistry || readContractAddress("VkRegistry", network?.name);
-
   // check if zKey files exist
-  if (useQuadraticVoting && processMessagesZkeyPathQv && !fs.existsSync(processMessagesZkeyPathQv)) {
+  const isProcessMessagesZkeyPathQvExists = processMessagesZkeyPathQv
+    ? fs.existsSync(processMessagesZkeyPathQv)
+    : false;
+
+  if (useQuadraticVoting && processMessagesZkeyPathQv && !isProcessMessagesZkeyPathQvExists) {
     logError(`${processMessagesZkeyPathQv} does not exist.`);
   }
 
-  if (useQuadraticVoting && tallyVotesZkeyPathQv && !fs.existsSync(tallyVotesZkeyPathQv)) {
+  const isTallyVotesZkeyPathQvExists = tallyVotesZkeyPathQv ? fs.existsSync(tallyVotesZkeyPathQv) : false;
+
+  if (useQuadraticVoting && tallyVotesZkeyPathQv && !isTallyVotesZkeyPathQvExists) {
     logError(`${tallyVotesZkeyPathQv} does not exist.`);
   }
 
-  if (!useQuadraticVoting && processMessagesZkeyPathNonQv && !fs.existsSync(processMessagesZkeyPathNonQv)) {
+  const isProcessMessagesZkeyPathNonQvExists = processMessagesZkeyPathNonQv
+    ? fs.existsSync(processMessagesZkeyPathNonQv)
+    : false;
+
+  if (!useQuadraticVoting && processMessagesZkeyPathNonQv && !isProcessMessagesZkeyPathNonQvExists) {
     logError(`${processMessagesZkeyPathNonQv} does not exist.`);
   }
 
-  if (!useQuadraticVoting && tallyVotesZkeyPathNonQv && !fs.existsSync(tallyVotesZkeyPathNonQv)) {
+  const isTallyVotesZkeyPathNonQvExists = tallyVotesZkeyPathNonQv ? fs.existsSync(tallyVotesZkeyPathNonQv) : false;
+
+  if (!useQuadraticVoting && tallyVotesZkeyPathNonQv && !isTallyVotesZkeyPathNonQvExists) {
     logError(`${tallyVotesZkeyPathNonQv} does not exist.`);
   }
 

--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -287,7 +287,7 @@ program
       const signer = await getSigner();
       const network = await signer.provider?.getNetwork();
 
-      const maciAddress = cmdObj.maciAddress || readContractAddress("MACI", network?.name);
+      const maciAddress = cmdObj.maciAddress || (await readContractAddress("MACI", network?.name));
       const privateKey = cmdObj.privkey || (await promptSensitiveValue("Insert your MACI private key"));
 
       await publish({
@@ -415,7 +415,7 @@ program
       const signer = await getSigner();
       const network = await signer.provider?.getNetwork();
 
-      const maciAddress = cmdObj.maciAddress || readContractAddress("MACI", network?.name);
+      const maciAddress = cmdObj.maciAddress || (await readContractAddress("MACI", network?.name));
 
       await signup({
         maciPubKey: cmdObj.pubkey,
@@ -440,7 +440,7 @@ program
       const signer = await getSigner();
       const network = await signer.provider?.getNetwork();
 
-      const maciAddress = cmdObj.maciAddress || readContractAddress("MACI", network?.name);
+      const maciAddress = cmdObj.maciAddress || (await readContractAddress("MACI", network?.name));
 
       await isRegisteredUser({
         maciPubKey: cmdObj.pubkey,
@@ -463,7 +463,7 @@ program
       const signer = await getSigner();
       const network = await signer.provider?.getNetwork();
 
-      const maciAddress = cmdObj.maciAddress || readContractAddress("MACI", network?.name);
+      const maciAddress = cmdObj.maciAddress || (await readContractAddress("MACI", network?.name));
 
       await getPoll({
         pollId: cmdObj.poll,
@@ -508,13 +508,14 @@ program
       const network = await signer.provider?.getNetwork();
 
       // read the tally file
-      if (!cmdObj.tallyFile || !fs.existsSync(cmdObj.tallyFile)) {
+      const isTallyFileExists = fs.existsSync(cmdObj.tallyFile);
+      if (!cmdObj.tallyFile || !isTallyFileExists) {
         logError(`Unable to open ${cmdObj.tallyFile}`);
       }
 
-      const tallyData = JSON.parse(fs.readFileSync(cmdObj.tallyFile, { encoding: "utf8" })) as TallyData;
+      const tallyData = JSON.parse(await fs.promises.readFile(cmdObj.tallyFile, { encoding: "utf8" })) as TallyData;
 
-      const maciAddress = tallyData.maci || cmdObj.maciAddress || readContractAddress("MACI", network?.name);
+      const maciAddress = tallyData.maci || cmdObj.maciAddress || (await readContractAddress("MACI", network?.name));
 
       await verify({
         tallyData,

--- a/contracts/tasks/helpers/ProofGenerator.ts
+++ b/contracts/tasks/helpers/ProofGenerator.ts
@@ -85,12 +85,16 @@ export class ProofGenerator {
     outputDir,
     options: { transactionHash, stateFile, startBlock, endBlock, blocksPerBatch },
   }: IPrepareStateParams): Promise<MaciState> {
-    if (!fs.existsSync(path.resolve(outputDir))) {
-      fs.mkdirSync(path.resolve(outputDir));
+    const isOutputDirExists = fs.existsSync(path.resolve(outputDir));
+
+    if (!isOutputDirExists) {
+      await fs.promises.mkdir(path.resolve(outputDir));
     }
 
     if (stateFile) {
-      const content = JSON.parse(fs.readFileSync(stateFile).toString()) as unknown as IJsonMaciState;
+      const content = await fs.promises
+        .readFile(stateFile)
+        .then((res) => JSON.parse(res.toString()) as unknown as IJsonMaciState);
       const serializedPrivateKey = maciPrivateKey.serialize();
 
       const maciState = MaciState.fromJSON(content);
@@ -347,7 +351,7 @@ export class ProofGenerator {
         newTallyCommitment = hashLeftRight(newResultsCommitment, newSpentVoiceCreditsCommitment);
       }
 
-      fs.writeFileSync(this.tallyOutputFile, JSON.stringify(tallyFileData, null, 4));
+      await fs.promises.writeFile(this.tallyOutputFile, JSON.stringify(tallyFileData, null, 4));
 
       console.log(`Tally file:\n${JSON.stringify(tallyFileData, null, 4)}\n`);
 

--- a/contracts/tasks/runner/prove.ts
+++ b/contracts/tasks/runner/prove.ts
@@ -52,9 +52,11 @@ task("prove", "Command to generate proof and prove the result of a poll on-chain
       deployment.setHre(hre);
       const storage = ContractStorage.getInstance();
       // if we do not have the output directory just create it
-      if (!fs.existsSync(outputDir)) {
+      const isOutputDirExists = fs.existsSync(outputDir);
+
+      if (!isOutputDirExists) {
         // Create the directory
-        fs.mkdirSync(outputDir);
+        await fs.promises.mkdir(outputDir);
       }
 
       const maciPrivateKey = PrivKey.deserialize(coordinatorPrivateKey);

--- a/integrationTests/ts/__tests__/integration.test.ts
+++ b/integrationTests/ts/__tests__/integration.test.ts
@@ -136,9 +136,9 @@ describe("Integration tests", function test() {
   });
 
   // after each test we need to cleanup some files
-  afterEach(() => {
+  afterEach(async () => {
     if (fs.existsSync(path.resolve(__dirname, "../../../cli/tally.json"))) {
-      fs.unlinkSync(path.resolve(__dirname, "../../../cli/tally.json"));
+      await fs.promises.unlink(path.resolve(__dirname, "../../../cli/tally.json"));
     }
 
     const directory = path.resolve(__dirname, "../../../cli/proofs/");
@@ -147,15 +147,9 @@ describe("Integration tests", function test() {
       return;
     }
 
-    fs.readdir(directory, (err, files) => {
-      if (err) {
-        throw err;
-      }
+    const files = await fs.promises.readdir(directory);
 
-      files.forEach((file) => {
-        fs.unlinkSync(path.resolve(directory, file));
-      });
-    });
+    await Promise.all(files.map((file) => fs.promises.unlink(path.resolve(directory, file))));
   });
 
   // read the test suite data


### PR DESCRIPTION
# Description

Use async fs instead of sync version to prevent race conditions for tests

## Additional Notes

N/A

## Related issue(s)

Related to #1614 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
