### PR TITLE
fix(circuits): use dynamic imports for promisify

### DIFF
--- a/packages/circuits/ts/compile.ts
+++ b/packages/circuits/ts/compile.ts
@@ -3,11 +3,8 @@ import { type CircomkitConfig, type CircuitConfig, Circomkit } from "circomkit";
 import childProcess from "child_process";
 import fs from "fs";
 import path from "path";
-import { promisify } from "util";
 
 import type { CircuitConfigWithName } from "./types";
-
-const execFile = promisify(childProcess.execFile);
 
 /**
  * Compile MACI's circuits using circomkit
@@ -50,6 +47,9 @@ export const compileCircuits = async (cWitness?: boolean, outputPath?: string): 
     ...circomKitConfig,
     verbose: false,
   });
+
+  const { promisify } = await import("util");
+  const execFile = promisify(childProcess.execFile);
 
   // loop through each circuit config and compile them
   // eslint-disable-next-line @typescript-eslint/prefer-for-of

--- a/packages/circuits/ts/proofs.ts
+++ b/packages/circuits/ts/proofs.ts
@@ -5,14 +5,11 @@ import childProcess from "child_process";
 import fs from "fs";
 import { tmpdir } from "os";
 import path from "path";
-import { promisify } from "util";
 
 import type { IGenProofOptions, ISnarkJSVerificationKey, FullProveResult } from "./types";
 import type { IVkObjectParams } from "maci-domainobjs";
 
 import { cleanThreads, isArm } from "./utils";
-
-const execFile = promisify(childProcess.execFile);
 
 /**
  * Generate a zk-SNARK proof
@@ -69,6 +66,9 @@ export const genProof = async ({
   // Write input.json
   const jsonData = JSON.stringify(stringifyBigInts(inputs));
   await fs.promises.writeFile(inputJsonPath, jsonData);
+
+  const { promisify } = await import("util");
+  const execFile = promisify(childProcess.execFile);
 
   // Generate the witness
   await execFile(witnessExePath!, [inputJsonPath, outputWtnsPath]);


### PR DESCRIPTION
# Description

Use dynamic imports for promisify

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
