### PR TITLE
feat(sdk): get hats gatekeeper data

### DIFF
--- a/packages/cli/ts/commands/signup.ts
+++ b/packages/cli/ts/commands/signup.ts
@@ -5,6 +5,7 @@ import {
   SemaphoreGatekeeper__factory as SemaphoreGatekeeperFactory,
   ZupassGatekeeper__factory as ZupassGatekeeperFactory,
   EASGatekeeper__factory as EASGatekeeperFactory,
+  HatsGatekeeperSingle__factory as HatsSingleGatekeeperFactory,
 } from "maci-contracts/typechain-types";
 import { PubKey } from "maci-domainobjs";
 
@@ -18,6 +19,7 @@ import type {
   ISemaphoreGatekeeperData,
   IZupassGatekeeperData,
   IEASGatekeeperData,
+  IHatsGatekeeperData,
 } from "../utils/interfaces";
 
 import { banner } from "../utils/banner";
@@ -269,5 +271,31 @@ export const getEASGatekeeperData = async ({
     eas: eas.toString(),
     schema: schema.toString(),
     attester: attester.toString(),
+  };
+};
+
+/**
+ * Get the hats single gatekeeper data
+ * @param IGetGatekeeperDataArgs - The arguments for the get hats single gatekeeper data command
+ * @returns The hats single gatekeeper data
+ */
+export const getHatsSingleGatekeeperData = async ({
+  maciAddress,
+  signer,
+}: IGetGatekeeperDataArgs): Promise<IHatsGatekeeperData> => {
+  const maciContract = MACIFactory.connect(maciAddress, signer);
+
+  const gatekeeperContractAddress = await maciContract.signUpGatekeeper();
+
+  const gatekeeperContract = HatsSingleGatekeeperFactory.connect(gatekeeperContractAddress, signer);
+
+  const [criterionHat, hatsContract] = await Promise.all([
+    gatekeeperContract.criterionHat(),
+    gatekeeperContract.hats(),
+  ]);
+
+  return {
+    criterionHat: [criterionHat.toString()],
+    hatsContract: hatsContract.toString(),
   };
 };

--- a/packages/cli/ts/sdk/index.ts
+++ b/packages/cli/ts/sdk/index.ts
@@ -12,6 +12,7 @@ import {
   getSemaphoreGatekeeperData,
   getZupassGatekeeperData,
   getEASGatekeeperData,
+  getHatsSingleGatekeeperData,
 } from "../commands/signup";
 import { verify } from "../commands/verify";
 
@@ -31,6 +32,7 @@ export {
   getSemaphoreGatekeeperData,
   getZupassGatekeeperData,
   getEASGatekeeperData,
+  getHatsSingleGatekeeperData,
 };
 
 export type { ISnarkJSVerificationKey } from "maci-circuits";
@@ -66,4 +68,5 @@ export type {
   IGetGatekeeperDataArgs,
   ISemaphoreGatekeeperData,
   IZupassGatekeeperData,
+  IHatsGatekeeperData,
 } from "../utils";

--- a/packages/cli/ts/utils/index.ts
+++ b/packages/cli/ts/utils/index.ts
@@ -50,6 +50,7 @@ export type {
   IGetGatekeeperDataArgs,
   IZupassGatekeeperData,
   IEASGatekeeperData,
+  IHatsGatekeeperData,
 } from "./interfaces";
 export { GatekeeperTrait } from "./interfaces";
 export { compareVks } from "./vks";

--- a/packages/cli/ts/utils/interfaces.ts
+++ b/packages/cli/ts/utils/interfaces.ts
@@ -1195,3 +1195,18 @@ export interface IEASGatekeeperData {
    */
   attester: string;
 }
+
+/**
+ * Interface for the Hats gatekeeper data
+ */
+export interface IHatsGatekeeperData {
+  /**
+   * The criterion hat(s)
+   */
+  criterionHat: string[];
+
+  /**
+   * The hats contract
+   */
+  hatsContract: string;
+}


### PR DESCRIPTION
# Description

Add a function to get hats gatekeeper data for a client

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
