### PR TITLE
docs(deployment): ensure user is aware of chanding the coordinator key

### DIFF
--- a/apps/website/versioned_docs/version-v2.x/quick-start/deployment.md
+++ b/apps/website/versioned_docs/version-v2.x/quick-start/deployment.md
@@ -40,6 +40,17 @@ MACI uses a "gatekeeper" contract to configure and enforce the eligibility crite
 
 It's necessary to define which gatekeeper you are going to use before deploying, please refer to the [gatekeepers section](/docs/developers-references/smart-contracts/Gatekeepers) for more information on the supported Gatekeepers.
 
+### Coordinator Key
+
+Before deploying a Poll, make sure you have set the coordinator public to which you own the private key. You can generate a new one using `maci-cli` by running the following commands inside MACI's repo:
+
+```bash
+cd packages/cli && \
+node build/ts/index.js genMaciKeyPair
+```
+
+Make sure you store this safely.
+
 ### Deployment using `maci-contracts` hardhat tasks
 
 1. Take the `deploy-config-example.json` file and copy it over to `deploy-config.json`


### PR DESCRIPTION
# Description

Add a section on the coordinator key inside the deployment page

## Confirmation

- [ ] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [ ] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
