### PR TITLE
fix: poll verification

### DIFF
--- a/packages/contracts/tasks/deploy/poll/01-poll.ts
+++ b/packages/contracts/tasks/deploy/poll/01-poll.ts
@@ -92,6 +92,9 @@ deployment.deployTask("poll:deploy-poll", "Deploy poll").then((task) =>
       address: extContracts[1],
     });
 
+    // get the empty ballot root
+    const emptyBallotRoot = await pollContract.emptyBallotRoot();
+
     await Promise.all([
       storage.register({
         id: EContracts.Poll,
@@ -107,6 +110,7 @@ deployment.deployTask("poll:deploy-poll", "Deploy poll").then((task) =>
           },
           unserializedKey.asContractParam(),
           extContracts,
+          emptyBallotRoot.toString(),
         ],
         network: hre.network.name,
       }),


### PR DESCRIPTION
# Description

Ensure we can verify the poll contract by storing all constructor args

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
