### PR TITLE
feat(website): add darkmode for blog cards

### DIFF
--- a/apps/website/src/css/card.module.css
+++ b/apps/website/src/css/card.module.css
@@ -100,3 +100,31 @@
   display: -webkit-box;
   overflow: hidden;
 }
+
+[data-theme="dark"] .blogContainer {
+  background-color: black;
+}
+
+[data-theme="dark"] .blogCard {
+  background-color: #212121;
+  border: 1px solid #888888;
+}
+
+[data-theme="dark"] .blogTitle,
+.blogReadMoreButton {
+  color: #ffffff;
+}
+
+[data-theme="dark"] .blogDescription {
+  color: #cdcdcd;
+}
+
+[data-theme="dark"] .blogDate,
+.blogAuthors,
+.blogExcerpt {
+  color: #888888;
+}
+
+[data-theme="dark"] .blogReadMoreButton {
+  background-color: #1b2b50;
+}


### PR DESCRIPTION
# Description

Add dark mode styling for `/blogs` page, refer to the color set of maci-platform design.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
