### PR TITLE
fix: use correct tree arity and import from maci-core

### DIFF
--- a/packages/contracts/tasks/helpers/Prover.ts
+++ b/packages/contracts/tasks/helpers/Prover.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console, no-await-in-loop */
+import { STATE_TREE_ARITY, MESSAGE_TREE_ARITY } from "maci-core";
 import { G1Point, G2Point } from "maci-crypto";
 import { VerifyingKey } from "maci-domainobjs";
 
@@ -8,7 +9,6 @@ import type { BigNumberish } from "ethers";
 
 import { asHex, formatProofForVerifierContract } from "../../ts/utils";
 
-import { STATE_TREE_ARITY } from "./constants";
 import { IProverParams } from "./types";
 
 /**
@@ -92,7 +92,7 @@ export class Prover {
       ]);
 
     const numMessages = Number(numSignUpsAndMessages[1]);
-    const messageBatchSize = STATE_TREE_ARITY ** Number(treeDepths[1]);
+    const messageBatchSize = MESSAGE_TREE_ARITY ** Number(treeDepths[1]);
     let totalMessageBatches = numMessages <= messageBatchSize ? 1 : Math.floor(numMessages / messageBatchSize);
     let numberBatchesProcessed = numBatchesProcessed;
 

--- a/packages/contracts/tasks/helpers/constants.ts
+++ b/packages/contracts/tasks/helpers/constants.ts
@@ -32,8 +32,6 @@ export enum EChainId {
   Coverage = 1337,
 }
 
-export const STATE_TREE_ARITY = 5;
-
 /**
  * Get network rpc urls object
  *


### PR DESCRIPTION
# Description

Ensure we use the correct tree arity values

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
