### PR TITLE
feat: return voice credits on signup

### DIFF
--- a/packages/cli/ts/commands/signup.ts
+++ b/packages/cli/ts/commands/signup.ts
@@ -69,6 +69,7 @@ export const signup = async ({
   const maciContract = MACIFactory.connect(maciAddress, signer);
 
   let stateIndex = "";
+  let voiceCredits = "";
   let receipt: ContractTransactionReceipt | null = null;
 
   try {
@@ -88,7 +89,7 @@ export const signup = async ({
     if (receipt?.logs) {
       const [log] = receipt.logs;
       const { args } = iface.parseLog(log as unknown as { topics: string[]; data: string }) || { args: [] };
-      [stateIndex] = args;
+      [stateIndex, , , voiceCredits] = args;
       logGreen(quiet, success(`State index: ${stateIndex.toString()}`));
     } else {
       logError("Unable to retrieve the transaction receipt");
@@ -99,6 +100,7 @@ export const signup = async ({
 
   return {
     stateIndex: stateIndex ? stateIndex.toString() : "",
+    voiceCredits: voiceCredits ? Number.parseInt(voiceCredits, 10) : 0,
     hash: receipt!.hash,
   };
 };

--- a/packages/cli/ts/utils/interfaces.ts
+++ b/packages/cli/ts/utils/interfaces.ts
@@ -841,6 +841,11 @@ export interface ISignupData {
   stateIndex: string;
 
   /**
+   * The voice credits of the user
+   */
+  voiceCredits: number;
+
+  /**
    * The signup transaction hash
    */
   hash: string;


### PR DESCRIPTION
# Description

Return the voice credits when signing up to avoid having to fetch them separately later

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
