### PR TITLE
chore: add enum for gatekeepers and voice credits proxy

### DIFF
--- a/packages/contracts/tasks/helpers/types.ts
+++ b/packages/contracts/tasks/helpers/types.ts
@@ -536,6 +536,27 @@ export interface IRegisterContract {
 }
 
 /**
+ * Enum represents gatekeeper types
+ */
+export enum EGatekeepers {
+  FreeForAll = "FreeForAllGatekeeper",
+  EAS = "EASGatekeeper",
+  GitcoinPassport = "GitcoinPassportGatekeeper",
+  Hats = "HatsGatekeeper",
+  HatsSingle = "HatsGatekeeperSingle",
+  HatsMultiple = "HatsGatekeeperMultiple",
+  Zupass = "ZupassGatekeeper",
+  Semaphore = "SemaphoreGatekeeper",
+}
+
+/**
+ * Enum represents initial voice credit proxies
+ */
+export enum EInitialVoiceCreditProxies {
+  Constant = "ConstantInitialVoiceCreditProxy",
+}
+
+/**
  * Enum represents deployed contracts
  */
 export enum EContracts {

--- a/packages/contracts/ts/index.ts
+++ b/packages/contracts/ts/index.ts
@@ -26,6 +26,8 @@ export { ProofGenerator } from "../tasks/helpers/ProofGenerator";
 export { Prover } from "../tasks/helpers/Prover";
 export {
   EContracts,
+  EGatekeepers,
+  EInitialVoiceCreditProxies,
   type IGenerateProofsOptions,
   type IGenerateProofsBatchData,
   type TallyData,


### PR DESCRIPTION
# Description

Add enum to keep track of gatekeepers and voice credit proxies

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
