### PR TITLE
fix(contracts): remove poseidon builders from exports

### DIFF
--- a/packages/contracts/ts/index.ts
+++ b/packages/contracts/ts/index.ts
@@ -34,7 +34,6 @@ export {
   type IDeployParams,
 } from "../tasks/helpers/types";
 export { linkPoseidonLibraries } from "../tasks/helpers/abi";
-export { buildPoseidonT3, buildPoseidonT4, buildPoseidonT5, buildPoseidonT6 } from "./buildPoseidon";
 
 export type { IVerifyingKeyStruct, SnarkProof, Groth16Proof, Proof } from "./types";
 export * from "../typechain-types";


### PR DESCRIPTION
# Description

Remove poseidon contract creation from exports of `maci-contracts`

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
