### PR TITLE
chore(docs): remove version banner in v1.2

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -50,6 +50,11 @@ async function getConfig(): Promise<Config> {
             remarkPlugins: [remarkMath],
             rehypePlugins: [rehypeKatex],
             includeCurrentVersion: false,
+            versions: {
+              "v1.2": {
+                banner: "none",
+              },
+            },
           },
           blog: {
             showReadingTime: true,

--- a/apps/website/versioned_docs/version-v1.2/introduction.md
+++ b/apps/website/versioned_docs/version-v1.2/introduction.md
@@ -5,6 +5,10 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
+:::info
+For a more secure and stable protocol, please refer to MACI v2.x
+:::
+
 # Welcome to MACI
 
 ![MACI card](/img/maci-card.png)


### PR DESCRIPTION
# Description

This PR removes the version banner in v1.2

## Additional Notes

It also adds an info message in the `introduction.md`

## Related issue(s)

fix #1471 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
