### PR TITLE
chore: update message tree depth programmatically in benchmarks

### DIFF
--- a/packages/contracts/tasks/helpers/Deployment.ts
+++ b/packages/contracts/tasks/helpers/Deployment.ts
@@ -397,6 +397,22 @@ export class Deployment {
   }
 
   /**
+   * Update deploy config field (see deploy-config.json)
+   * @param id - contract name
+   * @param field - config field key
+   * @param value - config field value
+   */
+  updateDeployConfig<T = string | number | boolean, ID extends string = EContracts>(
+    id: ID,
+    field: string,
+    value: T,
+  ): void {
+    this.checkHre();
+
+    this.config.set(`${this.hre!.network.name}.${id}.${field}`, value).write();
+  }
+
+  /**
    * Get contract by name and group key
    *
    * @param {IGetContractParams} params - params

--- a/packages/contracts/tasks/runner/benchmarks.ts
+++ b/packages/contracts/tasks/runner/benchmarks.ts
@@ -3,6 +3,7 @@ import { task } from "hardhat/config";
 import { Keypair, PCommand } from "maci-domainobjs";
 
 import { Deployment } from "../helpers/Deployment";
+import { EContracts } from "../helpers/types";
 
 task("benchmark", "Run benchmarks").setAction(async (_, hre) => {
   const deployment = Deployment.getInstance(hre);
@@ -15,8 +16,14 @@ task("benchmark", "Run benchmarks").setAction(async (_, hre) => {
   await deployment.runSteps(steps, 0);
 
   // deploy a Poll
+  // get original tree depth
+  const messageTreeDepth = deployment.getDeployConfigField<number>(EContracts.VkRegistry, "messageTreeDepth");
+  // update it
+  deployment.updateDeployConfig(EContracts.VkRegistry, "messageTreeDepth", 3);
   const pollSteps = await deployment.start("poll", { incremental: true, verify: false });
   await deployment.runSteps(pollSteps, 0);
+  // restore it
+  deployment.updateDeployConfig(EContracts.VkRegistry, "messageTreeDepth", messageTreeDepth);
 
   try {
     const startBalance = await deployer.provider.getBalance(deployer);


### PR DESCRIPTION
# Description

Make benchmark automatically change message tree depth 
Do not use estimate gas as it provides unreliable results (for instance on op sepolia says 100 would work but doesn't actually work)

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
