### PR TITLE
fix: do not cleanup thread all the time while doing parallel proof gen

### DIFF
--- a/packages/circuits/ts/proofs.ts
+++ b/packages/circuits/ts/proofs.ts
@@ -118,25 +118,34 @@ async function unlinkFile(filepath: string): Promise<void> {
  * @param publicInputs - the public inputs to the circuit
  * @param proof - the proof
  * @param vk - the verification key
+ * @param cleanup - whether to cleanup the threads or not
  * @returns whether the proof is valid or not
  */
 export const verifyProof = async (
   publicInputs: PublicSignals,
   proof: Groth16Proof,
   vk: ISnarkJSVerificationKey,
+  cleanup = true,
 ): Promise<boolean> => {
   const isValid = await groth16.verify(vk, publicInputs, proof);
-  await cleanThreads();
+  if (cleanup) {
+    await cleanThreads();
+  }
   return isValid;
 };
 
 /**
  * Extract the Verification Key from a zKey
  * @param zkeyPath - the path to the zKey
+ * @param cleanup - whether to cleanup the threads or not
  * @returns the verification key
  */
-export const extractVk = async (zkeyPath: string): Promise<IVkObjectParams> =>
+export const extractVk = async (zkeyPath: string, cleanup = true): Promise<IVkObjectParams> =>
   zKey
     .exportVerificationKey(zkeyPath)
     .then((vk) => vk as IVkObjectParams)
-    .finally(() => cleanThreads());
+    .finally(() => {
+      if (cleanup) {
+        cleanThreads();
+      }
+    });


### PR DESCRIPTION
# Description

There currently is a hanging issue with generating proofs within the hardhat tasks due to the different promises opening and closing handles to the same curve (reference: https://github.com/iden3/snarkjs/issues/152)

Also, do not extract Vk every time but only once when generating proofs for multiple batches

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
