### PR TITLE
feat(scripts): added merkleproof gatekeeper to signup script and utils

### DIFF
--- a/packages/cli/ts/commands/signup.ts
+++ b/packages/cli/ts/commands/signup.ts
@@ -6,6 +6,7 @@ import {
   ZupassGatekeeper__factory as ZupassGatekeeperFactory,
   EASGatekeeper__factory as EASGatekeeperFactory,
   HatsGatekeeperSingle__factory as HatsSingleGatekeeperFactory,
+  MerkleProofGatekeeper__factory as MerkleProofGatekeeperFactory,
 } from "maci-contracts/typechain-types";
 import { PubKey } from "maci-domainobjs";
 
@@ -20,6 +21,7 @@ import type {
   IZupassGatekeeperData,
   IEASGatekeeperData,
   IHatsGatekeeperData,
+  IMerkleProofGatekeeperData,
 } from "../utils/interfaces";
 
 import { banner } from "../utils/banner";
@@ -299,5 +301,28 @@ export const getHatsSingleGatekeeperData = async ({
   return {
     criterionHat: [criterionHat.toString()],
     hatsContract: hatsContract.toString(),
+  };
+};
+
+/**
+ * Get the merkleproof gatekeeper data
+ * @param IGetGatekeeperDataArgs - The arguments for the get merkleproof gatekeeper data command
+ * @returns The merkleproof gatekeeper data
+ */
+export const getMerkleProofGatekeeperData = async ({
+  maciAddress,
+  signer,
+}: IGetGatekeeperDataArgs): Promise<IMerkleProofGatekeeperData> => {
+  const maciContract = MACIFactory.connect(maciAddress, signer);
+
+  // get the address of the signup gatekeeper
+  const gatekeeperContractAddress = await maciContract.signUpGatekeeper();
+
+  const gatekeeperContract = MerkleProofGatekeeperFactory.connect(gatekeeperContractAddress, signer);
+
+  const [validRoot] = await Promise.all([gatekeeperContract.root()]);
+
+  return {
+    root: validRoot.toString(),
   };
 };

--- a/packages/cli/ts/sdk/index.ts
+++ b/packages/cli/ts/sdk/index.ts
@@ -13,6 +13,7 @@ import {
   getZupassGatekeeperData,
   getEASGatekeeperData,
   getHatsSingleGatekeeperData,
+  getMerkleProofGatekeeperData,
 } from "../commands/signup";
 import { verify } from "../commands/verify";
 
@@ -33,6 +34,7 @@ export {
   getZupassGatekeeperData,
   getEASGatekeeperData,
   getHatsSingleGatekeeperData,
+  getMerkleProofGatekeeperData,
 };
 
 export type { ISnarkJSVerificationKey } from "maci-circuits";
@@ -69,4 +71,5 @@ export type {
   ISemaphoreGatekeeperData,
   IZupassGatekeeperData,
   IHatsGatekeeperData,
+  IMerkleProofGatekeeperData,
 } from "../utils";

--- a/packages/cli/ts/utils/index.ts
+++ b/packages/cli/ts/utils/index.ts
@@ -51,6 +51,7 @@ export type {
   IZupassGatekeeperData,
   IEASGatekeeperData,
   IHatsGatekeeperData,
+  IMerkleProofGatekeeperData,
 } from "./interfaces";
 export { GatekeeperTrait } from "./interfaces";
 export { compareVks } from "./vks";

--- a/packages/cli/ts/utils/interfaces.ts
+++ b/packages/cli/ts/utils/interfaces.ts
@@ -1134,6 +1134,7 @@ export enum GatekeeperTrait {
   Semaphore = "Semaphore",
   Token = "Token",
   Zupass = "Zupass",
+  MerkleProof = "MerkleProof",
 }
 
 /**
@@ -1219,4 +1220,14 @@ export interface IHatsGatekeeperData {
    * The hats contract
    */
   hatsContract: string;
+}
+
+/**
+ * Interface for the MerkleProof gatekeeper data
+ */
+export interface IMerkleProofGatekeeperData {
+  /**
+   * The merkle tree root
+   */
+  root: string;
 }


### PR DESCRIPTION
# Description

Added merkleproof gatekeeper to signup script and utils

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
