### PR TITLE
chore(docs): update link for AccQueue contract

### DIFF
--- a/apps/website/versioned_docs/version-v2.x/core-concepts/merkle-trees.md
+++ b/apps/website/versioned_docs/version-v2.x/core-concepts/merkle-trees.md
@@ -5,7 +5,7 @@ sidebar_label: Merkle Trees
 sidebar_position: 5
 ---
 
-MACI uses different types of merkle trees to store and manage data. On chain, a [LazyIMT](https://github.com/privacy-scaling-explorations/zk-kit.solidity/tree/main/packages/lazy-imt) is used to store user's state leaves, and an [AccQueue](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/trees/AccQueue.sol) to store user's messages.
+MACI uses different types of merkle trees to store and manage data. On chain, a [LazyIMT](https://github.com/privacy-scaling-explorations/zk-kit.solidity/tree/main/packages/lazy-imt) is used to store user's state leaves, and an [AccQueue](https://github.com/privacy-scaling-explorations/maci/blob/dev/packages/contracts/contracts/trees/AccQueue.sol) to store user's messages.
 
 ## Accumulator queue
 


### PR DESCRIPTION
# Description
This PR updates de github link for the `AccQueue.sol` contract in the documentation. The current link does not work

## Additional Notes
None

## Related issue(s)
None

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
