### PR TITLE
docs(maci-wrapper-guide): updated maci wrapper guide

### DIFF
--- a/apps/website/versioned_docs/version-v2.x/developers-references/maci-wrapper/QuickStartGuide.md
+++ b/apps/website/versioned_docs/version-v2.x/developers-references/maci-wrapper/QuickStartGuide.md
@@ -90,8 +90,6 @@ In a fourth terminal window, clone the MACI repository:
 
 ```bash
 git clone git@github.com:privacy-scaling-explorations/maci.git
-cd maci
-git reset --hard ee3e2a6
 ```
 
 Copy the zkeys generated from the maci-wrapper repo to the CLI directory of the MACI repo:


### PR DESCRIPTION
# Description

Updated to v2 MACI Wrapper guide

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
