### PR TITLE
feat(contracts): add total spent to tally

### DIFF
--- a/packages/cli/ts/commands/proveOnChain.ts
+++ b/packages/cli/ts/commands/proveOnChain.ts
@@ -383,7 +383,10 @@ export const proveOnChain = async ({
         tallyData.results.tally.map((_, index) => index),
         tallyResults,
         tallyResultProofs,
+        tallyData.totalSpentVoiceCredits.spent,
+        tallyData.totalSpentVoiceCredits.salt,
         tallyData.results.salt,
+        tallyData.results.commitment,
         tallyData.totalSpentVoiceCredits.commitment,
         tallyData.perVOSpentVoiceCredits?.commitment ?? 0n,
       )

--- a/packages/contracts/tasks/helpers/Prover.ts
+++ b/packages/contracts/tasks/helpers/Prover.ts
@@ -321,7 +321,10 @@ export class Prover {
         tallyData.results.tally.map((_, index) => index),
         tallyResults,
         tallyResultProofs,
+        tallyData.totalSpentVoiceCredits.spent,
+        tallyData.totalSpentVoiceCredits.salt,
         tallyData.results.salt,
+        tallyData.results.commitment,
         tallyData.totalSpentVoiceCredits.commitment,
         tallyData.perVOSpentVoiceCredits?.commitment ?? 0n,
       )

--- a/packages/contracts/tests/Tally.test.ts
+++ b/packages/contracts/tests/Tally.test.ts
@@ -320,7 +320,10 @@ describe("TallyVotes", () => {
           tallyData.results.tally.map((_, index) => index),
           tallyData.results.tally,
           tallyResultProofs,
+          tallyData.totalSpentVoiceCredits.spent,
+          tallyData.totalSpentVoiceCredits.salt,
           tallyData.results.salt,
+          tallyData.results.commitment,
           tallyData.totalSpentVoiceCredits.commitment,
           0n,
         ),
@@ -372,12 +375,29 @@ describe("TallyVotes", () => {
 
       const indices = tallyData.results.tally.map((_, index) => index);
 
+      await expect(
+        tallyContract.addTallyResults(
+          indices,
+          tallyData.results.tally,
+          tallyResultProofs,
+          0n,
+          0n,
+          tallyData.results.salt,
+          0n,
+          tallyData.totalSpentVoiceCredits.commitment,
+          newPerVOSpentVoiceCreditsCommitment,
+        ),
+      ).to.be.revertedWithCustomError(tallyContract, "IncorrectSpentVoiceCredits");
+
       await tallyContract
         .addTallyResults(
           indices,
           tallyData.results.tally,
           tallyResultProofs,
+          tallyData.totalSpentVoiceCredits.spent,
+          tallyData.totalSpentVoiceCredits.salt,
           tallyData.results.salt,
+          tallyData.results.commitment,
           tallyData.totalSpentVoiceCredits.commitment,
           newPerVOSpentVoiceCreditsCommitment,
         )
@@ -394,7 +414,10 @@ describe("TallyVotes", () => {
           indices,
           tallyData.results.tally,
           tallyResultProofs,
+          tallyData.totalSpentVoiceCredits.spent,
+          tallyData.totalSpentVoiceCredits.salt,
           tallyData.results.salt,
+          tallyData.results.commitment,
           tallyData.totalSpentVoiceCredits.commitment,
           newPerVOSpentVoiceCreditsCommitment,
         )
@@ -436,7 +459,10 @@ describe("TallyVotes", () => {
           tallyData.results.tally.map((_, index) => index),
           tallyData.results.tally,
           tallyResultProofs,
+          tallyData.totalSpentVoiceCredits.spent,
+          tallyData.totalSpentVoiceCredits.salt,
           tallyData.results.salt,
+          tallyData.results.commitment,
           tallyData.totalSpentVoiceCredits.commitment,
           0n,
         ),


### PR DESCRIPTION
# Description

- [x] Update add tally results method signature
- [x] Compatibility fixes
- [x] Add total spent to tally contract

## Additional Notes

Need for alpha calculation in https://github.com/privacy-scaling-explorations/maci-platform/pull/353

## Related issue(s)

Related to https://github.com/privacy-scaling-explorations/maci-platform/issues/263

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
