### PR TITLE
Revert "chore(deps-dev): bump typedoc-plugin-markdown from 4.2.6 to 4.2.9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "tar": "^7.4.3",
     "ts-node": "^10.9.1",
     "typedoc": "^0.26.7",
-    "typedoc-plugin-markdown": "^4.2.9",
+    "typedoc-plugin-markdown": "^4.2.6",
     "typescript": "^5.5.4"
   },
   "config": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^0.26.7
         version: 0.26.7(typescript@5.5.4)
       typedoc-plugin-markdown:
-        specifier: ^4.2.9
-        version: 4.2.9(typedoc@0.26.7(typescript@5.5.4))
+        specifier: ^4.2.6
+        version: 4.2.6(typedoc@0.26.7(typescript@5.5.4))
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -9750,8 +9750,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typedoc-plugin-markdown@4.2.9:
-    resolution: {integrity: sha512-Wqmx+7ezKFgtTklEq/iUhQ5uFeBDhAT6wiS2na9cFLidIpl9jpDHJy/COYh8jUZXgIRIZVQ/bPNjyrnPFoDwzg==}
+  typedoc-plugin-markdown@4.2.6:
+    resolution: {integrity: sha512-k33o2lZSGpL3GjH28eW+RsujzCYFP0L5GNqpK+wa4CBcMOxpj8WV7SydNRLS6eSa2UvaPvNVJTaAZ6Tm+8GXoA==}
     engines: {node: '>= 18'}
     peerDependencies:
       typedoc: 0.26.x
@@ -22628,7 +22628,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-plugin-markdown@4.2.9(typedoc@0.26.7(typescript@5.5.4)):
+  typedoc-plugin-markdown@4.2.6(typedoc@0.26.7(typescript@5.5.4)):
     dependencies:
       typedoc: 0.26.7(typescript@5.5.4)
 


### PR DESCRIPTION
Reverts privacy-scaling-explorations/maci#1863