### PR TITLE
revert(dev-deps): revert hardhat to 2.22.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "ethers": "^6.13.2",
-    "hardhat": "^2.22.13",
+    "hardhat": "^2.22.8",
     "maci-circuits": "^2.4.0",
     "maci-contracts": "^2.4.0",
     "maci-core": "^2.4.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -158,7 +158,7 @@
     "@openzeppelin/merkle-tree": "^1.0.7",
     "circomlibjs": "^0.1.7",
     "ethers": "^6.13.2",
-    "hardhat": "^2.22.13",
+    "hardhat": "^2.22.8",
     "lowdb": "^1.0.0",
     "maci-circuits": "^2.4.0",
     "maci-core": "^2.4.0",

--- a/packages/integrationTests/package.json
+++ b/packages/integrationTests/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^22.8.1",
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.2",
-    "hardhat": "^2.22.13",
+    "hardhat": "^2.22.8",
     "hardhat-artifactor": "^0.2.0",
     "hardhat-contract-sizer": "^2.0.3",
     "mocha": "^10.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,7 +265,7 @@ importers:
         version: 12.1.0(commander@12.1.0)
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(iwitdxydvn3ug6asrzd5zh2jwu)
+        version: 5.0.0(mchzsygxifgsg6sab4essetdli)
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -276,8 +276,8 @@ importers:
         specifier: ^6.13.2
         version: 6.13.2
       hardhat:
-        specifier: ^2.22.13
-        version: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+        specifier: ^2.22.8
+        version: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       maci-circuits:
         specifier: ^2.4.0
         version: link:../circuits
@@ -341,10 +341,10 @@ importers:
     dependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.8
-        version: 3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+        version: 3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(iwitdxydvn3ug6asrzd5zh2jwu)
+        version: 5.0.0(mchzsygxifgsg6sab4essetdli)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -358,8 +358,8 @@ importers:
         specifier: ^6.13.2
         version: 6.13.2
       hardhat:
-        specifier: ^2.22.13
-        version: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+        specifier: ^2.22.8
+        version: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       lowdb:
         specifier: ^1.0.0
         version: 1.0.0
@@ -377,7 +377,7 @@ importers:
         version: link:../domainobjs
       solidity-docgen:
         specifier: ^0.6.0-beta.36
-        version: 0.6.0-beta.36(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+        version: 0.6.0-beta.36(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -411,10 +411,10 @@ importers:
         version: 16.4.5
       hardhat-artifactor:
         specifier: ^0.2.0
-        version: 0.2.0(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+        version: 0.2.0(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       hardhat-contract-sizer:
         specifier: ^2.10.0
-        version: 2.10.0(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+        version: 2.10.0(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@22.8.1)(typescript@5.5.4)
@@ -540,7 +540,7 @@ importers:
     dependencies:
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(iwitdxydvn3ug6asrzd5zh2jwu)
+        version: 5.0.0(mchzsygxifgsg6sab4essetdli)
       ethers:
         specifier: ^6.13.2
         version: 6.13.2
@@ -582,14 +582,14 @@ importers:
         specifier: ^7.1.2
         version: 7.1.2(chai@4.4.1)
       hardhat:
-        specifier: ^2.22.13
-        version: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+        specifier: ^2.22.8
+        version: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       hardhat-artifactor:
         specifier: ^0.2.0
-        version: 0.2.0(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+        version: 0.2.0(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       hardhat-contract-sizer:
         specifier: ^2.0.3
-        version: 2.10.0(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+        version: 2.10.0(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       mocha:
         specifier: ^10.7.3
         version: 10.7.3
@@ -2069,36 +2069,36 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.6.3':
-    resolution: {integrity: sha512-hqtI7tYDqKG5PDmZ//Z65EH5cgH8VL/SAAu50rpHP7WAVfJWkOCcYbecywwF6nhHdonJbRTDGAeG1/+VOy6zew==}
+  '@nomicfoundation/edr-darwin-arm64@0.6.4':
+    resolution: {integrity: sha512-QNQErISLgssV9+qia8sIjRANqtbW8snSDvjspixT/kSQ5ZSGxxctTg7x72wPSrcu8+EBEveIe5uqENIp5GH8HQ==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-darwin-x64@0.6.3':
-    resolution: {integrity: sha512-4fGi79/lyOlRUORhCYsYb3sWqRHuHT7qqzyZfZuNOn8llaxmT1k36xNmvpyg37R8SzjnhT/DzoukSJrs23Ip9Q==}
+  '@nomicfoundation/edr-darwin-x64@0.6.4':
+    resolution: {integrity: sha512-cjVmREiwByyc9+oGfvAh49IAw+oVJHF9WWYRD+Tm/ZlSpnEVWxrGNBak2bd/JSYjn+mZE7gmWS4SMRi4nKaLUg==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.6.3':
-    resolution: {integrity: sha512-yFFTvGFMhfAvQ1Z2itUh1jpoUA+mVROyVELcaxjIq8fyg602lQmbS+NXkhQ+oaeDgJ+06mSENrHBg4fcfRf9cw==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.6.4':
+    resolution: {integrity: sha512-96o9kRIVD6W5VkgKvUOGpWyUGInVQ5BRlME2Fa36YoNsRQMaKtmYJEU0ACosYES6ZTpYC8U5sjMulvPtVoEfOA==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.6.3':
-    resolution: {integrity: sha512-pOKmd0Fa3a6BHg5qbjbl/jMRELVi9oazbfiuU7Bvgn/dpTK+ID3jwT0SXiuC2zxjmPByWgXL6G9XRf5BPAM2rQ==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.6.4':
+    resolution: {integrity: sha512-+JVEW9e5plHrUfQlSgkEj/UONrIU6rADTEk+Yp9pbe+mzNkJdfJYhs5JYiLQRP4OjxH4QOrXI97bKU6FcEbt5Q==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.6.3':
-    resolution: {integrity: sha512-3AUferhkLIXtLV63w5GjpHttzdxZ36i656XMy+pkBZbbiqnzIVeKWg6DJv1A94fQY16gB4gqj9CLq4CWvbNN6w==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.6.4':
+    resolution: {integrity: sha512-nzYWW+fO3EZItOeP4CrdMgDXfaGBIBkKg0Y/7ySpUxLqzut40O4Mb0/+quqLAFkacUSWMlFp8nsmypJfOH5zoA==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.6.3':
-    resolution: {integrity: sha512-fr6bD872WIBXe9YnTDi0CzYepMcYRgSnkVqn0yK4wRnIvKrloWhxXNVY45GVIl51aNZguBnvoA4WEt6HIazs3A==}
+  '@nomicfoundation/edr-linux-x64-musl@0.6.4':
+    resolution: {integrity: sha512-QFRoE9qSQ2boRrVeQ1HdzU+XN7NUgwZ1SIy5DQt4d7jCP+5qTNsq8LBNcqhRBOATgO63nsweNUhxX/Suj5r1Sw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.6.3':
-    resolution: {integrity: sha512-sn34MvN1ajw2Oq1+Drpxej78Z0HfIzI4p4WlolupAV9dOZKzp2JAIQeLVfZpjIFbF3zuyxLPP4dUBrQoFPEqhA==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.6.4':
+    resolution: {integrity: sha512-2yopjelNkkCvIjUgBGhrn153IBPLwnsDeNiq6oA0WkeM8tGmQi4td+PGi9jAriUDAkc59Yoi2q9hYA6efiY7Zw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr@0.6.3':
-    resolution: {integrity: sha512-hThe5ORR75WFYTXKL0K2AyLDxkTMrG+VQ1yL9BhQYsuh3OIH+3yNDxMz2LjfvrpOrMmJ4kk5NKdFewpqDojjXQ==}
+  '@nomicfoundation/edr@0.6.4':
+    resolution: {integrity: sha512-YgrSuT3yo5ZQkbvBGqQ7hG+RDvz3YygSkddg4tb1Z0Y6pLXFzwrcEwWaJCFAVeeZxdxGfCgGMUYgRVneK+WXkw==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/ethereumjs-common@4.0.4':
@@ -5799,8 +5799,8 @@ packages:
     peerDependencies:
       hardhat: ^2.0.2
 
-  hardhat@2.22.13:
-    resolution: {integrity: sha512-psVJX4FSXDpSXwsU8OcKTJN04pQEj9cFBMX5OPko+OFwbIoiOpvRmafa954/UaA1934npTj8sV3gaTSdx9bPbA==}
+  hardhat@2.22.15:
+    resolution: {integrity: sha512-BpTGa9PE/sKAaHi4s/S1e9WGv63DR1m7Lzfd60C8gSEchDPfAJssVRSq0MZ2v2k76ig9m0kHAwVLf5teYwu/Mw==}
     hasBin: true
     peerDependencies:
       ts-node: '*'
@@ -13189,29 +13189,29 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@nomicfoundation/edr-darwin-arm64@0.6.3': {}
+  '@nomicfoundation/edr-darwin-arm64@0.6.4': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.6.3': {}
+  '@nomicfoundation/edr-darwin-x64@0.6.4': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.6.3': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.6.4': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.6.3': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.6.4': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.6.3': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.6.4': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.6.3': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.6.4': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.6.3': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.6.4': {}
 
-  '@nomicfoundation/edr@0.6.3':
+  '@nomicfoundation/edr@0.6.4':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.6.3
-      '@nomicfoundation/edr-darwin-x64': 0.6.3
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.6.3
-      '@nomicfoundation/edr-linux-arm64-musl': 0.6.3
-      '@nomicfoundation/edr-linux-x64-gnu': 0.6.3
-      '@nomicfoundation/edr-linux-x64-musl': 0.6.3
-      '@nomicfoundation/edr-win32-x64-msvc': 0.6.3
+      '@nomicfoundation/edr-darwin-arm64': 0.6.4
+      '@nomicfoundation/edr-darwin-x64': 0.6.4
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.6.4
+      '@nomicfoundation/edr-linux-arm64-musl': 0.6.4
+      '@nomicfoundation/edr-linux-x64-gnu': 0.6.4
+      '@nomicfoundation/edr-linux-x64-musl': 0.6.4
+      '@nomicfoundation/edr-win32-x64-msvc': 0.6.4
 
   '@nomicfoundation/ethereumjs-common@4.0.4':
     dependencies:
@@ -13233,83 +13233,83 @@ snapshots:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
 
-  '@nomicfoundation/hardhat-chai-matchers@2.0.7(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(chai@4.4.1)(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
+  '@nomicfoundation/hardhat-chai-matchers@2.0.7(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(chai@4.4.1)(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       '@types/chai-as-promised': 7.1.8
       chai: 4.4.1
       chai-as-promised: 7.1.2(chai@4.4.1)
       deep-eql: 4.1.4
       ethers: 6.13.2
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       ordinal: 1.0.3
 
-  '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
+  '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
     dependencies:
       debug: 4.3.6(supports-color@8.1.1)
       ethers: 6.13.2
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
 
-  '@nomicfoundation/hardhat-ignition-ethers@0.15.4(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/hardhat-ignition@0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/ignition-core@0.15.4)(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
+  '@nomicfoundation/hardhat-ignition-ethers@0.15.4(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/hardhat-ignition@0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/ignition-core@0.15.4)(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
-      '@nomicfoundation/hardhat-ignition': 0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-ignition': 0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       '@nomicfoundation/ignition-core': 0.15.4
       ethers: 6.13.2
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
 
-  '@nomicfoundation/hardhat-ignition@0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
+  '@nomicfoundation/hardhat-ignition@0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
     dependencies:
-      '@nomicfoundation/hardhat-verify': 2.0.8(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-verify': 2.0.8(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       '@nomicfoundation/ignition-core': 0.15.4
       '@nomicfoundation/ignition-ui': 0.15.4
       chalk: 4.1.2
       debug: 4.3.6(supports-color@8.1.1)
       fs-extra: 10.1.0
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       prompts: 2.4.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@nomicfoundation/hardhat-network-helpers@1.0.11(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
+  '@nomicfoundation/hardhat-network-helpers@1.0.11(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
 
-  '@nomicfoundation/hardhat-toolbox@5.0.0(iwitdxydvn3ug6asrzd5zh2jwu)':
+  '@nomicfoundation/hardhat-toolbox@5.0.0(mchzsygxifgsg6sab4essetdli)':
     dependencies:
-      '@nomicfoundation/hardhat-chai-matchers': 2.0.7(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(chai@4.4.1)(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
-      '@nomicfoundation/hardhat-ignition-ethers': 0.15.4(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/hardhat-ignition@0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/ignition-core@0.15.4)(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
-      '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
-      '@nomicfoundation/hardhat-verify': 2.0.8(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-chai-matchers': 2.0.7(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(chai@4.4.1)(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-ignition-ethers': 0.15.4(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/hardhat-ignition@0.15.4(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)))(@nomicfoundation/ignition-core@0.15.4)(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      '@nomicfoundation/hardhat-verify': 2.0.8(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.2)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)
-      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.2)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4))(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))(typechain@8.3.2(typescript@5.5.4))
+      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.2)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4))(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))(typechain@8.3.2(typescript@5.5.4))
       '@types/chai': 4.3.16
       '@types/mocha': 10.0.8
       '@types/node': 22.8.1
       chai: 4.4.1
       ethers: 6.13.2
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
-      hardhat-gas-reporter: 1.0.10(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
-      solidity-coverage: 0.8.12(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat-gas-reporter: 1.0.10(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
+      solidity-coverage: 0.8.12(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))
       ts-node: 10.9.2(@types/node@22.8.1)(typescript@5.5.4)
       typechain: 8.3.2(typescript@5.5.4)
       typescript: 5.5.4
 
-  '@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
+  '@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/address': 5.7.0
       cbor: 8.1.0
       chalk: 2.4.2
       debug: 4.3.6(supports-color@8.1.1)
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       lodash.clonedeep: 4.5.0
       semver: 6.3.1
       table: 6.8.2
@@ -14082,12 +14082,12 @@ snapshots:
       typechain: 8.3.2(typescript@5.5.4)
       typescript: 5.5.4
 
-  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.2)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4))(ethers@6.13.2)(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))(typechain@8.3.2(typescript@5.5.4))':
+  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.2)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4))(ethers@6.13.2)(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4))(typechain@8.3.2(typescript@5.5.4))':
     dependencies:
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.2)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)
       ethers: 6.13.2
       fs-extra: 9.1.0
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       typechain: 8.3.2(typescript@5.5.4)
 
   '@types/acorn@4.0.6':
@@ -17772,22 +17772,22 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  hardhat-artifactor@0.2.0(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
+  hardhat-artifactor@0.2.0(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
     dependencies:
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
 
-  hardhat-contract-sizer@2.10.0(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
+  hardhat-contract-sizer@2.10.0(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
     dependencies:
       chalk: 4.1.2
       cli-table3: 0.6.5
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       strip-ansi: 6.0.1
 
-  hardhat-gas-reporter@1.0.10(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
+  hardhat-gas-reporter@1.0.10(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
     dependencies:
       array-uniq: 1.0.3
       eth-gas-reporter: 0.2.27
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       sha1: 1.1.1
     transitivePeerDependencies:
       - '@codechecks/client'
@@ -17795,11 +17795,11 @@ snapshots:
       - debug
       - utf-8-validate
 
-  hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4):
+  hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
-      '@nomicfoundation/edr': 0.6.3
+      '@nomicfoundation/edr': 0.6.4
       '@nomicfoundation/ethereumjs-common': 4.0.4
       '@nomicfoundation/ethereumjs-tx': 5.0.4
       '@nomicfoundation/ethereumjs-util': 9.0.4
@@ -22109,7 +22109,7 @@ snapshots:
     dependencies:
       array.prototype.findlast: 1.2.5
 
-  solidity-coverage@0.8.12(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
+  solidity-coverage@0.8.12(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@solidity-parser/parser': 0.18.0
@@ -22120,7 +22120,7 @@ snapshots:
       ghost-testrpc: 0.0.2
       global-modules: 2.0.0
       globby: 10.0.2
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       jsonschema: 1.4.1
       lodash: 4.17.21
       mocha: 10.7.3
@@ -22132,10 +22132,10 @@ snapshots:
       shelljs: 0.8.5
       web3-utils: 1.10.4
 
-  solidity-docgen@0.6.0-beta.36(hardhat@2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
+  solidity-docgen@0.6.0-beta.36(hardhat@2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)):
     dependencies:
       handlebars: 4.7.8
-      hardhat: 2.22.13(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
+      hardhat: 2.22.15(ts-node@10.9.2(@types/node@22.8.1)(typescript@5.5.4))(typescript@5.5.4)
       solidity-ast: 0.4.56
 
   sort-css-media-queries@2.2.0: {}


### PR DESCRIPTION
# Description

Revert hardhat dependency to fix vercel builds

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
