### PR TITLE
feat(contracts): use contract names for deployment service

### DIFF
--- a/packages/contracts/tasks/runner/benchmarks.ts
+++ b/packages/contracts/tasks/runner/benchmarks.ts
@@ -6,7 +6,7 @@ import { Deployment } from "../helpers/Deployment";
 import { EContracts } from "../helpers/types";
 
 task("benchmark", "Run benchmarks").setAction(async (_, hre) => {
-  const deployment = Deployment.getInstance(hre);
+  const deployment = Deployment.getInstance({ hre });
   deployment.setHre(hre);
 
   const deployer = await deployment.getDeployer();

--- a/packages/contracts/tasks/runner/deployFull.ts
+++ b/packages/contracts/tasks/runner/deployFull.ts
@@ -15,7 +15,7 @@ task("deploy-full", "Deploy environment")
   .addFlag("verify", "Verify contracts at Etherscan")
   .addOptionalParam("skip", "Skip steps with less or equal index", 0, types.int)
   .setAction(async ({ incremental, strict, verify, skip = 0 }: IDeployParams, hre) => {
-    const deployment = Deployment.getInstance(hre);
+    const deployment = Deployment.getInstance({ hre });
 
     deployment.setHre(hre);
 

--- a/packages/contracts/tasks/runner/deployPoll.ts
+++ b/packages/contracts/tasks/runner/deployPoll.ts
@@ -15,7 +15,7 @@ task("deploy-poll", "Deploy poll")
   .addFlag("verify", "Verify contracts at Etherscan")
   .addOptionalParam("skip", "Skip steps with less or equal index", 0, types.int)
   .setAction(async ({ strict, verify, skip = 0 }: IDeployParams, hre) => {
-    const deployment = Deployment.getInstance(hre);
+    const deployment = Deployment.getInstance({ hre });
 
     deployment.setHre(hre);
 

--- a/packages/contracts/tasks/runner/merge.ts
+++ b/packages/contracts/tasks/runner/merge.ts
@@ -18,7 +18,7 @@ task("merge", "Merge signups and messages")
   .addOptionalParam("queueOps", "The number of queue operations to perform", DEFAULT_SR_QUEUE_OPS, types.int)
   .addOptionalParam("prove", "Run prove command after merging", false, types.boolean)
   .setAction(async ({ poll, prove, queueOps = DEFAULT_SR_QUEUE_OPS }: IMergeParams, hre) => {
-    const deployment = Deployment.getInstance(hre);
+    const deployment = Deployment.getInstance({ hre });
 
     deployment.setHre(hre);
 

--- a/packages/contracts/ts/deploy.ts
+++ b/packages/contracts/ts/deploy.ts
@@ -47,7 +47,7 @@ import { log } from "./utils";
  */
 export const createContractFactory = async (abi: TAbi, bytecode: string, signer?: Signer): Promise<ContractFactory> => {
   const hre = await import("hardhat");
-  const deployment = Deployment.getInstance(hre);
+  const deployment = Deployment.getInstance({ hre });
   deployment.setHre(hre);
   const deployer = signer || (await deployment.getDeployer());
 
@@ -69,7 +69,7 @@ export const deployContract = async <T extends BaseContract>(
 ): Promise<T> => {
   log(`Deploying ${contractName}`, quiet);
   const hre = await import("hardhat");
-  const deployment = Deployment.getInstance(hre);
+  const deployment = Deployment.getInstance({ hre });
   deployment.setHre(hre);
 
   return deployment.deployContract({ name: contractName as EContracts, signer }, ...args);
@@ -246,7 +246,7 @@ export const deployContractWithLinkedLibraries = async <T extends BaseContract>(
   ...args: unknown[]
 ): Promise<T> => {
   const hre = await import("hardhat");
-  const deployment = Deployment.getInstance(hre);
+  const deployment = Deployment.getInstance({ hre });
   deployment.setHre(hre);
 
   return deployment.deployContractWithLinkedLibraries({ contractFactory }, ...args);


### PR DESCRIPTION
# Description

Update deployment helper service to support different contract names.

## Additional Notes

N/A

## Related issue(s)

Related to https://github.com/privacy-scaling-explorations/maci-platform/issues/433

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
