### PR TITLE
docs: update README.md

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -103,5 +103,5 @@ For more details about testing please refer to the [tests documentation](https:/
 ## Directory Structure
 
 - `ts/`: The home for our core classes, `MaciState` and `Poll`
-- `ts/utls/`: Contains supporting utilities
+- `ts/utils/`: Contains supporting utilities
 - `ts/__tests__/`: A dedicated test suite directory


### PR DESCRIPTION
### Fix Typo in Directory Path: `ts/utls/` → `ts/utils/`

**Summary:**
This PR fixes a minor typo in the directory path from `ts/utls/` to `ts/utils/`. The original spelling "utls" is incorrect, and the correct term is "utils", which is short for "utilities."

**Importance:**
This fix is crucial for ensuring the clarity and consistency of the project. The typo could confuse developers who are unfamiliar with the directory structure or lead to potential issues if they try to reference a non-existent directory. Correcting it will improve the overall readability of the documentation and prevent possible errors in the future.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
