### PR TITLE
Typo Update README.md

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -103,5 +103,5 @@ For more details about testing please refer to the [tests documentation](https:/
 ## Directory Structure
 
 - `ts/`: The home for our core classes, `MaciState` and `Poll`
-- `ts/utls/`: Contains supporting utilities
+- `ts/utils/`: Contains supporting utilities
 - `ts/__tests__/`: A dedicated test suite directory


### PR DESCRIPTION
## Description:
I noticed a small typo in the directory structure section of the documentation. Specifically, the directory name **"utls"** was used, which is a common misspelling of **"utils"**. 

The corrected directory structure should be:

- `ts/utils/`: Contains supporting utilities

## Importance:
This change is important because the misspelling could cause confusion for developers reading the documentation, especially when they try to access or reference the correct directory. Standardizing the spelling of "utils" will ensure consistency and reduce the likelihood of errors during development.

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
