### PR TITLE
Update README.md

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@
 [![Actions Status][cli-actions-badge]][cli-actions-link]
 
 Please refer to the [documentation for the
-CLI](https://maci.pse.dev/docs/developers-references/typescript-code/cli).
+CLI](https://maci.pse.dev/docs/technical-references/typescript-code/cli).
 
 [cli-npm-badge]: https://img.shields.io/npm/v/maci-cli.svg
 [cli-actions-badge]: https://github.com/privacy-scaling-explorations/maci/actions/workflows/e2e.yml/badge.svg


### PR DESCRIPTION
# Description

The link for the documentation for the Command-line interface is broken here on the repo, Updating the correct link 🦄 from the Documentation [ maci.pse.dev ] 

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

The current link from the repo [ https://github.com/privacy-scaling-explorations/maci/tree/dev/packages/cli ] is getting redirected to [ https://maci.pse.dev/docs/developers-references/typescript-code/cli ] Which is broken, This PR is to change the reflected correct one [ https://maci.pse.dev/docs/technical-references/typescript-code/cli ] as referred on the documentation. 

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
