### PR TITLE
test(contracts): check the NOTHING_UP_MY_SLEEVE value in Poll test suite

### DIFF
--- a/packages/contracts/tests/Poll.test.ts
+++ b/packages/contracts/tests/Poll.test.ts
@@ -92,6 +92,10 @@ describe("Poll", () => {
       expect(p.toString()).to.eq(pollId.toString());
       // publish the NOTHING_UP_MY_SLEEVE message
       const messageData = [NOTHING_UP_MY_SLEEVE];
+      expect(
+        NOTHING_UP_MY_SLEEVE === BigInt("8370432830353022751713833565135785980866757267633941821328460903436894336785"),
+      );
+
       for (let i = 1; i < 10; i += 1) {
         messageData.push(BigInt(0));
       }


### PR DESCRIPTION
# Description

This PR checks the value of the NOTHING_UP_MY_SLEEVE in the Poll test suite

## Additional Notes

Hello :)

I am not entirely sure if this is the right approach to fix this issue but i figured the making the PR will be a good place to start. Please let me know what do you think. Any guidance will be appreciated for sure.

## Related issue(s)

Fix #1153 

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
