### PR TITLE
refactor: remove redundant init from poll contract

### DIFF
--- a/packages/contracts/contracts/PollFactory.sol
+++ b/packages/contracts/contracts/PollFactory.sol
@@ -35,9 +35,6 @@ contract PollFactory is Params, DomainObjs, IPollFactory {
       _pollId
     );
 
-    // init Poll
-    poll.init();
-
     pollAddr = address(poll);
   }
 }

--- a/packages/contracts/tests/Poll.test.ts
+++ b/packages/contracts/tests/Poll.test.ts
@@ -131,10 +131,6 @@ describe("Poll", () => {
       );
     });
 
-    it("should not be possible to init the Poll contract twice", async () => {
-      await expect(pollContract.init()).to.be.revertedWithCustomError(pollContract, "PollAlreadyInit");
-    });
-
     it("should have the correct coordinator public key set", async () => {
       const coordinatorPubKey = await pollContract.coordinatorPubKey();
       expect(coordinatorPubKey[0].toString()).to.eq(coordinator.pubKey.rawPubKey[0].toString());


### PR DESCRIPTION
# Description

Poll init is redundant so it can be removed to simplify the code

(needs #1854 merged first and new anon poll joining artifacts built)

## Confirmation

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have read and understand MACI's [GitHub processes](https://github.com/privacy-scaling-explorations/maci/discussions/847).
- [x] I have read and understand MACI's [testing guide](https://maci.pse.dev/docs/testing).
