### PR TITLE
Fix typographical errors

### DIFF
--- a/apps/website/src/scripts/utils.ts
+++ b/apps/website/src/scripts/utils.ts
@@ -99,7 +99,7 @@ export function generateToC(dir: string, prefix = ""): string {
 }
 
 /**
- * A function that insert a index page
+ * A function that insert an index page
  * @param dir - the directory to insert an index page
  * @param sidebarProps - including title, description, label, and position
  */

--- a/apps/website/versioned_docs/version-v1.2/typedoc/crypto/interfaces/PoseidonFuncs.md
+++ b/apps/website/versioned_docs/version-v1.2/typedoc/crypto/interfaces/PoseidonFuncs.md
@@ -3,7 +3,7 @@ title: PoseidonFuncs
 sidebar_label: PoseidonFuncs
 ---
 
-A interface for poseidon hash functions
+An interface for poseidon hash functions
 
 ## Indexable
 

--- a/apps/website/versioned_docs/version-v1.2/typedoc/domainobjs/classes/Ballot.md
+++ b/apps/website/versioned_docs/version-v1.2/typedoc/domainobjs/classes/Ballot.md
@@ -171,7 +171,7 @@ whether the two ballots are equal
 
 ▸ **hash**(): `bigint`
 
-Generate an hash of this ballot
+Generate a hash of this ballot
 
 #### Returns
 

--- a/packages/circuits/ts/proofs.ts
+++ b/packages/circuits/ts/proofs.ts
@@ -13,7 +13,7 @@ import { cleanThreads, isArm } from "./utils";
 
 /**
  * Generate a zk-SNARK proof
- * @dev if running on a intel chip we use rapidsnark for
+ * @dev if running on an intel chip we use rapidsnark for
  * speed - on the other hand if running on ARM we need to use
  * snark and a WASM witness
  * @param inputs - the inputs to the circuit

--- a/packages/cli/ts/utils/storage.ts
+++ b/packages/cli/ts/utils/storage.ts
@@ -51,7 +51,7 @@ export const storeContractAddress = async (
 /**
  * Read a contract address from the local address store file
  * @param contractName - the name of the contract
- * @returns the contract address or a undefined if it does not exist
+ * @returns the contract address or an undefined if it does not exist
  */
 export const readContractAddress = async (contractName: string, network = "default"): Promise<string> => {
   try {

--- a/packages/domainobjs/ts/__tests__/ballot.test.ts
+++ b/packages/domainobjs/ts/__tests__/ballot.test.ts
@@ -17,7 +17,7 @@ describe("Ballot", () => {
   });
 
   describe("hash", () => {
-    it("should produce an hash of the ballot", () => {
+    it("should produce a hash of the ballot", () => {
       const b = new Ballot(0, 2);
       const h = b.hash();
       expect(h).to.not.eq(null);

--- a/packages/domainobjs/ts/ballot.ts
+++ b/packages/domainobjs/ts/ballot.ts
@@ -30,7 +30,7 @@ export class Ballot {
   }
 
   /**
-   * Generate an hash of this ballot
+   * Generate a hash of this ballot
    * @returns The hash of the ballot
    */
   hash = (): bigint => {

--- a/packages/domainobjs/ts/commands/PCommand.ts
+++ b/packages/domainobjs/ts/commands/PCommand.ts
@@ -203,7 +203,7 @@ export class PCommand {
     const nonce = extract(p, 150);
     const pollId = extract(p, 200);
 
-    // create new public key but allow it to be invalid (as when passing an mismatched
+    // create new public key but allow it to be invalid (as when passing a mismatched
     // encPubKey, a message will not decrypt resulting in potentially invalid public keys)
     const newPubKey = new PubKey([decrypted[1], decrypted[2]], true);
     const salt = decrypted[3];


### PR DESCRIPTION
This pull request addresses various grammar and typographical errors across multiple files in the repository. 
The changes include the correction of improper articles ("a" vs. "an") and minor phrasing adjustments to improve code comments, documentation, and test descriptions.

## Changes Overview

1. **`apps/website/src/scripts/utils.ts`**:
   - Corrected "a index page" to "an index page".

2. **`PoseidonFuncs.md`**:
   - Updated "A interface" to "An interface".

3. **`Ballot.md`**:
   - Changed "Generate an hash" to "Generate a hash".

4. **`proofs.ts`**:
   - Adjusted "a intel chip" to "an intel chip".

5. **`storage.ts`**:
   - Replaced "a undefined" with "an undefined".

6. **`ballot.test.ts`**:
   - Fixed "an hash" to "a hash".

7. **`ballot.ts`**:
   - Updated "an hash" to "a hash".

8. **`PCommand.ts`**:
   - Corrected "an mismatched" to "a mismatched".

---

## Additional Notes

- These changes are aimed at enhancing the clarity and professionalism of the documentation and codebase.
- No functional changes were introduced.

---

## Related Issues

No specific issues linked to this PR.

---

## Confirmation

- [x] I have reviewed and adhered to the repository's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I have verified that all tests pass and my changes do not introduce any errors.

---

## Summary of Commits

- Fixed grammar in utility and domain objects files.
- Corrected articles and minor phrasing inconsistencies across test cases and documentation.
