### PR TITLE
feat: force the same key for each poll

### DIFF
--- a/packages/circuits/circom/anon/pollJoining.circom
+++ b/packages/circuits/circom/anon/pollJoining.circom
@@ -11,8 +11,6 @@ template PollJoining(stateTreeDepth) {
 
     // User's private key
     signal input privKey;
-    // Poll's private key
-    signal input pollPrivKey;
     // Poll's public key
     signal input pollPubKey[2];
     // Siblings
@@ -37,18 +35,17 @@ template PollJoining(stateTreeDepth) {
     // Hash the public key
     var pubKeyHash = PoseidonHasher(2)([derivedPubKey[0], derivedPubKey[1]]);
 
-    // Poll private to public key to verify the correct one is used to join the poll (public input)
-    var derivedPollPubKey[2] = PrivToPubKey()(pollPrivKey);
-    derivedPollPubKey[0] === pollPubKey[0];
-    derivedPollPubKey[1] === pollPubKey[1];
+    // Ensure the poll public key is the same as the maci one (public input)
+    derivedPubKey[0] === pollPubKey[0];
+    derivedPubKey[1] === pollPubKey[1];
 
     // Inclusion proof  
-    var stateLeafQip = BinaryMerkleRoot(stateTreeDepth)(
+    var calculatedRoot = BinaryMerkleRoot(stateTreeDepth)(
         pubKeyHash,
         actualStateTreeDepth,
         indices,
         siblings
     );
 
-    stateLeafQip === stateRoot;
+    calculatedRoot === stateRoot;
 }

--- a/packages/circuits/ts/types.ts
+++ b/packages/circuits/ts/types.ts
@@ -45,7 +45,6 @@ export interface IGenProofOptions {
  */
 export interface IPollJoiningInputs {
   privKey: bigint;
-  pollPrivKey: bigint;
   pollPubKey: bigint[][];
   stateLeaf: bigint[];
   siblings: bigint[][];

--- a/packages/cli/tests/e2e/e2e.test.ts
+++ b/packages/cli/tests/e2e/e2e.test.ts
@@ -107,7 +107,6 @@ describe("e2e tests", function test() {
     });
 
     const user = new Keypair();
-    const pollKeys = new Keypair();
 
     before(async () => {
       // deploy the smart contracts
@@ -129,7 +128,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user.privKey.serialize(),
-        pollPrivKey: pollKeys.privKey.serialize(),
         stateIndex: 1n,
         pollId: 0n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -144,7 +142,7 @@ describe("e2e tests", function test() {
 
     it("should publish one message", async () => {
       await publish({
-        pubkey: pollKeys.pubKey.serialize(),
+        pubkey: user.pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -152,7 +150,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys.privKey.serialize(),
+        privateKey: user.privKey.serialize(),
         signer,
       });
     });
@@ -176,7 +174,6 @@ describe("e2e tests", function test() {
     });
 
     const user = new Keypair();
-    const pollKeys = new Keypair();
 
     before(async () => {
       // deploy the smart contracts
@@ -193,7 +190,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user.privKey.serialize(),
-        pollPrivKey: pollKeys.privKey.serialize(),
         stateIndex: 1n,
         pollId: 0n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -208,7 +204,7 @@ describe("e2e tests", function test() {
 
     it("should publish one message", async () => {
       await publish({
-        pubkey: pollKeys.pubKey.serialize(),
+        pubkey: user.pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -216,7 +212,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys.privKey.serialize(),
+        privateKey: user.privKey.serialize(),
         signer,
       });
     });
@@ -242,7 +238,6 @@ describe("e2e tests", function test() {
     });
 
     const users = [new Keypair(), new Keypair(), new Keypair(), new Keypair()];
-    const pollKeys = [new Keypair(), new Keypair(), new Keypair(), new Keypair()];
 
     before(async () => {
       // deploy the smart contracts
@@ -266,7 +261,6 @@ describe("e2e tests", function test() {
         await joinPoll({
           maciAddress: maciAddresses.maciAddress,
           privateKey: users[i].privKey.serialize(),
-          pollPrivKey: pollKeys[i].privKey.serialize(),
           stateIndex: BigInt(i + 1),
           pollId: 0n,
           pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -282,7 +276,7 @@ describe("e2e tests", function test() {
 
     it("should publish eight messages", async () => {
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 2n,
@@ -290,11 +284,11 @@ describe("e2e tests", function test() {
         newVoteWeight: 4n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 2n,
@@ -302,11 +296,11 @@ describe("e2e tests", function test() {
         newVoteWeight: 3n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -314,11 +308,11 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
       await publish({
-        pubkey: pollKeys[1].pubKey.serialize(),
+        pubkey: users[1].pubKey.serialize(),
         stateIndex: 2n,
         voteOptionIndex: 2n,
         nonce: 1n,
@@ -326,11 +320,11 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[1].privKey.serialize(),
+        privateKey: users[1].privKey.serialize(),
         signer,
       });
       await publish({
-        pubkey: pollKeys[2].pubKey.serialize(),
+        pubkey: users[2].pubKey.serialize(),
         stateIndex: 3n,
         voteOptionIndex: 2n,
         nonce: 1n,
@@ -338,11 +332,11 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[2].privKey.serialize(),
+        privateKey: users[2].privKey.serialize(),
         signer,
       });
       await publish({
-        pubkey: pollKeys[3].pubKey.serialize(),
+        pubkey: users[3].pubKey.serialize(),
         stateIndex: 4n,
         voteOptionIndex: 2n,
         nonce: 3n,
@@ -350,11 +344,11 @@ describe("e2e tests", function test() {
         newVoteWeight: 3n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[3].privKey.serialize(),
+        privateKey: users[3].privKey.serialize(),
         signer,
       });
       await publish({
-        pubkey: pollKeys[3].pubKey.serialize(),
+        pubkey: users[3].pubKey.serialize(),
         stateIndex: 4n,
         voteOptionIndex: 2n,
         nonce: 2n,
@@ -362,11 +356,11 @@ describe("e2e tests", function test() {
         newVoteWeight: 2n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[3].privKey.serialize(),
+        privateKey: users[3].privKey.serialize(),
         signer,
       });
       await publish({
-        pubkey: pollKeys[3].pubKey.serialize(),
+        pubkey: users[3].pubKey.serialize(),
         stateIndex: 4n,
         voteOptionIndex: 1n,
         nonce: 1n,
@@ -374,7 +368,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[3].privKey.serialize(),
+        privateKey: users[3].privKey.serialize(),
         signer,
       });
     });
@@ -394,18 +388,6 @@ describe("e2e tests", function test() {
     });
 
     const users = [
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-    ];
-
-    const pollKeys = [
       new Keypair(),
       new Keypair(),
       new Keypair(),
@@ -439,7 +421,6 @@ describe("e2e tests", function test() {
         await joinPoll({
           maciAddress: maciAddresses.maciAddress,
           privateKey: users[i].privKey.serialize(),
-          pollPrivKey: pollKeys[i].privKey.serialize(),
           stateIndex: BigInt(i + 1),
           pollId: 0n,
           pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -455,7 +436,7 @@ describe("e2e tests", function test() {
 
     it("should publish one message", async () => {
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -463,7 +444,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
     });
@@ -483,7 +464,6 @@ describe("e2e tests", function test() {
     });
 
     const user = new Keypair();
-    const pollKeys = new Keypair();
 
     before(async () => {
       // deploy the smart contracts
@@ -504,7 +484,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user.privKey.serialize(),
-        pollPrivKey: pollKeys.privKey.serialize(),
         stateIndex: 1n,
         pollId: 0n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -521,7 +500,7 @@ describe("e2e tests", function test() {
       for (let i = 0; i < 12; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await publish({
-          pubkey: pollKeys.pubKey.serialize(),
+          pubkey: user.pubKey.serialize(),
           stateIndex: 1n,
           voteOptionIndex: 0n,
           nonce: 1n,
@@ -529,7 +508,7 @@ describe("e2e tests", function test() {
           newVoteWeight: 9n,
           maciAddress: maciAddresses.maciAddress,
           salt: genRandomSalt(),
-          privateKey: pollKeys.privKey.serialize(),
+          privateKey: user.privKey.serialize(),
           signer,
         });
       }
@@ -550,7 +529,6 @@ describe("e2e tests", function test() {
     });
 
     const users = Array.from({ length: 30 }, () => new Keypair());
-    const pollKeys = Array.from({ length: 30 }, () => new Keypair());
 
     before(async () => {
       // deploy the smart contracts
@@ -574,7 +552,6 @@ describe("e2e tests", function test() {
         await joinPoll({
           maciAddress: maciAddresses.maciAddress,
           privateKey: users[i].privKey.serialize(),
-          pollPrivKey: pollKeys[i].privKey.serialize(),
           stateIndex: BigInt(i + 1),
           pollId: 0n,
           pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -592,53 +569,53 @@ describe("e2e tests", function test() {
       // publish four different messages
       await publish({
         maciAddress: maciAddresses.maciAddress,
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
         pollId: 0n,
         newVoteWeight: 9n,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
 
       await publish({
         maciAddress: maciAddresses.maciAddress,
-        pubkey: pollKeys[1].pubKey.serialize(),
+        pubkey: users[1].pubKey.serialize(),
         stateIndex: 2n,
         voteOptionIndex: 1n,
         nonce: 1n,
         pollId: 0n,
         newVoteWeight: 9n,
         salt: genRandomSalt(),
-        privateKey: pollKeys[1].privKey.serialize(),
+        privateKey: users[1].privKey.serialize(),
         signer,
       });
 
       await publish({
         maciAddress: maciAddresses.maciAddress,
-        pubkey: pollKeys[2].pubKey.serialize(),
+        pubkey: users[2].pubKey.serialize(),
         stateIndex: 3n,
         voteOptionIndex: 2n,
         nonce: 1n,
         pollId: 0n,
         newVoteWeight: 9n,
         salt: genRandomSalt(),
-        privateKey: pollKeys[2].privKey.serialize(),
+        privateKey: users[2].privKey.serialize(),
         signer,
       });
 
       await publish({
         maciAddress: maciAddresses.maciAddress,
-        pubkey: pollKeys[3].pubKey.serialize(),
+        pubkey: users[3].pubKey.serialize(),
         stateIndex: 4n,
         voteOptionIndex: 3n,
         nonce: 1n,
         pollId: 0n,
         newVoteWeight: 9n,
         salt: genRandomSalt(),
-        privateKey: pollKeys[3].privKey.serialize(),
+        privateKey: users[3].privKey.serialize(),
         signer,
       });
     });
@@ -668,7 +645,6 @@ describe("e2e tests", function test() {
     });
 
     const user = new Keypair();
-    const pollKeys = new Keypair();
 
     before(async () => {
       // deploy the smart contracts
@@ -681,7 +657,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user.privKey.serialize(),
-        pollPrivKey: pollKeys.privKey.serialize(),
         stateIndex: 1n,
         pollId: 0n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -724,7 +699,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user.privKey.serialize(),
-        pollPrivKey: pollKeys.privKey.serialize(),
         stateIndex: 1n,
         pollId: 1n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -739,7 +713,7 @@ describe("e2e tests", function test() {
 
     it("should publish a new message", async () => {
       await publish({
-        pubkey: pollKeys.pubKey.serialize(),
+        pubkey: user.pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -747,7 +721,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 7n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys.privKey.serialize(),
+        privateKey: user.privKey.serialize(),
         signer,
       });
     });
@@ -767,7 +741,6 @@ describe("e2e tests", function test() {
     });
 
     const users = Array.from({ length: 4 }, () => new Keypair());
-    const pollKeys = Array.from({ length: 4 }, () => new Keypair());
 
     before(async () => {
       // deploy the smart contracts
@@ -780,7 +753,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: users[0].privKey.serialize(),
-        pollPrivKey: pollKeys[0].privKey.serialize(),
         stateIndex: 1n,
         pollId: 0n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -794,7 +766,7 @@ describe("e2e tests", function test() {
 
       // publish
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -802,7 +774,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
 
@@ -814,7 +786,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: users[1].privKey.serialize(),
-        pollPrivKey: pollKeys[1].privKey.serialize(),
         stateIndex: 2n,
         pollId: 0n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -852,7 +823,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: users[2].privKey.serialize(),
-        pollPrivKey: pollKeys[2].privKey.serialize(),
         stateIndex: 4n,
         pollId: 1n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -867,7 +837,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: users[3].privKey.serialize(),
-        pollPrivKey: pollKeys[3].privKey.serialize(),
         stateIndex: 5n,
         pollId: 1n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -882,7 +851,7 @@ describe("e2e tests", function test() {
 
     it("should publish a new message from the first poll voter", async () => {
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -890,14 +859,14 @@ describe("e2e tests", function test() {
         newVoteWeight: 7n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
     });
 
     it("should publish a new message by the new poll voters", async () => {
       await publish({
-        pubkey: pollKeys[1].pubKey.serialize(),
+        pubkey: users[1].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -905,7 +874,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 7n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[1].privKey.serialize(),
+        privateKey: users[1].privKey.serialize(),
         signer,
       });
     });
@@ -921,15 +890,6 @@ describe("e2e tests", function test() {
 
   describe("multiplePolls2", () => {
     const users = [
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-      new Keypair(),
-    ];
-    const pollKeys = [
       new Keypair(),
       new Keypair(),
       new Keypair(),
@@ -976,7 +936,6 @@ describe("e2e tests", function test() {
         await joinPoll({
           maciAddress: maciAddresses.maciAddress,
           privateKey: users[i].privKey.serialize(),
-          pollPrivKey: pollKeys[i].privKey.serialize(),
           stateIndex: BigInt(i + 1),
           pollId: 0n,
           pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -991,7 +950,7 @@ describe("e2e tests", function test() {
         const { isJoined, pollStateIndex } = await isJoinedUser({
           maciAddress: maciAddresses.maciAddress,
           pollId: 0n,
-          pollPubKey: pollKeys[i].pubKey.serialize(),
+          pollPubKey: users[i].pubKey.serialize(),
           signer,
           startBlock: 0,
           quiet: true,
@@ -1003,7 +962,7 @@ describe("e2e tests", function test() {
 
       // publish
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -1011,7 +970,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
 
@@ -1039,7 +998,6 @@ describe("e2e tests", function test() {
           await joinPoll({
             maciAddress: maciAddresses.maciAddress,
             privateKey: users[i].privKey.serialize(),
-            pollPrivKey: pollKeys[i].privKey.serialize(),
             stateIndex: BigInt(i + 1),
             pollId: BigInt(p),
             pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -1054,7 +1012,7 @@ describe("e2e tests", function test() {
           const { isJoined, pollStateIndex } = await isJoinedUser({
             maciAddress: maciAddresses.maciAddress,
             pollId: BigInt(p),
-            pollPubKey: pollKeys[i].pubKey.serialize(),
+            pollPubKey: users[i].pubKey.serialize(),
             signer,
             startBlock: 0,
             quiet: true,
@@ -1068,7 +1026,7 @@ describe("e2e tests", function test() {
 
     it("should publish messages to the second poll", async () => {
       await publish({
-        pubkey: pollKeys[0].pubKey.serialize(),
+        pubkey: users[0].pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 0n,
         nonce: 1n,
@@ -1076,12 +1034,12 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[0].privKey.serialize(),
+        privateKey: users[0].privKey.serialize(),
         signer,
       });
 
       await publish({
-        pubkey: pollKeys[1].pubKey.serialize(),
+        pubkey: users[1].pubKey.serialize(),
         stateIndex: 2n,
         voteOptionIndex: 3n,
         nonce: 1n,
@@ -1089,12 +1047,12 @@ describe("e2e tests", function test() {
         newVoteWeight: 1n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[1].privKey.serialize(),
+        privateKey: users[1].privKey.serialize(),
         signer,
       });
 
       await publish({
-        pubkey: pollKeys[2].pubKey.serialize(),
+        pubkey: users[2].pubKey.serialize(),
         stateIndex: 3n,
         voteOptionIndex: 5n,
         nonce: 1n,
@@ -1102,14 +1060,14 @@ describe("e2e tests", function test() {
         newVoteWeight: 3n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[2].privKey.serialize(),
+        privateKey: users[2].privKey.serialize(),
         signer,
       });
     });
 
     it("should publish messages to the third poll", async () => {
       await publish({
-        pubkey: pollKeys[3].pubKey.serialize(),
+        pubkey: users[3].pubKey.serialize(),
         stateIndex: 3n,
         voteOptionIndex: 5n,
         nonce: 1n,
@@ -1117,12 +1075,12 @@ describe("e2e tests", function test() {
         newVoteWeight: 3n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[3].privKey.serialize(),
+        privateKey: users[3].privKey.serialize(),
         signer,
       });
 
       await publish({
-        pubkey: pollKeys[4].pubKey.serialize(),
+        pubkey: users[4].pubKey.serialize(),
         stateIndex: 4n,
         voteOptionIndex: 7n,
         nonce: 1n,
@@ -1130,12 +1088,12 @@ describe("e2e tests", function test() {
         newVoteWeight: 2n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[4].privKey.serialize(),
+        privateKey: users[4].privKey.serialize(),
         signer,
       });
 
       await publish({
-        pubkey: pollKeys[5].pubKey.serialize(),
+        pubkey: users[5].pubKey.serialize(),
         stateIndex: 5n,
         voteOptionIndex: 5n,
         nonce: 1n,
@@ -1143,7 +1101,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 9n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys[5].privKey.serialize(),
+        privateKey: users[5].privKey.serialize(),
         signer,
       });
     });
@@ -1191,7 +1149,6 @@ describe("e2e tests", function test() {
     const stateOutPath = "./state.json";
 
     const user = new Keypair();
-    const pollKeys = new Keypair();
 
     after(async () => {
       await clean();
@@ -1217,7 +1174,6 @@ describe("e2e tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user.privKey.serialize(),
-        pollPrivKey: pollKeys.privKey.serialize(),
         stateIndex: 1n,
         pollId: 0n,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -1232,7 +1188,7 @@ describe("e2e tests", function test() {
 
     it("should publish one message", async () => {
       await publish({
-        pubkey: pollKeys.pubKey.serialize(),
+        pubkey: user.pubKey.serialize(),
         stateIndex: 1n,
         voteOptionIndex: 5n,
         nonce: 1n,
@@ -1240,7 +1196,7 @@ describe("e2e tests", function test() {
         newVoteWeight: 3n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollKeys.privKey.serialize(),
+        privateKey: user.privKey.serialize(),
         signer,
       });
     });

--- a/packages/cli/tests/e2e/keyChange.test.ts
+++ b/packages/cli/tests/e2e/keyChange.test.ts
@@ -89,7 +89,7 @@ describe("keyChange tests", function test() {
     });
 
     const user1Keypair = new Keypair();
-    const { privKey: pollPrivKey1, pubKey: pollPubKey1 } = new Keypair();
+    const { privKey: pollPrivKey1, pubKey: pollPubKey1 } = user1Keypair;
     const { pubKey: pollPubKey2 } = new Keypair();
 
     const initialNonce = 1n;
@@ -115,7 +115,6 @@ describe("keyChange tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user1Keypair.privKey.serialize(),
-        pollPrivKey: pollPrivKey1.serialize(),
         stateIndex,
         pollId,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -178,7 +177,6 @@ describe("keyChange tests", function test() {
     });
 
     const user1Keypair = new Keypair();
-    const { privKey: pollPrivKey1, pubKey: pollPubKey1 } = new Keypair();
     const { pubKey: pollPubKey2 } = new Keypair();
 
     const initialNonce = 1n;
@@ -204,7 +202,6 @@ describe("keyChange tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user1Keypair.privKey.serialize(),
-        pollPrivKey: pollPrivKey1.serialize(),
         stateIndex,
         pollId,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -216,7 +213,7 @@ describe("keyChange tests", function test() {
         quiet: true,
       });
       await publish({
-        pubkey: pollPubKey1.serialize(),
+        pubkey: user1Keypair.pubKey.serialize(),
         stateIndex,
         voteOptionIndex: initialVoteOption,
         nonce: initialNonce,
@@ -224,12 +221,12 @@ describe("keyChange tests", function test() {
         newVoteWeight: initialVoteAmount,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollPrivKey1.serialize(),
+        privateKey: user1Keypair.privKey.serialize(),
         signer,
       });
     });
 
-    it("should publish a message to change the poll and cast a new vote", async () => {
+    it("should publish a message to change the key and cast a new vote", async () => {
       await publish({
         pubkey: pollPubKey2.serialize(),
         stateIndex,
@@ -239,7 +236,7 @@ describe("keyChange tests", function test() {
         newVoteWeight: initialVoteAmount - 1n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollPrivKey1.serialize(),
+        privateKey: user1Keypair.privKey.serialize(),
         signer,
       });
     });
@@ -267,8 +264,7 @@ describe("keyChange tests", function test() {
     });
 
     const user1Keypair = new Keypair();
-    const { privKey: pollPrivKey1, pubKey: pollPubKey1 } = new Keypair();
-    const { pubKey: pollPubKey2 } = new Keypair();
+    const secondKeypair = new Keypair();
 
     const initialNonce = 1n;
     const initialVoteOption = 0n;
@@ -293,7 +289,6 @@ describe("keyChange tests", function test() {
       await joinPoll({
         maciAddress: maciAddresses.maciAddress,
         privateKey: user1Keypair.privKey.serialize(),
-        pollPrivKey: pollPrivKey1.serialize(),
         stateIndex,
         pollId,
         pollJoiningZkey: pollJoiningTestZkeyPath,
@@ -306,7 +301,7 @@ describe("keyChange tests", function test() {
       });
 
       await publish({
-        pubkey: pollPubKey1.serialize(),
+        pubkey: user1Keypair.pubKey.serialize(),
         stateIndex,
         voteOptionIndex: initialVoteOption,
         nonce: initialNonce,
@@ -314,14 +309,14 @@ describe("keyChange tests", function test() {
         newVoteWeight: initialVoteAmount,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollPrivKey1.serialize(),
+        privateKey: user1Keypair.privKey.serialize(),
         signer,
       });
     });
 
     it("should publish a message to change the poll key, and a new vote", async () => {
       await publish({
-        pubkey: pollPubKey2.serialize(),
+        pubkey: secondKeypair.pubKey.serialize(),
         stateIndex,
         voteOptionIndex: initialVoteOption + 2n,
         nonce: initialNonce,
@@ -329,7 +324,7 @@ describe("keyChange tests", function test() {
         newVoteWeight: initialVoteAmount - 3n,
         maciAddress: maciAddresses.maciAddress,
         salt: genRandomSalt(),
-        privateKey: pollPrivKey1.serialize(),
+        privateKey: user1Keypair.privKey.serialize(),
         signer,
       });
     });

--- a/packages/cli/tests/unit/joinPoll.test.ts
+++ b/packages/cli/tests/unit/joinPoll.test.ts
@@ -30,7 +30,6 @@ describe("joinPoll", function test() {
   const userPrivateKey = user.privKey.serialize();
   const userPublicKey = user.pubKey.serialize();
 
-  const { privKey: pollPrivateKey, pubKey: pollPublicKey } = new Keypair();
   const mockStateIndex = 1n;
   const mockPollId = 9000n;
 
@@ -64,7 +63,6 @@ describe("joinPoll", function test() {
       stateIndex: 1n,
       signer,
       pollId: 0n,
-      pollPrivKey: pollPrivateKey.serialize(),
       pollJoiningZkey: pollJoiningTestZkeyPath,
       useWasm: true,
       pollWasm: testPollJoiningWasmPath,
@@ -76,7 +74,7 @@ describe("joinPoll", function test() {
     const registeredUserData = await isJoinedUser({
       maciAddress: maciAddresses.maciAddress,
       pollId: 0n,
-      pollPubKey: pollPublicKey.serialize(),
+      pollPubKey: user.pubKey.serialize(),
       signer,
       startBlock: startBlock || 0,
       quiet: true,
@@ -94,7 +92,6 @@ describe("joinPoll", function test() {
         stateIndex: mockStateIndex,
         signer,
         pollId: mockPollId,
-        pollPrivKey: pollPrivateKey.serialize(),
         pollJoiningZkey: pollJoiningTestZkeyPath,
         quiet: true,
       }),
@@ -109,7 +106,6 @@ describe("joinPoll", function test() {
         stateIndex: -1n,
         signer,
         pollId: 0n,
-        pollPrivKey: pollPrivateKey.serialize(),
         pollJoiningZkey: pollJoiningTestZkeyPath,
         quiet: true,
       }),
@@ -124,7 +120,6 @@ describe("joinPoll", function test() {
         stateIndex: mockStateIndex,
         signer,
         pollId: -1n,
-        pollPrivKey: pollPrivateKey.serialize(),
         pollJoiningZkey: pollJoiningTestZkeyPath,
         quiet: true,
       }),

--- a/packages/cli/ts/index.ts
+++ b/packages/cli/ts/index.ts
@@ -219,7 +219,6 @@ program
   .requiredOption("-k, --priv-key <privKey>", "the private key")
   .option("-i, --state-index <stateIndex>", "the user's state index", BigInt)
   .requiredOption("-s, --sg-data <sgData>", "the signup gateway data")
-  .requiredOption("-e, --poll-priv-key <pollPrivKey>", "the user ephemeral private key for the poll")
   .option("-v, --ivcp-data <ivcpData>", "the initial voice credit proxy data")
   .option(
     "-n, --new-voice-credit-balance <newVoiceCreditBalance>",
@@ -253,7 +252,6 @@ program
       await joinPoll({
         maciAddress,
         privateKey,
-        pollPrivKey: cmdObj.pollPrivKey,
         stateIndex: cmdObj.stateIndex || undefined,
         stateFile: cmdObj.stateFile,
         pollId: cmdObj.pollId,

--- a/packages/cli/ts/utils/interfaces.ts
+++ b/packages/cli/ts/utils/interfaces.ts
@@ -460,11 +460,6 @@ export interface IJoinPollArgs {
   pollWasm?: string;
 
   /**
-   * Poll private key for the poll
-   */
-  pollPrivKey: string;
-
-  /**
    * The signup gatekeeper data
    */
   sgDataArg?: string;

--- a/packages/core/ts/Poll.ts
+++ b/packages/core/ts/Poll.ts
@@ -434,14 +434,12 @@ export class Poll implements IPoll {
    * Create circuit input for pollJoining
    * @param maciPrivKey User's private key for signing up
    * @param stateLeafIndex Index where the user is stored in the state leaves
-   * @param pollPrivKey Poll's private key for the poll joining
-   * @param pollPubKey Poll's public key for the poll joining
+   * @param pollPubKey Poll's public key for joining the poll
    * @returns stringified circuit inputs
    */
   joiningCircuitInputs = ({
     maciPrivKey,
     stateLeafIndex,
-    pollPrivKey,
     pollPubKey,
   }: IJoiningCircuitArgs): IPollJoiningCircuitInputs => {
     // calculate the path elements for the state tree given the original state tree
@@ -476,7 +474,6 @@ export class Poll implements IPoll {
 
     const circuitInputs = {
       privKey: maciPrivKey.asCircuitInputs(),
-      pollPrivKey: pollPrivKey.asCircuitInputs(),
       pollPubKey: pollPubKey.asCircuitInputs(),
       siblings: siblingsArray,
       indices,

--- a/packages/core/ts/utils/types.ts
+++ b/packages/core/ts/utils/types.ts
@@ -139,7 +139,6 @@ export interface IProcessMessagesOutput {
 export interface IJoiningCircuitArgs {
   maciPrivKey: PrivKey;
   stateLeafIndex: bigint;
-  pollPrivKey: PrivKey;
   pollPubKey: PubKey;
 }
 /**
@@ -147,7 +146,6 @@ export interface IJoiningCircuitArgs {
  */
 export interface IPollJoiningCircuitInputs {
   privKey: string;
-  pollPrivKey: string;
   pollPubKey: string[];
   stateLeaf: string[];
   siblings: string[][];


### PR DESCRIPTION
# Description

Revert joining polls with a new key to improve privacy vs coordinator, with forcing the use of one key to reduce the risk of key selling, as keys would now be reused within polls.

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
