### PR TITLE
feat: allow to fetch state index from contracts

### DIFF
--- a/packages/contracts/contracts/interfaces/IMACI.sol
+++ b/packages/contracts/contracts/interfaces/IMACI.sol
@@ -1,9 +1,42 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { Params } from "../utilities/Params.sol";
+import { DomainObjs } from "../utilities/DomainObjs.sol";
+
 /// @title IMACI
 /// @notice MACI interface
 interface IMACI {
+  /// @notice A struct holding the addresses of poll, mp and tally
+  struct PollContracts {
+    address poll;
+    address messageProcessor;
+    address tally;
+  }
+  /// @notice A struct holding the params for poll deployment
+  struct DeployPollArgs {
+    /// @param duration How long should the Poll last for
+    uint256 duration;
+    /// @param treeDepths The depth of the Merkle trees
+    Params.TreeDepths treeDepths;
+    /// @param messageBatchSize The message batch size
+    uint8 messageBatchSize;
+    /// @param coordinatorPubKey The coordinator's public key
+    DomainObjs.PubKey coordinatorPubKey;
+    /// @param verifier The Verifier Contract
+    address verifier;
+    /// @param vkRegistry The VkRegistry Contract
+    address vkRegistry;
+    /// @param mode Voting mode
+    DomainObjs.Mode mode;
+    /// @param gatekeeper The gatekeeper contract
+    address gatekeeper;
+    /// @param initialVoiceCreditProxy The initial voice credit proxy contract
+    address initialVoiceCreditProxy;
+    /// @param relayer The message relayer (optional)
+    address[] relayers;
+  }
+
   /// @notice Get the depth of the state tree
   /// @return The depth of the state tree
   function stateTreeDepth() external view returns (uint8);
@@ -11,6 +44,25 @@ interface IMACI {
   /// @notice Return the main root of the StateAq contract
   /// @return The Merkle root
   function getStateTreeRoot() external view returns (uint256);
+
+  /// @notice Get the index of a public key in the state tree
+  /// @param _pubKeyHash The hash of the public key
+  /// @return index The index of the public key in the state tree
+  function getStateIndex(uint256 _pubKeyHash) external view returns (uint256);
+
+  /// @notice Deploy a new Poll contract.
+  /// @param _pollArgs The deploy poll args
+  function deployPoll(DeployPollArgs memory _pollArgs) external returns (PollContracts memory);
+
+  /// @notice Allows any eligible user sign up. The sign-up gatekeeper should prevent
+  /// double sign-ups or ineligible users from doing so.  This function will
+  /// only succeed if the sign-up deadline has not passed.
+  /// @param _pubKey The user's desired public key.
+  /// @param _signUpGatekeeperData Data to pass to the sign-up gatekeeper's
+  ///     register() function. For instance, the POAPGatekeeper or
+  ///     SignUpTokenGatekeeper requires this value to be the ABI-encoded
+  ///     token ID.
+  function signUp(DomainObjs.PubKey memory _pubKey, bytes memory _signUpGatekeeperData) external;
 
   /// @notice Return the state root when the '_index' user signed up
   /// @param _index The serial number when the user signed up

--- a/packages/contracts/contracts/interfaces/IPoll.sol
+++ b/packages/contracts/contracts/interfaces/IPoll.sol
@@ -7,7 +7,13 @@ import { IMACI } from "./IMACI.sol";
 /// @title IPoll
 /// @notice Poll interface
 interface IPoll {
-  /// @notice Join the poll
+  /// @notice Join the poll for voting
+  /// @param _nullifier Hashed user's private key to check whether user has already voted
+  /// @param _pubKey Poll user's public key
+  /// @param _stateRootIndex Index of the MACI's stateRootOnSignUp for which the inclusion proof is generated
+  /// @param _proof The zk-SNARK proof
+  /// @param _signUpGatekeeperData Data to pass to the SignUpGatekeeper
+  /// @param _initialVoiceCreditProxyData Data to pass to the InitialVoiceCreditProxy
   function joinPoll(
     uint256 _nullifier,
     DomainObjs.PubKey calldata _pubKey,
@@ -99,4 +105,9 @@ interface IPoll {
   /// @notice Get the external contracts
   /// @return maci The IMACI contract
   function getMaciContract() external view returns (IMACI maci);
+
+  /// @notice Get the index of a state leaf in the state tree
+  /// @param element The hash of thestate leaf
+  /// @return index The index of the state leaf in the state tree
+  function getStateIndex(uint256 element) external view returns (uint40);
 }

--- a/packages/contracts/tests/MACI.test.ts
+++ b/packages/contracts/tests/MACI.test.ts
@@ -187,6 +187,13 @@ describe("MACI", function test() {
     });
   });
 
+  describe("getStateIndex", () => {
+    it("should return the index of a state leaf", async () => {
+      const index = await maciContract.getStateIndex(users[0].pubKey.hash());
+      expect(index.toString()).to.eq("1");
+    });
+  });
+
   describe("Deploy a Poll", () => {
     let deployTime: number | undefined;
 

--- a/packages/contracts/tests/Poll.test.ts
+++ b/packages/contracts/tests/Poll.test.ts
@@ -5,7 +5,7 @@ import { AbiCoder, decodeBase58, encodeBase58, getBytes, hexlify, Signer, ZeroAd
 import { EthereumProvider } from "hardhat/types";
 import { MaciState, VOTE_OPTION_TREE_ARITY } from "maci-core";
 import { NOTHING_UP_MY_SLEEVE } from "maci-crypto";
-import { Keypair, Message, PCommand, PubKey } from "maci-domainobjs";
+import { Keypair, Message, PCommand, PubKey, StateLeaf } from "maci-domainobjs";
 
 import { EMode } from "../ts/constants";
 import { IVerifyingKeyStruct } from "../ts/types";
@@ -232,9 +232,13 @@ describe("Poll", () => {
 
         const expectedIndex = maciState.polls
           .get(pollId)
-          ?.joinPoll(BigInt(mockNullifier), keypair.pubKey, BigInt(voiceCredits), BigInt(timestamp));
+          ?.joinPoll(BigInt(mockNullifier), keypair.pubKey, voiceCredits, BigInt(timestamp));
 
         expect(index).to.eq(expectedIndex);
+
+        // get the index with getStateIndex
+        const stateLeaf = new StateLeaf(keypair.pubKey, voiceCredits, BigInt(timestamp));
+        expect(await pollContract.getStateIndex(stateLeaf.hash())).to.eq(index);
       }
     });
 


### PR DESCRIPTION
# Description

Allow to fetch state index from contracts for both MACI and Poll trees 

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [ ] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
