### PR TITLE
fix: improve sorting of proof files by numeric value

### DIFF
--- a/packages/contracts/tasks/runner/submitOnChain.ts
+++ b/packages/contracts/tasks/runner/submitOnChain.ts
@@ -31,7 +31,11 @@ async function readProofs({ files, folder, type }: IReadProofsArgs): Promise<Pro
   return Promise.all(
     files
       .filter((f) => f.startsWith(`${type}_`) && f.endsWith(".json"))
-      .sort()
+      .sort((a, b) => {
+        const numA = parseInt(a.match(/\d+/)?.[0] ?? "0", 10);
+        const numB = parseInt(b.match(/\d+/)?.[0] ?? "0", 10);
+        return numA - numB;
+      })
       .map(async (file) =>
         fs.promises.readFile(`${folder}/${file}`, "utf8").then((result) => JSON.parse(result) as Proof),
       ),


### PR DESCRIPTION

# Description

This pull request includes an update to the `readProofs` function in the `submitOnChain.ts` file to improve the sorting mechanism for JSON files. The most important change is the modification of the sorting logic to ensure that files are sorted numerically based on the numbers in their filenames instead of based on characters which lead to errors when proof files exceeded `9`.

Improvements to sorting mechanism:

* [`packages/contracts/tasks/runner/submitOnChain.ts`](diffhunk://#diff-14953e8fe3e600b38e5f8b7f453c6cc812fc375dc7d4d660e9bef979a787ef89L34-R38): Changed the sorting logic in the `readProofs` function to sort files numerically based on the numbers in their filenames instead of using the default string sort.


## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
