### PR TITLE
test: remove redundant tests and cleanup

### DIFF
--- a/packages/integrationTests/ts/__tests__/data/suites.json
+++ b/packages/integrationTests/ts/__tests__/data/suites.json
@@ -2,30 +2,12 @@
   "suites": [
     {
       "name": "Happy path",
-      "description": "Full tree, 4 batches, no bribers",
-      "numVotesPerUser": 1,
-      "numUsers": 15,
-      "expectedTally": [15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "expectedSpentVoiceCredits": [15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "expectedTotalSpentVoiceCredits": 15
-    },
-    {
-      "name": "Happy path",
       "description": "Full tree, 4 full batches, no bribers",
       "numVotesPerUser": 1,
       "numUsers": 16,
       "expectedTally": [16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expectedSpentVoiceCredits": [16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expectedTotalSpentVoiceCredits": 16
-    },
-    {
-      "name": "Happy path 2",
-      "description": "Quarter tree, 1 batch, no bribers",
-      "numUsers": 4,
-      "numVotesPerUser": 1,
-      "expectedTally": [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "expectedSpentVoiceCredits": [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "expectedTotalSpentVoiceCredits": 4
     },
     {
       "name": "10 Users test",


### PR DESCRIPTION
# Description

Remove redundant e2e/integration steps. 
First part in the refactoring of tests which will unify the test suite to make it more maintainable 

re #2141 

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
