### PR TITLE
refactor: remove redundant param

### DIFF
--- a/packages/contracts/contracts/Poll.sol
+++ b/packages/contracts/contracts/Poll.sol
@@ -402,10 +402,7 @@ contract Poll is Params, Utilities, SnarkCommon, IPoll {
     uint256[8] memory _proof
   ) public view returns (bool isValid) {
     // Get the verifying key from the VkRegistry
-    VerifyingKey memory vk = extContracts.vkRegistry.getPollJoiningVk(
-      extContracts.maci.stateTreeDepth(),
-      treeDepths.voteOptionTreeDepth
-    );
+    VerifyingKey memory vk = extContracts.vkRegistry.getPollJoiningVk(extContracts.maci.stateTreeDepth());
 
     // Generate the circuit public input
     uint256[] memory circuitPublicInputs = getPublicJoiningCircuitInputs(_nullifier, _index, _pubKey);
@@ -419,10 +416,7 @@ contract Poll is Params, Utilities, SnarkCommon, IPoll {
   /// @return isValid Whether the proof is valid
   function verifyJoinedPollProof(uint256 _index, uint256[8] memory _proof) public view returns (bool isValid) {
     // Get the verifying key from the VkRegistry
-    VerifyingKey memory vk = extContracts.vkRegistry.getPollJoinedVk(
-      extContracts.maci.stateTreeDepth(),
-      treeDepths.voteOptionTreeDepth
-    );
+    VerifyingKey memory vk = extContracts.vkRegistry.getPollJoinedVk(extContracts.maci.stateTreeDepth());
 
     // Generate the circuit public input
     uint256[] memory circuitPublicInputs = getPublicJoinedCircuitInputs(_index);

--- a/packages/contracts/contracts/VkRegistry.sol
+++ b/packages/contracts/contracts/VkRegistry.sol
@@ -68,19 +68,14 @@ contract VkRegistry is Ownable(msg.sender), DomainObjs, SnarkCommon, IVkRegistry
 
   /// @notice generate the signature for the poll joining verifying key
   /// @param _stateTreeDepth The state tree depth
-  /// @param _voteOptionTreeDepth The vote option tree depth
-  function genPollJoiningVkSig(
-    uint256 _stateTreeDepth,
-    uint256 _voteOptionTreeDepth
-  ) public pure returns (uint256 sig) {
-    sig = (_stateTreeDepth << 64) + _voteOptionTreeDepth;
+  function genPollJoiningVkSig(uint256 _stateTreeDepth) public pure returns (uint256 sig) {
+    sig = (_stateTreeDepth << 64);
   }
 
   /// @notice generate the signature for the poll joined verifying key
   /// @param _stateTreeDepth The state tree depth
-  /// @param _voteOptionTreeDepth The vote option tree depth
-  function genPollJoinedVkSig(uint256 _stateTreeDepth, uint256 _voteOptionTreeDepth) public pure returns (uint256 sig) {
-    sig = (_stateTreeDepth << 128) + (_voteOptionTreeDepth << 64);
+  function genPollJoinedVkSig(uint256 _stateTreeDepth) public pure returns (uint256 sig) {
+    sig = (_stateTreeDepth << 128);
   }
 
   /// @notice generate the signature for the process verifying key
@@ -136,8 +131,8 @@ contract VkRegistry is Ownable(msg.sender), DomainObjs, SnarkCommon, IVkRegistry
 
     uint256 length = _modes.length;
 
-    setPollJoiningVkKey(_stateTreeDepth, _voteOptionTreeDepth, _pollJoiningVk);
-    setPollJoinedVkKey(_stateTreeDepth, _voteOptionTreeDepth, _pollJoinedVk);
+    setPollJoiningVkKey(_stateTreeDepth, _pollJoiningVk);
+    setPollJoinedVkKey(_stateTreeDepth, _pollJoinedVk);
 
     for (uint256 index = 0; index < length; ) {
       setVerifyingKeys(
@@ -253,14 +248,9 @@ contract VkRegistry is Ownable(msg.sender), DomainObjs, SnarkCommon, IVkRegistry
 
   /// @notice Set the poll joining verifying key for a certain combination of parameters
   /// @param _stateTreeDepth The state tree depth
-  /// @param _voteOptionTreeDepth The vote option tree depth
   /// @param _pollJoiningVk The poll joining verifying key
-  function setPollJoiningVkKey(
-    uint256 _stateTreeDepth,
-    uint256 _voteOptionTreeDepth,
-    VerifyingKey calldata _pollJoiningVk
-  ) public onlyOwner {
-    uint256 pollJoiningVkSig = genPollJoiningVkSig(_stateTreeDepth, _voteOptionTreeDepth);
+  function setPollJoiningVkKey(uint256 _stateTreeDepth, VerifyingKey calldata _pollJoiningVk) public onlyOwner {
+    uint256 pollJoiningVkSig = genPollJoiningVkSig(_stateTreeDepth);
 
     if (pollJoiningVkSet[pollJoiningVkSig]) revert VkAlreadySet();
 
@@ -286,14 +276,9 @@ contract VkRegistry is Ownable(msg.sender), DomainObjs, SnarkCommon, IVkRegistry
 
   /// @notice Set the poll joined verifying key for a certain combination of parameters
   /// @param _stateTreeDepth The state tree depth
-  /// @param _voteOptionTreeDepth The vote option tree depth
   /// @param _pollJoinedVk The poll joined verifying key
-  function setPollJoinedVkKey(
-    uint256 _stateTreeDepth,
-    uint256 _voteOptionTreeDepth,
-    VerifyingKey calldata _pollJoinedVk
-  ) public onlyOwner {
-    uint256 pollJoinedVkSig = genPollJoinedVkSig(_stateTreeDepth, _voteOptionTreeDepth);
+  function setPollJoinedVkKey(uint256 _stateTreeDepth, VerifyingKey calldata _pollJoinedVk) public onlyOwner {
+    uint256 pollJoinedVkSig = genPollJoinedVkSig(_stateTreeDepth);
 
     if (pollJoinedVkSet[pollJoinedVkSig]) revert VkAlreadySet();
 
@@ -413,21 +398,15 @@ contract VkRegistry is Ownable(msg.sender), DomainObjs, SnarkCommon, IVkRegistry
   }
 
   /// @inheritdoc IVkRegistry
-  function getPollJoiningVk(
-    uint256 _stateTreeDepth,
-    uint256 _voteOptionTreeDepth
-  ) public view returns (VerifyingKey memory vk) {
-    uint256 sig = genPollJoiningVkSig(_stateTreeDepth, _voteOptionTreeDepth);
+  function getPollJoiningVk(uint256 _stateTreeDepth) public view returns (VerifyingKey memory vk) {
+    uint256 sig = genPollJoiningVkSig(_stateTreeDepth);
 
     vk = getPollJoiningVkBySig(sig);
   }
 
   /// @inheritdoc IVkRegistry
-  function getPollJoinedVk(
-    uint256 _stateTreeDepth,
-    uint256 _voteOptionTreeDepth
-  ) public view returns (VerifyingKey memory vk) {
-    uint256 sig = genPollJoinedVkSig(_stateTreeDepth, _voteOptionTreeDepth);
+  function getPollJoinedVk(uint256 _stateTreeDepth) public view returns (VerifyingKey memory vk) {
+    uint256 sig = genPollJoinedVkSig(_stateTreeDepth);
 
     vk = getPollJoinedVkBySig(sig);
   }

--- a/packages/contracts/contracts/interfaces/IVkRegistry.sol
+++ b/packages/contracts/contracts/interfaces/IVkRegistry.sol
@@ -35,19 +35,11 @@ interface IVkRegistry {
 
   /// @notice Get the poll joining verifying key
   /// @param _stateTreeDepth The state tree depth
-  /// @param _voteOptionTreeDepth The vote option tree depth
   /// @return The verifying key
-  function getPollJoiningVk(
-    uint256 _stateTreeDepth,
-    uint256 _voteOptionTreeDepth
-  ) external view returns (SnarkCommon.VerifyingKey memory);
+  function getPollJoiningVk(uint256 _stateTreeDepth) external view returns (SnarkCommon.VerifyingKey memory);
 
   /// @notice Get the poll joined verifying key
   /// @param _stateTreeDepth The state tree depth
-  /// @param _voteOptionTreeDepth The vote option tree depth
   /// @return The verifying key
-  function getPollJoinedVk(
-    uint256 _stateTreeDepth,
-    uint256 _voteOptionTreeDepth
-  ) external view returns (SnarkCommon.VerifyingKey memory);
+  function getPollJoinedVk(uint256 _stateTreeDepth) external view returns (SnarkCommon.VerifyingKey memory);
 }

--- a/packages/contracts/tests/Poll.test.ts
+++ b/packages/contracts/tests/Poll.test.ts
@@ -125,7 +125,6 @@ describe("Poll", () => {
       // set the verification keys on the vk smart contract
       await vkRegistryContract.setPollJoiningVkKey(
         STATE_TREE_DEPTH,
-        treeDepths.voteOptionTreeDepth,
         testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );
@@ -133,7 +132,6 @@ describe("Poll", () => {
       // set the verification keys on the vk smart contract
       await vkRegistryContract.setPollJoinedVkKey(
         STATE_TREE_DEPTH,
-        treeDepths.voteOptionTreeDepth,
         testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );

--- a/packages/contracts/tests/Tally.test.ts
+++ b/packages/contracts/tests/Tally.test.ts
@@ -299,14 +299,12 @@ describe("TallyVotes", () => {
 
       await vkRegistryContract.setPollJoiningVkKey(
         STATE_TREE_DEPTH,
-        treeDepths.voteOptionTreeDepth,
         testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );
 
       await vkRegistryContract.setPollJoinedVkKey(
         STATE_TREE_DEPTH,
-        treeDepths.voteOptionTreeDepth,
         testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );
@@ -616,7 +614,6 @@ describe("TallyVotes", () => {
       // set the verification keys on the vk smart contract
       await vkRegistryContract.setPollJoiningVkKey(
         STATE_TREE_DEPTH,
-        treeDepths.voteOptionTreeDepth,
         testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );
@@ -624,7 +621,6 @@ describe("TallyVotes", () => {
       // set the verification keys on the vk smart contract
       await vkRegistryContract.setPollJoinedVkKey(
         STATE_TREE_DEPTH,
-        treeDepths.voteOptionTreeDepth,
         testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );

--- a/packages/contracts/tests/VkRegistry.test.ts
+++ b/packages/contracts/tests/VkRegistry.test.ts
@@ -37,7 +37,6 @@ describe("VkRegistry", () => {
     it("should set the poll vk", async () => {
       const tx = await vkRegistryContract.setPollJoiningVkKey(
         stateTreeDepth + 1,
-        treeDepths.voteOptionTreeDepth,
         testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 1000000 },
       );
@@ -49,7 +48,6 @@ describe("VkRegistry", () => {
       await expect(
         vkRegistryContract.setPollJoiningVkKey(
           stateTreeDepth + 1,
-          treeDepths.voteOptionTreeDepth,
           testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
           { gasLimit: 1000000 },
         ),
@@ -61,7 +59,6 @@ describe("VkRegistry", () => {
     it("should set the poll vk", async () => {
       const tx = await vkRegistryContract.setPollJoinedVkKey(
         stateTreeDepth + 1,
-        treeDepths.voteOptionTreeDepth,
         testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 1000000 },
       );
@@ -73,7 +70,6 @@ describe("VkRegistry", () => {
       await expect(
         vkRegistryContract.setPollJoinedVkKey(
           stateTreeDepth + 1,
-          treeDepths.voteOptionTreeDepth,
           testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
           { gasLimit: 1000000 },
         ),
@@ -230,7 +226,7 @@ describe("VkRegistry", () => {
   describe("genSignatures", () => {
     describe("genPollJoiningVkSig", () => {
       it("should generate a valid signature", async () => {
-        const sig = await vkRegistryContract.genPollJoiningVkSig(stateTreeDepth, treeDepths.voteOptionTreeDepth);
+        const sig = await vkRegistryContract.genPollJoiningVkSig(stateTreeDepth);
         const vk = await vkRegistryContract.getPollJoiningVkBySig(sig);
         compareVks(testPollJoiningVk, vk);
       });
@@ -238,7 +234,7 @@ describe("VkRegistry", () => {
 
     describe("genPollJoinedVkSig", () => {
       it("should generate a valid signature", async () => {
-        const sig = await vkRegistryContract.genPollJoinedVkSig(stateTreeDepth, treeDepths.voteOptionTreeDepth);
+        const sig = await vkRegistryContract.genPollJoinedVkSig(stateTreeDepth);
         const vk = await vkRegistryContract.getPollJoinedVkBySig(sig);
         compareVks(testPollJoinedVk, vk);
       });

--- a/packages/core/ts/utils/utils.ts
+++ b/packages/core/ts/utils/utils.ts
@@ -5,22 +5,18 @@
  * This can be used to check if a PollJoining' circuit VK is registered
  * in a smart contract that holds several VKs.
  * @param stateTreeDepth - The depth of the state tree.
- * @param voteOptionTreeDepth - The depth of the vote option tree.
  * @returns Returns a signature for querying if a verifying key with the given parameters is already registered in the contract.
  */
-export const genPollJoiningVkSig = (stateTreeDepth: number, voteOptionTreeDepth: number): bigint =>
-  (BigInt(stateTreeDepth) << 64n) + BigInt(voteOptionTreeDepth);
+export const genPollJoiningVkSig = (stateTreeDepth: number): bigint => BigInt(stateTreeDepth) << 64n;
 
 /**
  * This function generates the signature of a Poll Joined Verifying Key (VK).
  * This can be used to check if a PollJoined' circuit VK is registered
  * in a smart contract that holds several VKs.
  * @param stateTreeDepth - The depth of the state tree.
- * @param voteOptionTreeDepth - The depth of the vote option tree.
  * @returns Returns a signature for querying if a verifying key with the given parameters is already registered in the contract.
  */
-export const genPollJoinedVkSig = (stateTreeDepth: number, voteOptionTreeDepth: number): bigint =>
-  (BigInt(stateTreeDepth) << 128n) + (BigInt(voteOptionTreeDepth) << 64n);
+export const genPollJoinedVkSig = (stateTreeDepth: number): bigint => BigInt(stateTreeDepth) << 128n;
 
 /**
  * This function generates the signature of a ProcessMessage Verifying Key(VK).

--- a/packages/sdk/ts/keys/verifyingKeys.ts
+++ b/packages/sdk/ts/keys/verifyingKeys.ts
@@ -23,8 +23,8 @@ export const getAllOnChainVks = async ({
   const vkRegistryContractInstance = VkRegistryFactory.connect(vkRegistryAddress, signer);
 
   const [pollJoiningVkOnChain, pollJoinedVkOnChain, processVkOnChain, tallyVkOnChain] = await Promise.all([
-    vkRegistryContractInstance.getPollJoiningVk(stateTreeDepth, voteOptionTreeDepth),
-    vkRegistryContractInstance.getPollJoinedVk(stateTreeDepth, voteOptionTreeDepth),
+    vkRegistryContractInstance.getPollJoiningVk(stateTreeDepth),
+    vkRegistryContractInstance.getPollJoinedVk(stateTreeDepth),
     vkRegistryContractInstance.getProcessVk(stateTreeDepth, voteOptionTreeDepth, messageBatchSize, mode),
     vkRegistryContractInstance.getTallyVk(stateTreeDepth, intStateTreeDepth, voteOptionTreeDepth, mode),
   ]);
@@ -136,14 +136,14 @@ export const setVerifyingKeys = async ({
   const vkRegistryContract = VkRegistryFactory.connect(vkRegistryAddress, signer);
 
   // check if the poll vk was already set
-  const pollJoiningVkSig = genPollJoiningVkSig(stateTreeDepth, voteOptionTreeDepth);
+  const pollJoiningVkSig = genPollJoiningVkSig(stateTreeDepth);
 
   if (await vkRegistryContract.isPollJoiningVkSet(pollJoiningVkSig)) {
     throw new Error("This poll verifying key is already set in the contract");
   }
 
   // check if the poll vk was already set
-  const pollJoinedVkSig = genPollJoinedVkSig(stateTreeDepth, voteOptionTreeDepth);
+  const pollJoinedVkSig = genPollJoinedVkSig(stateTreeDepth);
 
   if (await vkRegistryContract.isPollJoinedVkSet(pollJoinedVkSig)) {
     throw new Error("This poll verifying key is already set in the contract");
@@ -183,8 +183,8 @@ export const setVerifyingKeys = async ({
   }
 
   const [pollJoiningVkOnChain, pollJoinedVkOnChain, processVkOnChain, tallyVkOnChain] = await Promise.all([
-    vkRegistryContract.getPollJoiningVk(stateTreeDepth, voteOptionTreeDepth),
-    vkRegistryContract.getPollJoinedVk(stateTreeDepth, voteOptionTreeDepth),
+    vkRegistryContract.getPollJoiningVk(stateTreeDepth),
+    vkRegistryContract.getPollJoinedVk(stateTreeDepth),
     vkRegistryContract.getProcessVk(stateTreeDepth, voteOptionTreeDepth, messageBatchSize, mode),
     vkRegistryContract.getTallyVk(stateTreeDepth, intStateTreeDepth, voteOptionTreeDepth, mode),
   ]);


### PR DESCRIPTION
# Description

Remove redundant voteOptionThreeDepth param form pollJoined and pollJoining VkRegistry signatures

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
