### PR TITLE
Grammar Fixes in MACI Docs

### DIFF
--- a/apps/website/blog/2021-10-12-maci-v1.md
+++ b/apps/website/blog/2021-10-12-maci-v1.md
@@ -21,7 +21,7 @@ MACI 1.0 was audited by Hashcloak. All vulnerabilities found have been fixed. Th
 
 ## About MACI
 
-MACI is a set of smart contracts and zero-knowledge circuits upon which which developers can build collusion-resistant applications, such as voting systems or quadratic funding platforms. MACI per se is not a user-facing application. Rather, developers may build applications on top of it. In turn, such applications can benefit from the following properties:
+MACI is a set of smart contracts and zero-knowledge circuits upon which developers can build collusion-resistant applications, such as voting systems or quadratic funding platforms. MACI per se is not a user-facing application. Rather, developers may build applications on top of it. In turn, such applications can benefit from the following properties:
 
 - Collusion resistance: no-one, except a trusted coordinator, can be convinced of the validity of a vote, reducing the effectiveness of bribery.
 - Receipt-freeness: a voter cannot prove, besides to the coordinator, which way they voted.

--- a/apps/website/blog/2023-01-18-maci-v1.1.1.md
+++ b/apps/website/blog/2023-01-18-maci-v1.1.1.md
@@ -66,7 +66,7 @@ Now, the Poll contract will hold all the funds deposited from users for the curr
 
 When a user deposits tokens by calling topup, they will also need to specify the stateTree index. The topup function will insert a topup message into the message queue for them. When the voting period ends, any call of topup function will be rejected. Both voting and topup messages have the same ending time, which ensures there is a well-defined ending state for each poll.
 
-Please note that in this approach, the initial credit is still shared across multiple polls, and the actual credit an user can spend in a given poll is the following: `totalCredit=initialCredit+topupCredit` where the `topupCredit` is the voice credit amount deposited by the user during the voting period of the given pollID.
+Please note that in this approach, the initial credit is still shared across multiple polls, and the actual credit a user can spend in a given poll is the following: `totalCredit=initialCredit+topupCredit` where the `topupCredit` is the voice credit amount deposited by the user during the voting period of the given pollID.
 
 For a detailed description, please refer to this [document](https://hackmd.io/@chaosma/rkyPfI7Iq).
 

--- a/apps/website/blog/2024-05-28-upcoming-grants.md
+++ b/apps/website/blog/2024-05-28-upcoming-grants.md
@@ -30,7 +30,7 @@ The key focus of this improvement is to enable users to be completely anonymous 
 
 Thus, voters can prove anonymously that they know the preimage of a [`StateLeaf`](/docs/developers-references/typescript-code/typedoc/domainobjs/classes/StateLeaf), by passing this information to a zk-SNARK circuit, and validating this proof within the poll contract when joining with the new key. You might be thinking that everyone knows the preimage of a state leaf, as it's public information that can be taken from the contracts' logs. However, the circuit will not accept the public key directly but would instead take the private key and use it to generate the public key. This way, only users with knowledge of a specific private key can generate a valid inclusion proof.
 
-Now after signing up to the Poll with this new key, there will not be any link to the original key, and users will effectively be anonymous. Of course users should ensure that they are using different wallets where possible.
+Now after signing up for the Poll with this new key, there will not be any link to the original key, and users will effectively be anonymous. Of course users should ensure that they are using different wallets where possible.
 
 Finally, with the use of a nullifier, it will not be possible for the same original key to be used to signup more than once for each new poll.
 


### PR DESCRIPTION
File: 2021-10-12-maci-v1.md

Fix: Removed duplicate "which"
Before: "upon which which developers can build..."
After: "upon which developers can build..."
File: 2023-01-18-maci-v1.1.1.md

Fix: Corrected article usage
Before: "an user"
After: "a user"
File: 2024-05-28-upcoming-grants.md

Fix: Improved preposition
Before: "signing up to the Poll..."
After: "signing up for the Poll..."
