### PR TITLE
Return processProofs, tallyProofs and tallyData in generateProofs function

### DIFF
--- a/packages/cli/ts/commands/genProofs.ts
+++ b/packages/cli/ts/commands/genProofs.ts
@@ -102,7 +102,7 @@ export const genProofsCommand = async ({
     logError("Invalid MACI private key");
   }
 
-  const tallyData = await generateProofs({
+  const { tallyData } = await generateProofs({
     networkName: network?.name || "",
     chainId: network?.chainId.toString() || "0",
     maciContractAddress,

--- a/packages/sdk/ts/proof/generate.ts
+++ b/packages/sdk/ts/proof/generate.ts
@@ -3,9 +3,7 @@ import { Keypair, PrivKey } from "maci-domainobjs";
 
 import fs from "fs";
 
-import type { ITallyData } from "../tally";
-
-import { IGenerateProofsArgs } from "./types";
+import { IGenerateProofsArgs, IGenerateProofsData } from "./types";
 
 /**
  * Generate proofs for the message processing and tally calculations
@@ -35,7 +33,7 @@ export const generateProofs = async ({
   processWitgen,
   processWasm,
   tallyFile,
-}: IGenerateProofsArgs): Promise<ITallyData> => {
+}: IGenerateProofsArgs): Promise<IGenerateProofsData> => {
   // if we do not have the output directory just create it
   const isOutputDirExists = fs.existsSync(outputDir);
 
@@ -103,8 +101,8 @@ export const generateProofs = async ({
     useQuadraticVoting,
   });
 
-  await proofGenerator.generateMpProofs();
-  const { tallyData } = await proofGenerator.generateTallyProofs(networkName, chainId);
+  const processProofs = await proofGenerator.generateMpProofs();
+  const { proofs: tallyProofs, tallyData } = await proofGenerator.generateTallyProofs(networkName, chainId);
 
-  return tallyData;
+  return { processProofs, tallyProofs, tallyData };
 };

--- a/packages/sdk/ts/proof/index.ts
+++ b/packages/sdk/ts/proof/index.ts
@@ -1,3 +1,3 @@
-export type { IGenerateProofsArgs, IProof, IProveOnChainArgs } from "./types";
+export type { IGenerateProofsArgs, IGenerateProofsData, IProof, IProveOnChainArgs } from "./types";
 export { generateProofs } from "./generate";
 export { proveOnChain } from "./prove";

--- a/packages/sdk/ts/proof/types.ts
+++ b/packages/sdk/ts/proof/types.ts
@@ -3,6 +3,8 @@ import type { Groth16Proof, SnarkProof } from "maci-contracts";
 import type { CircuitInputs } from "maci-core";
 import type { PublicSignals } from "snarkjs";
 
+import { ITallyData } from "../tally";
+
 /**
  * Interface for the arguments to the proveOnChain command
  */
@@ -166,4 +168,13 @@ export interface IGenerateProofsArgs {
    * The tally file
    */
   tallyFile: string;
+}
+
+/**
+ * Interface for the data returned by the generateProofs function
+ */
+export interface IGenerateProofsData {
+  processProofs: IProof[];
+  tallyProofs: IProof[];
+  tallyData: ITallyData;
 }


### PR DESCRIPTION
# Description

The previous `generateProofs` function was returning only `tallyData` but `processProofs` and `tallyProofs` were missing. The coordinator service was built using these two missing variables so I needed to return them in the sdk function. By using an interface, we are not modifying the function usage to much (instead of `const tallyData = await generateProofs( ... )` we use `const { tallyData } = await generateProofs( ... )`

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [ ] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
