### PR TITLE
docs: update broken links

### DIFF
--- a/apps/website/blog/2024-02-28-maci-v1.2.0.md
+++ b/apps/website/blog/2024-02-28-maci-v1.2.0.md
@@ -106,7 +106,7 @@ For those looking to contribute directly, report bugs, or offer feedback, our [G
 
 For practical implementation insights, review our docs as well as the [clr.fund](https://github.com/clrfund/monorepo/) and [QF](https://github.com/quadratic-gardens/qfi) repositories as reference implementations. Both are quadratic funding implementations, a mechanism which otherwise is highly susceptible to collusion and bribery. Most notably, clr.fund is already working on integrating MACI v1.2.0, after having used v0.x until now. You can follow their development effort under this [GitHub branch](https://github.com/clrfund/monorepo/tree/feat/maci-v1).
 
-For any other questions or feedback, please reach out to us via [PSE's Discord](https://discord.com/invite/sF5CT5rzrR), in our [`#🗳️-maci` channel](https://https//discord.com/channels/943612659163602974/1164613809730748507). We're excited to connect and collaborate with you!
+For any other questions or feedback, please reach out to us via [PSE's Discord](https://discord.com/invite/sF5CT5rzrR), in our [`#🗳️-maci` channel](https://discord.com/channels/943612659163602974/1164613809730748507). We're excited to connect and collaborate with you!
 
 ## References
 

--- a/apps/website/blog/2024-08-10-maci-v2.md
+++ b/apps/website/blog/2024-08-10-maci-v2.md
@@ -84,7 +84,7 @@ For those looking to contribute directly, report bugs, or offer feedback, our [G
 
 For practical implementation insights, review our docs as well as the [clr.fund](https://github.com/clrfund/monorepo/), [Allo Stack with MACI](https://github.com/gitcoinco/MACI_QF), and [maci-platform](https://github.com/privacy-scaling-explorations/maci-platform) repositories as reference implementations. The first two integrations are quadratic funding implementations, a mechanism which otherwise is highly susceptible to collusion and bribery.
 
-For any other questions or feedback, please reach out to us via [PSE's Discord](https://discord.com/invite/sF5CT5rzrR), in our [`#🗳️-maci` channel](https://https//discord.com/channels/943612659163602974/1164613809730748507). We're excited to connect and collaborate with you!
+For any other questions or feedback, please reach out to us via [PSE's Discord](https://discord.com/invite/sF5CT5rzrR), in our [`#🗳️-maci` channel](https://discord.com/channels/943612659163602974/1164613809730748507). We're excited to connect and collaborate with you!
 
 ## References
 


### PR DESCRIPTION
# Description

Hi! The links contained an extra `https//` prefix, which made them invalid.

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
