### PR TITLE
feat: allow to download artifacts on browser

### DIFF
--- a/packages/contracts/ts/proofs.ts
+++ b/packages/contracts/ts/proofs.ts
@@ -23,12 +23,6 @@ export const genProofSnarkjs = async ({ inputs, zkeyPath, wasmPath }: IGenProofO
     throw new Error("wasmPath must be specified");
   }
 
-  const isWasmExists = fs.existsSync(wasmPath);
-
-  if (!isWasmExists) {
-    throw new Error(`wasmPath ${wasmPath} does not exist`);
-  }
-
   const { proof, publicSignals } = await groth16.fullProve(inputs, wasmPath, zkeyPath);
   return { proof, publicSignals };
 };

--- a/packages/sdk/ts/proof/__tests__/download.test.ts
+++ b/packages/sdk/ts/proof/__tests__/download.test.ts
@@ -1,0 +1,54 @@
+import { genProofSnarkjs } from "maci-contracts";
+
+import { CircuitInputs } from "../../utils/types";
+import { downloadPollJoiningArtifactsBrowser } from "../download";
+
+/**
+ * The inputs for the proof generation
+ */
+const inputs = {
+  privKey: "1259082279488355278660453796037744749156697484507442909424227073450806091599",
+  pollPubKey: [
+    "4604149953291977424931588219098726306922992659857425248363017596008978179462",
+    "1911350329545195833133079763781611226710101140694516439580176096139978229522",
+  ],
+  siblings: [
+    ["1309255631273308531193241901289907343161346846555918942743921933037802809814"],
+    ["0"],
+    ["0"],
+    ["0"],
+    ["0"],
+    ["0"],
+    ["0"],
+    ["0"],
+    ["0"],
+    ["0"],
+  ],
+  indices: ["1", "0", "0", "0", "0", "0", "0", "0", "0", "0"],
+  nullifier: "5960968591926285526739882209300764345427591192846309606519433839944864771425",
+  stateRoot: "19853258600018552129206808764461795697997153860385513081821578400505176714352",
+  actualStateTreeDepth: "1",
+  pollId: "0",
+};
+
+describe("downloadPollJoiningArtifactsBrowser", () => {
+  it("should allow to generate a proof using the downloaded artifacts", async () => {
+    const { zKey, wasm } = await downloadPollJoiningArtifactsBrowser(true);
+
+    expect(zKey).toBeDefined();
+    expect(wasm).toBeDefined();
+
+    const { proof } = await genProofSnarkjs({
+      inputs: inputs as unknown as CircuitInputs,
+      zkeyPath: zKey as unknown as string,
+      wasmPath: wasm as unknown as string,
+    });
+
+    expect(proof).toBeDefined();
+    expect(proof.protocol).toBe("groth16");
+    expect(proof.pi_a.length).toBe(3);
+    expect(proof.pi_b.length).toBe(3);
+    expect(proof.pi_c.length).toBe(3);
+    expect(proof.curve).toBe("bn128");
+  });
+});

--- a/packages/sdk/ts/proof/constants.ts
+++ b/packages/sdk/ts/proof/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * The url of the poll joining zkey for testing
+ */
+export const pollJoiningZkeyTestingUrl =
+  "https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v3.0.0/browser-poll-join/testing/PollJoining_10_test.0.zkey";
+
+/**
+ * The url of the poll joining zkey for production
+ */
+export const pollJoiningWasmTestingUrl =
+  "https://maci-develop-fra.s3.eu-central-1.amazonaws.com/v3.0.0/browser-poll-join/testing/PollJoining_10_test.wasm";
+
+/**
+ * The url of the poll joining zkey for production
+ */
+export const pollJoiningZkeyProductionUrl = "not-available";
+
+/**
+ * The url of the poll joining wasm for production
+ */
+export const pollJoiningWasmProductionUrl = "not-available";

--- a/packages/sdk/ts/proof/download.ts
+++ b/packages/sdk/ts/proof/download.ts
@@ -1,0 +1,67 @@
+import type { IPollJoiningArtifacts } from "./types";
+
+import {
+  pollJoiningWasmProductionUrl,
+  pollJoiningWasmTestingUrl,
+  pollJoiningZkeyProductionUrl,
+  pollJoiningZkeyTestingUrl,
+} from "./constants";
+
+/**
+ * Read the chunks of a response
+ *
+ * @param response - The response to read the chunks from
+ * @returns The chunks and the length
+ */
+const readChunks = async (reader: ReadableStreamDefaultReader<Uint8Array>): Promise<Uint8Array> => {
+  let result = await reader.read();
+
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+
+  while (!result.done) {
+    const { value } = result;
+
+    length += value.length;
+    chunks.push(value as unknown as Uint8Array);
+
+    // continue reading
+    // eslint-disable-next-line no-await-in-loop
+    result = await reader.read();
+  }
+
+  const { acc: obj } = chunks.reduce(
+    ({ acc, position }, chunk) => {
+      acc.set(chunk, position);
+
+      return { acc, position: position + chunk.length };
+    },
+    { acc: new Uint8Array(length), position: 0 },
+  );
+
+  return obj;
+};
+
+/**
+ * Download the poll joining artifacts for the browser
+ *
+ * @param testing - Whether to download the testing artifacts
+ * @returns The poll joining artifacts
+ */
+export const downloadPollJoiningArtifactsBrowser = async (testing = false): Promise<IPollJoiningArtifacts> => {
+  const [zKeyResponse, wasmResponse] = await Promise.all([
+    fetch(testing ? pollJoiningZkeyTestingUrl : pollJoiningZkeyProductionUrl),
+    fetch(testing ? pollJoiningWasmTestingUrl : pollJoiningWasmProductionUrl),
+  ]);
+
+  const zKeyReader = zKeyResponse.body?.getReader();
+  const wasmReader = wasmResponse.body?.getReader();
+
+  if (!zKeyReader || !wasmReader) {
+    throw new Error("Failed to read zKey or wasm");
+  }
+
+  const [zKey, wasm] = await Promise.all([readChunks(zKeyReader), readChunks(wasmReader)]);
+
+  return { zKey, wasm };
+};

--- a/packages/sdk/ts/proof/types.ts
+++ b/packages/sdk/ts/proof/types.ts
@@ -194,3 +194,18 @@ export interface IGenerateProofsData {
    */
   tallyData: ITallyData;
 }
+
+/**
+ * Interface for the poll joining artifacts
+ */
+export interface IPollJoiningArtifacts {
+  /**
+   * The zkey
+   */
+  zKey: Uint8Array;
+
+  /**
+   * The wasm
+   */
+  wasm: Uint8Array;
+}


### PR DESCRIPTION
# Description

Allow to download zkey and wasm on browsers for the poll joining circuit

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
