### PR TITLE
test: move tests over to testing package

### DIFF
--- a/packages/testing/ts/__tests__/unit/fundWallet.test.ts
+++ b/packages/testing/ts/__tests__/unit/fundWallet.test.ts
@@ -1,7 +1,6 @@
+import { expect } from "chai";
 import { ZeroAddress } from "ethers";
-import { getDefaultSigner } from "maci-contracts";
-
-import { fundWallet } from "../fundWallet";
+import { getDefaultSigner, fundWallet } from "maci-sdk";
 
 describe("fundWallet", () => {
   it("should increase the balance of a wallet", async () => {
@@ -11,6 +10,6 @@ describe("fundWallet", () => {
     await fundWallet({ amount: 1000000000, address: ZeroAddress, signer });
     const balanceAfter = await signer.provider?.getBalance(ZeroAddress);
 
-    expect(Number(balanceAfter)).toBeGreaterThan(Number(balanceBefore!));
+    expect(Number(balanceAfter)).to.be.gt(Number(balanceBefore!));
   });
 });

--- a/packages/testing/ts/__tests__/unit/timeTravel.test.ts
+++ b/packages/testing/ts/__tests__/unit/timeTravel.test.ts
@@ -1,15 +1,14 @@
-import { getDefaultSigner } from "maci-contracts";
-
-import { timeTravel } from "../timeTravel";
+import { expect } from "chai";
+import { getDefaultSigner, timeTravel } from "maci-sdk";
 
 describe("timeTravel", () => {
-  test("should work when given a valid integer number", async () => {
+  it("should work when given a valid integer number", async () => {
     const signer = await getDefaultSigner();
     const blockNumber = await signer.provider?.getBlock("latest");
 
     await timeTravel({ seconds: 5, signer });
 
     const blockNumberAfter = await signer.provider?.getBlock("latest");
-    expect(blockNumberAfter!.timestamp).toBeGreaterThan(blockNumber!.timestamp);
+    expect(blockNumberAfter!.timestamp).to.be.gt(blockNumber!.timestamp);
   });
 });


### PR DESCRIPTION
# Description

Move tests over to testing package as they require hardhat which is not configured in maci-sdk

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
