### PR TITLE
docs: ensure solidity docs are displayed

### DIFF
--- a/apps/website/src/scripts/setupSolidityDocs.ts
+++ b/apps/website/src/scripts/setupSolidityDocs.ts
@@ -9,7 +9,7 @@ const solidityDocDir = path.resolve(
   "../../versioned_docs/version-v3.x/technical-references/smart-contracts/solidity-docs",
 );
 // the origin folder (from the contracts package)
-const sourceDir = path.resolve(__dirname, "../../../packages/contracts/docs");
+const sourceDir = path.resolve(__dirname, "../../../../packages/contracts/docs");
 
 /**
  * Currently, Solidity docgen generates the same heading for all files.

--- a/packages/contracts/contracts/mocks/Mocker.sol
+++ b/packages/contracts/contracts/mocks/Mocker.sol
@@ -26,5 +26,5 @@ import "@excubiae/contracts/contracts/test/extensions/mocks/MockHatsProtocol.sol
 import "@excubiae/contracts/contracts/test/extensions/mocks/MockToken.sol";
 
 /// @title Mocker
-/// @notice import all external contracts for tests
+/// @notice Import all external contracts for tests
 contract Mocker {}


### PR DESCRIPTION
# Description

Ensure SolidityDocs are correctly displayed on the doc website

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
