### PR TITLE
chore: explicity define packages as not private

### DIFF
--- a/apps/coordinator/package.json
+++ b/apps/coordinator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/maci-coordinator",
   "version": "1.0.0",
+  "private": false,
   "description": "Coordinator service for MACI",
   "main": "build/ts/main.js",
   "type": "module",

--- a/apps/relayer/package.json
+++ b/apps/relayer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/relayer",
   "version": "1.0.0",
+  "private": false,
   "description": "Relayer service for MACI",
   "main": "build/ts/main.js",
   "type": "module",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/website",
   "version": "1.0.0",
+  "private": false,
   "scripts": {
     "setup-typedoc": "ts-node ./src/scripts/setupTypedoc.ts",
     "setup-soliditydocs": "ts-node ./src/scripts/setupSolidityDocs.ts",

--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/circuits",
   "version": "3.0.0",
+  "private": false,
   "description": "zk-SNARK circuits for MACI",
   "main": "build/ts/index.js",
   "files": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/cli",
   "version": "3.0.0",
+  "private": false,
   "description": "CLI utilities for MACI",
   "main": "build/ts/index.js",
   "exports": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/contracts",
   "version": "3.0.0",
+  "private": false,
   "description": "Solidity Smart Contracts for MACI (Minimal Anti-Collusion Infrastructure)",
   "main": "build/ts/index.js",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/core",
   "version": "3.0.0",
+  "private": false,
   "description": "The MACI state machine implemented in TypeScript",
   "main": "build/ts/index.js",
   "types": "build/ts/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -2,6 +2,7 @@
   "name": "@maci-protocol/crypto",
   "version": "3.0.0",
   "description": "A package containing cryptography utilities for MACI",
+  "private": false,
   "main": "build/ts/index.js",
   "files": [
     "build",

--- a/packages/domainobjs/package.json
+++ b/packages/domainobjs/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@maci-protocol/domainobjs",
   "version": "3.0.0",
-  "description": "",
+  "private": false,
+  "description": "Classes representing domain objects for MACI",
   "main": "build/ts/index.js",
   "files": [
     "build",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/sdk",
   "version": "1.0.0",
+  "private": false,
   "description": "MACI's SDK",
   "main": "build/ts/index.js",
   "exports": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maci-protocol/testing",
   "version": "1.0.0",
+  "private": false,
   "description": "A package with testing utilities for MACI",
   "main": "build/ts/index.js",
   "files": [


### PR DESCRIPTION
# Description

Seems like publishing keeps failing due to packages being private, so setting all of them as explicitly not private

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
