### PR TITLE
fix: remove caching zkeys for downloading

### DIFF
--- a/.github/workflows/relayer-build.yml
+++ b/.github/workflows/relayer-build.yml
@@ -109,7 +109,7 @@ jobs:
           pnpm setup:zkeys -- --outPath ../../apps/relayer/zkeys
 
       - name: Download zkeys
-        if: ${{ env.CHANGED == 'false' && steps.cache_zkeys.outputs.cache-hit != 'true' }}
+        if: ${{ env.CHANGED == 'false' }}
         run: |
           pnpm download-zkeys:test:relayer
 

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -96,7 +96,7 @@ jobs:
           pnpm setup:zkeys -- --outPath ../testing/zkeys
 
       - name: Download zkeys
-        if: ${{ env.CHANGED == 'false' && steps.cache_zkeys.outputs.cache-hit != 'true' }}
+        if: ${{ env.CHANGED == 'false' }}
         run: |
           pnpm download-zkeys:test
 


### PR DESCRIPTION
# Description

Always download zkeys instead of caching

## Additional Notes

N/A

## Related issue(s)

N/A

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
