### PR TITLE
feat: add poll state tree depth

### DIFF
--- a/apps/coordinator/ts/deployer/__tests__/utils.ts
+++ b/apps/coordinator/ts/deployer/__tests__/utils.ts
@@ -27,6 +27,7 @@ export const testMaciDeploymentConfig: IDeployMaciConfig = {
   VkRegistry: {
     args: {
       stateTreeDepth: 10n,
+      pollStateTreeDepth: 10n,
       messageBatchSize: MSG_BATCH_SIZE,
       voteOptionTreeDepth: 2n,
       intStateTreeDepth: 1n,
@@ -51,6 +52,7 @@ export const testPollDeploymentConfig: IDeployPollConfig = {
   coordinatorPubkey: new Keypair().pubKey.serialize(),
   intStateTreeDepth: 1,
   messageBatchSize: MSG_BATCH_SIZE,
+  pollStateTreeDepth: 10,
   voteOptionTreeDepth: 2,
   policy: {
     type: EPolicies.FreeForAll,

--- a/apps/coordinator/ts/deployer/deployer.service.ts
+++ b/apps/coordinator/ts/deployer/deployer.service.ts
@@ -471,7 +471,8 @@ export class DeployerService {
       processMessagesZkeyPath,
       tallyVotesZkeyPath,
     });
-    const { stateTreeDepth, intStateTreeDepth, voteOptionTreeDepth, messageBatchSize } = vkRegistryArgs;
+    const { stateTreeDepth, intStateTreeDepth, voteOptionTreeDepth, pollStateTreeDepth, messageBatchSize } =
+      vkRegistryArgs;
     return {
       pollJoiningVk: pollJoiningVk!,
       pollJoinedVk: pollJoinedVk!,
@@ -481,6 +482,7 @@ export class DeployerService {
       intStateTreeDepth: Number(intStateTreeDepth),
       voteOptionTreeDepth: Number(voteOptionTreeDepth),
       messageBatchSize: Number(messageBatchSize),
+      pollStateTreeDepth: Number(pollStateTreeDepth),
       signer,
       mode,
       vkRegistryAddress: await vkRegistryContract.getAddress(),
@@ -745,6 +747,7 @@ export class DeployerService {
           "setVerifyingKeysBatch",
           [
             config.VkRegistry.args.stateTreeDepth,
+            config.VkRegistry.args.pollStateTreeDepth,
             config.VkRegistry.args.intStateTreeDepth,
             config.VkRegistry.args.voteOptionTreeDepth,
             config.VkRegistry.args.messageBatchSize,
@@ -887,6 +890,7 @@ export class DeployerService {
       intStateTreeDepth: config.intStateTreeDepth,
       voteOptionTreeDepth: config.voteOptionTreeDepth,
       messageBatchSize: config.messageBatchSize,
+      stateTreeDepth: config.pollStateTreeDepth,
       coordinatorPubKey: PubKey.deserialize(config.coordinatorPubkey),
       verifierContractAddress: verifierAddress,
       vkRegistryContractAddress: vkRegistryAddress,

--- a/apps/coordinator/ts/deployer/types.ts
+++ b/apps/coordinator/ts/deployer/types.ts
@@ -201,6 +201,11 @@ export interface IVkRegistryArgs {
   stateTreeDepth: bigint | string;
 
   /**
+   * The poll state tree depth
+   */
+  pollStateTreeDepth: bigint | string;
+
+  /**
    * The int state tree depth determines the tally batch size
    */
   intStateTreeDepth: bigint | string;
@@ -300,6 +305,11 @@ export interface IDeployPollConfig {
    * Message batch size
    */
   messageBatchSize: number;
+
+  /**
+   * Poll state tree depth
+   */
+  pollStateTreeDepth: number;
 
   /**
    * Vote option tree depth

--- a/apps/subgraph/tests/common.ts
+++ b/apps/subgraph/tests/common.ts
@@ -13,9 +13,10 @@ export function mockPollContract(): void {
     ethereum.Value.fromI32(20),
   ]);
 
-  createMockedFunction(DEFAULT_POLL_ADDRESS, "treeDepths", "treeDepths():(uint8,uint8)").returns([
+  createMockedFunction(DEFAULT_POLL_ADDRESS, "treeDepths", "treeDepths():(uint8,uint8,uint8)").returns([
     ethereum.Value.fromI32(1),
     ethereum.Value.fromI32(2),
+    ethereum.Value.fromI32(10),
   ]);
 
   createMockedFunction(

--- a/packages/circuits/ts/__tests__/CeremonyParams.test.ts
+++ b/packages/circuits/ts/__tests__/CeremonyParams.test.ts
@@ -22,6 +22,7 @@ describe("Ceremony param tests", () => {
   const treeDepths = {
     intStateTreeDepth: 1,
     voteOptionTreeDepth: params.voteOptionTreeDepth,
+    stateTreeDepth: params.stateTreeDepth,
   };
 
   const voiceCreditBalance = BigInt(100);

--- a/packages/circuits/ts/__tests__/TallyVotes.test.ts
+++ b/packages/circuits/ts/__tests__/TallyVotes.test.ts
@@ -14,6 +14,7 @@ describe("TallyVotes circuit", function test() {
   const treeDepths = {
     intStateTreeDepth: 1,
     voteOptionTreeDepth: 2,
+    stateTreeDepth: 10,
   };
 
   const coordinatorKeypair = new Keypair();

--- a/packages/circuits/ts/__tests__/utils/constants.ts
+++ b/packages/circuits/ts/__tests__/utils/constants.ts
@@ -7,6 +7,7 @@ export const duration = 30;
 export const treeDepths = {
   intStateTreeDepth: 5,
   voteOptionTreeDepth: 2,
+  stateTreeDepth: 10,
 };
 
 export const messageBatchSize = 20;

--- a/packages/cli/ts/index.ts
+++ b/packages/cli/ts/index.ts
@@ -328,6 +328,7 @@ program
   .requiredOption("-e, --end <pollEndDate>", "the poll end date", parseInt)
   .requiredOption("-i, --int-state-tree-depth <intStateTreeDepth>", "the int state tree depth", parseInt)
   .requiredOption("-b, --msg-batch-size <messageBatchSize>", "the message batch size", parseInt)
+  .requiredOption("-s, --state-tree-depth <stateTreeDepth>", "the state tree depth", parseInt)
   .requiredOption("-v, --vote-option-tree-depth <voteOptionTreeDepth>", "the vote option tree depth", parseInt)
   .requiredOption("-p, --pubkey <coordinatorPubkey>", "the coordinator public key")
   .option(
@@ -390,6 +391,7 @@ program
         pollEndTimestamp: cmdObj.end,
         intStateTreeDepth: cmdObj.intStateTreeDepth,
         messageBatchSize: cmdObj.msgBatchSize,
+        stateTreeDepth: cmdObj.stateTreeDepth,
         voteOptionTreeDepth: cmdObj.voteOptionTreeDepth,
         coordinatorPubKey: PubKey.deserialize(cmdObj.pubkey),
         maciAddress,
@@ -495,6 +497,7 @@ program
   .requiredOption("-i, --int-state-tree-depth <intStateTreeDepth>", "the intermediate state tree depth", parseInt)
   .requiredOption("-v, --vote-option-tree-depth <voteOptionTreeDepth>", "the vote option tree depth", parseInt)
   .requiredOption("-b, --msg-batch-size <messageBatchSize>", "the message batch size", parseInt)
+  .option("--poll-state-tree-depth <pollStateTreeDepth>", "the poll state tree depth", parseInt)
   .option(
     "--poll-joining-zkey <pollJoiningZkeyPath>",
     "the poll joining zkey path (see different options for zkey files to use specific circuits https://maci.pse.dev/docs/trusted-setup, https://maci.pse.dev/docs/testing/#pre-compiled-artifacts-for-testing)",
@@ -552,6 +555,7 @@ program
         intStateTreeDepth: cmdObj.intStateTreeDepth,
         voteOptionTreeDepth: cmdObj.voteOptionTreeDepth,
         messageBatchSize: cmdObj.msgBatchSize,
+        pollStateTreeDepth: cmdObj.pollStateTreeDepth || cmdObj.stateTreeDepth,
         pollJoiningVk: pollJoiningVk!,
         pollJoinedVk: pollJoinedVk!,
         processMessagesVk: processVk!,

--- a/packages/contracts/contracts/MessageProcessor.sol
+++ b/packages/contracts/contracts/MessageProcessor.sol
@@ -69,7 +69,7 @@ contract MessageProcessor is Clone, SnarkCommon, Hasher, IMessageProcessor, Doma
       revert NoMoreMessages();
     }
 
-    (, uint8 voteOptionTreeDepth) = poll.treeDepths();
+    (, uint8 voteOptionTreeDepth, ) = poll.treeDepths();
     uint8 messageBatchSize = poll.messageBatchSize();
 
     uint256[] memory batchHashes;

--- a/packages/contracts/contracts/Tally.sol
+++ b/packages/contracts/contracts/Tally.sol
@@ -100,7 +100,7 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
   /// @notice Check if all ballots are tallied
   /// @return tallied whether all ballots are tallied
   function isTallied() public view returns (bool tallied) {
-    (uint8 intStateTreeDepth, ) = poll.treeDepths();
+    (uint8 intStateTreeDepth, , ) = poll.treeDepths();
     (uint256 numSignUps, ) = poll.numSignUpsAndMessages();
 
     // Require that there are untallied ballots left
@@ -126,7 +126,7 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
     updateSbCommitment();
 
     // get the batch size and start index
-    (uint8 intStateTreeDepth, ) = poll.treeDepths();
+    (uint8 intStateTreeDepth, , ) = poll.treeDepths();
     uint256 tallyBatchSize = TREE_ARITY ** intStateTreeDepth;
     uint256 batchStartIndex = tallyBatchNum * tallyBatchSize;
 
@@ -178,7 +178,7 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
     uint256 _newTallyCommitment,
     uint256[8] calldata _proof
   ) public view returns (bool isValid) {
-    (uint8 intStateTreeDepth, uint8 voteOptionTreeDepth) = poll.treeDepths();
+    (uint8 intStateTreeDepth, uint8 voteOptionTreeDepth, ) = poll.treeDepths();
     uint256[] memory circuitPublicInputs = getPublicCircuitInputs(_batchStartIndex, _newTallyCommitment);
     IMACI maci = poll.getMaciContract();
 
@@ -367,7 +367,7 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
       revert VotesNotTallied();
     }
 
-    (, uint8 voteOptionTreeDepth) = poll.treeDepths();
+    (, uint8 voteOptionTreeDepth, ) = poll.treeDepths();
     uint256 voteOptionsLength = args.voteOptionIndices.length;
 
     for (uint256 i = 0; i < voteOptionsLength; ) {

--- a/packages/contracts/contracts/VkRegistry.sol
+++ b/packages/contracts/contracts/VkRegistry.sol
@@ -105,44 +105,26 @@ contract VkRegistry is Ownable(msg.sender), DomainObjs, SnarkCommon, IVkRegistry
 
   /// @notice Set the process and tally verifying keys for a certain combination
   /// of parameters and modes
-  /// @param _stateTreeDepth The state tree depth
-  /// @param _intStateTreeDepth The intermediate state tree depth
-  /// @param _voteOptionTreeDepth The vote option tree depth
-  /// @param _messageBatchSize The message batch size
-  /// @param _modes Array of QV or Non-QV modes (must have the same length as process and tally keys)
-  /// @param _pollJoiningVk The poll joining verifying key
-  /// @param _pollJoinedVk The poll joined verifying key
-  /// @param _processVks The process verifying keys (must have the same length as modes)
-  /// @param _tallyVks The tally verifying keys (must have the same length as modes)
-  function setVerifyingKeysBatch(
-    uint256 _stateTreeDepth,
-    uint256 _intStateTreeDepth,
-    uint256 _voteOptionTreeDepth,
-    uint8 _messageBatchSize,
-    Mode[] calldata _modes,
-    VerifyingKey calldata _pollJoiningVk,
-    VerifyingKey calldata _pollJoinedVk,
-    VerifyingKey[] calldata _processVks,
-    VerifyingKey[] calldata _tallyVks
-  ) public onlyOwner {
-    if (_modes.length != _processVks.length || _modes.length != _tallyVks.length) {
+  /// @param _args The verifying keys arguments
+  function setVerifyingKeysBatch(SetVerifyingKeysBatchArgs calldata _args) public onlyOwner {
+    if (_args.modes.length != _args.processVks.length || _args.modes.length != _args.tallyVks.length) {
       revert InvalidKeysParams();
     }
 
-    uint256 length = _modes.length;
+    uint256 length = _args.modes.length;
 
-    setPollJoiningVkKey(_stateTreeDepth, _pollJoiningVk);
-    setPollJoinedVkKey(_stateTreeDepth, _pollJoinedVk);
+    setPollJoiningVkKey(_args.pollStateTreeDepth, _args.pollJoiningVk);
+    setPollJoinedVkKey(_args.pollStateTreeDepth, _args.pollJoinedVk);
 
     for (uint256 index = 0; index < length; ) {
       setVerifyingKeys(
-        _stateTreeDepth,
-        _intStateTreeDepth,
-        _voteOptionTreeDepth,
-        _messageBatchSize,
-        _modes[index],
-        _processVks[index],
-        _tallyVks[index]
+        _args.stateTreeDepth,
+        _args.intStateTreeDepth,
+        _args.voteOptionTreeDepth,
+        _args.messageBatchSize,
+        _args.modes[index],
+        _args.processVks[index],
+        _args.tallyVks[index]
       );
 
       unchecked {

--- a/packages/contracts/contracts/interfaces/IPoll.sol
+++ b/packages/contracts/contracts/interfaces/IPoll.sol
@@ -82,7 +82,11 @@ interface IPoll {
   /// @notice Get the depths of the merkle trees
   /// @return intStateTreeDepth The depth of the state tree
   /// @return voteOptionTreeDepth The subdepth of the vote option tree
-  function treeDepths() external view returns (uint8 intStateTreeDepth, uint8 voteOptionTreeDepth);
+  /// @return stateTreeDepth The poll state tree depth
+  function treeDepths()
+    external
+    view
+    returns (uint8 intStateTreeDepth, uint8 voteOptionTreeDepth, uint8 stateTreeDepth);
 
   /// @notice Get the number of vote options for the poll
   /// @return voteOptions The number of vote options

--- a/packages/contracts/contracts/interfaces/IVkRegistry.sol
+++ b/packages/contracts/contracts/interfaces/IVkRegistry.sol
@@ -7,6 +7,29 @@ import { DomainObjs } from "../utilities/DomainObjs.sol";
 /// @title IVkRegistry
 /// @notice VkRegistry interface
 interface IVkRegistry {
+  struct SetVerifyingKeysBatchArgs {
+    /// @param stateTreeDepth The state tree depth
+    uint256 stateTreeDepth;
+    /// @param pollStateTreeDepth The poll state tree depth
+    uint256 pollStateTreeDepth;
+    /// @param intStateTreeDepth The intermediate state tree depth
+    uint256 intStateTreeDepth;
+    /// @param voteOptionTreeDepth The vote option tree depth
+    uint256 voteOptionTreeDepth;
+    /// @param messageBatchSize The message batch size
+    uint8 messageBatchSize;
+    /// @param modes Array of QV or Non-QV modes (must have the same length as process and tally keys)
+    DomainObjs.Mode[] modes;
+    /// @param pollJoiningVk The poll joining verifying key
+    SnarkCommon.VerifyingKey pollJoiningVk;
+    /// @param pollJoinedVk The poll joined verifying key
+    SnarkCommon.VerifyingKey pollJoinedVk;
+    /// @param processVks The process verifying keys (must have the same length as modes)
+    SnarkCommon.VerifyingKey[] processVks;
+    /// @param tallyVks The tally verifying keys (must have the same length as modes)
+    SnarkCommon.VerifyingKey[] tallyVks;
+  }
+
   /// @notice Get the tally verifying key
   /// @param _stateTreeDepth The state tree depth
   /// @param _intStateTreeDepth The intermediate state tree depth

--- a/packages/contracts/contracts/utilities/Params.sol
+++ b/packages/contracts/contracts/utilities/Params.sol
@@ -18,6 +18,7 @@ contract Params {
   struct TreeDepths {
     uint8 intStateTreeDepth;
     uint8 voteOptionTreeDepth;
+    uint8 stateTreeDepth;
   }
 
   /// @notice A struct holding the external contracts

--- a/packages/contracts/deploy-config-example.json
+++ b/packages/contracts/deploy-config-example.json
@@ -91,7 +91,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "scroll_sepolia": {
@@ -185,7 +186,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "optimism": {
@@ -280,7 +282,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "arbitrum_sepolia": {
@@ -375,7 +378,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "localhost": {
@@ -470,7 +474,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "base_sepolia": {
@@ -565,7 +570,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "optimism_sepolia": {
@@ -665,7 +671,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "gnosis_chiado": {
@@ -765,7 +772,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "gnosis": {
@@ -865,7 +873,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "polygon_amoy": {
@@ -965,7 +974,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   },
   "polygon": {
@@ -1065,7 +1075,8 @@
       "policy": "FreeForAllPolicy",
       "relayers": "0x0000000000000000000000000000000000000000",
       "initialVoiceCreditProxy": "ConstantInitialVoiceCreditProxy",
-      "voteOptions": 2
+      "voteOptions": 2,
+      "stateTreeDepth": 10
     }
   }
 }

--- a/packages/contracts/tasks/deploy/maci/08-vkRegistry.ts
+++ b/packages/contracts/tasks/deploy/maci/08-vkRegistry.ts
@@ -31,6 +31,8 @@ deployment.deployTask(EDeploySteps.VkRegistry, "Deploy Vk Registry and set keys"
     }
 
     const stateTreeDepth = deployment.getDeployConfigField<number>(EContracts.VkRegistry, "stateTreeDepth");
+    const pollStateTreeDepth =
+      deployment.getDeployConfigField<number>(EContracts.Poll, "stateTreeDepth") || stateTreeDepth;
     const intStateTreeDepth = deployment.getDeployConfigField<number>(EContracts.VkRegistry, "intStateTreeDepth");
     const messageBatchSize = deployment.getDeployConfigField<number>(EContracts.VkRegistry, "messageBatchSize");
     const voteOptionTreeDepth = deployment.getDeployConfigField<number>(EContracts.VkRegistry, "voteOptionTreeDepth");
@@ -105,17 +107,18 @@ deployment.deployTask(EDeploySteps.VkRegistry, "Deploy Vk Registry and set keys"
     }
 
     await vkRegistryContract
-      .setVerifyingKeysBatch(
+      .setVerifyingKeysBatch({
         stateTreeDepth,
+        pollStateTreeDepth,
         intStateTreeDepth,
         voteOptionTreeDepth,
         messageBatchSize,
         modes,
-        pollJoiningVk as IVerifyingKeyStruct,
-        pollJoinedVk as IVerifyingKeyStruct,
-        processZkeys,
-        tallyZkeys,
-      )
+        pollJoiningVk: pollJoiningVk as IVerifyingKeyStruct,
+        pollJoinedVk: pollJoinedVk as IVerifyingKeyStruct,
+        processVks: processZkeys,
+        tallyVks: tallyZkeys,
+      })
       .then((tx) => tx.wait());
 
     await storage.register({

--- a/packages/contracts/tests/Tally.test.ts
+++ b/packages/contracts/tests/Tally.test.ts
@@ -300,13 +300,13 @@ describe("TallyVotes", () => {
       poll.updatePoll(BigInt(maciState.pubKeys.length));
 
       await vkRegistryContract.setPollJoiningVkKey(
-        STATE_TREE_DEPTH,
+        treeDepths.stateTreeDepth,
         testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );
 
       await vkRegistryContract.setPollJoinedVkKey(
-        STATE_TREE_DEPTH,
+        treeDepths.stateTreeDepth,
         testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );
@@ -621,14 +621,14 @@ describe("TallyVotes", () => {
 
       // set the verification keys on the vk smart contract
       await vkRegistryContract.setPollJoiningVkKey(
-        STATE_TREE_DEPTH,
+        treeDepths.stateTreeDepth,
         testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );
 
       // set the verification keys on the vk smart contract
       await vkRegistryContract.setPollJoinedVkKey(
-        STATE_TREE_DEPTH,
+        treeDepths.stateTreeDepth,
         testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
         { gasLimit: 10000000 },
       );

--- a/packages/contracts/tests/VkRegistry.test.ts
+++ b/packages/contracts/tests/VkRegistry.test.ts
@@ -21,6 +21,7 @@ describe("VkRegistry", () => {
   let vkRegistryContract: VkRegistry;
 
   const stateTreeDepth = 10;
+  const pollStateTreeDepth = 10;
 
   describe("deployment", () => {
     before(async () => {
@@ -137,17 +138,18 @@ describe("VkRegistry", () => {
 
   describe("setVerifyingKeysBatch", () => {
     it("should set the process, tally, poll vks", async () => {
-      const tx = await vkRegistryContract.setVerifyingKeysBatch(
+      const tx = await vkRegistryContract.setVerifyingKeysBatch({
         stateTreeDepth,
-        treeDepths.intStateTreeDepth,
-        treeDepths.voteOptionTreeDepth,
+        pollStateTreeDepth,
+        intStateTreeDepth: treeDepths.intStateTreeDepth,
+        voteOptionTreeDepth: treeDepths.voteOptionTreeDepth,
         messageBatchSize,
-        [EMode.NON_QV],
-        testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
-        testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
-        [testProcessVkNonQv.asContractParam() as IVerifyingKeyStruct],
-        [testTallyVkNonQv.asContractParam() as IVerifyingKeyStruct],
-      );
+        modes: [EMode.NON_QV],
+        pollJoiningVk: testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
+        pollJoinedVk: testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
+        processVks: [testProcessVkNonQv.asContractParam() as IVerifyingKeyStruct],
+        tallyVks: [testTallyVkNonQv.asContractParam() as IVerifyingKeyStruct],
+      });
 
       const receipt = await tx.wait();
       expect(receipt?.status).to.eq(1);
@@ -155,20 +157,21 @@ describe("VkRegistry", () => {
 
     it("should throw when zkeys doesn't have the same length", async () => {
       await expect(
-        vkRegistryContract.setVerifyingKeysBatch(
+        vkRegistryContract.setVerifyingKeysBatch({
           stateTreeDepth,
-          treeDepths.intStateTreeDepth,
-          treeDepths.voteOptionTreeDepth,
+          pollStateTreeDepth,
+          intStateTreeDepth: treeDepths.intStateTreeDepth,
+          voteOptionTreeDepth: treeDepths.voteOptionTreeDepth,
           messageBatchSize,
-          [EMode.QV],
-          testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
-          testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
-          [
+          modes: [EMode.QV],
+          pollJoiningVk: testPollJoiningVk.asContractParam() as IVerifyingKeyStruct,
+          pollJoinedVk: testPollJoinedVk.asContractParam() as IVerifyingKeyStruct,
+          processVks: [
             testProcessVk.asContractParam() as IVerifyingKeyStruct,
             testProcessVkNonQv.asContractParam() as IVerifyingKeyStruct,
           ],
-          [testTallyVk.asContractParam() as IVerifyingKeyStruct],
-        ),
+          tallyVks: [testTallyVk.asContractParam() as IVerifyingKeyStruct],
+        }),
       ).to.be.revertedWithCustomError(vkRegistryContract, "InvalidKeysParams");
     });
   });
@@ -226,7 +229,7 @@ describe("VkRegistry", () => {
   describe("genSignatures", () => {
     describe("genPollJoiningVkSig", () => {
       it("should generate a valid signature", async () => {
-        const sig = await vkRegistryContract.genPollJoiningVkSig(stateTreeDepth);
+        const sig = await vkRegistryContract.genPollJoiningVkSig(pollStateTreeDepth);
         const vk = await vkRegistryContract.getPollJoiningVkBySig(sig);
         compareVks(testPollJoiningVk, vk);
       });
@@ -234,7 +237,7 @@ describe("VkRegistry", () => {
 
     describe("genPollJoinedVkSig", () => {
       it("should generate a valid signature", async () => {
-        const sig = await vkRegistryContract.genPollJoinedVkSig(stateTreeDepth);
+        const sig = await vkRegistryContract.genPollJoinedVkSig(pollStateTreeDepth);
         const vk = await vkRegistryContract.getPollJoinedVkBySig(sig);
         compareVks(testPollJoinedVk, vk);
       });

--- a/packages/contracts/tests/constants.ts
+++ b/packages/contracts/tests/constants.ts
@@ -72,6 +72,7 @@ export const maxVoteOptions = 25;
 export const treeDepths: TreeDepths = {
   intStateTreeDepth: 1,
   voteOptionTreeDepth: 2,
+  stateTreeDepth: 10,
 };
 
 export const tallyBatchSize = STATE_TREE_ARITY ** treeDepths.intStateTreeDepth;

--- a/packages/contracts/ts/genMaciState.ts
+++ b/packages/contracts/ts/genMaciState.ts
@@ -137,6 +137,7 @@ export const genMaciStateFromContract = async ({
   const treeDepths = {
     intStateTreeDepth: Number(onChainTreeDepths.intStateTreeDepth),
     voteOptionTreeDepth: Number(onChainTreeDepths.voteOptionTreeDepth),
+    stateTreeDepth: Number(onChainTreeDepths.stateTreeDepth),
   };
 
   const messageBatchSize = Number(msgBatchSize);

--- a/packages/core/ts/Poll.ts
+++ b/packages/core/ts/Poll.ts
@@ -65,9 +65,6 @@ export class Poll implements IPoll {
 
   maxVoteOptions: number;
 
-  // the depth of the state tree
-  stateTreeDepth: number;
-
   // the actual depth of the state tree (can be <= stateTreeDepth)
   actualStateTreeDepth: number;
 
@@ -167,8 +164,7 @@ export class Poll implements IPoll {
     this.maxVoteOptions = VOTE_OPTION_TREE_ARITY ** treeDepths.voteOptionTreeDepth;
     this.maciStateRef = maciStateRef;
     this.pollId = BigInt(maciStateRef.polls.size);
-    this.stateTreeDepth = maciStateRef.stateTreeDepth;
-    this.actualStateTreeDepth = maciStateRef.stateTreeDepth;
+    this.actualStateTreeDepth = treeDepths.stateTreeDepth;
     this.currentMessageBatchIndex = 0;
 
     this.pollNullifiers = new Map<bigint, boolean>();
@@ -252,7 +248,12 @@ export class Poll implements IPoll {
 
     // Create as many ballots as state leaves
     this.emptyBallotHash = this.emptyBallot.hash();
-    this.ballotTree = new IncrementalQuinTree(this.stateTreeDepth, this.emptyBallotHash, STATE_TREE_ARITY, hash2);
+    this.ballotTree = new IncrementalQuinTree(
+      Number(this.treeDepths.stateTreeDepth),
+      this.emptyBallotHash,
+      STATE_TREE_ARITY,
+      hash2,
+    );
     this.ballotTree.insert(this.emptyBallotHash);
 
     // we fill the ballotTree with empty ballots hashes to match the number of signups in the tree
@@ -452,12 +453,12 @@ export class Poll implements IPoll {
     const siblingsLength = siblings.length;
 
     // The index must be converted to a list of indices, 1 for each tree level.
-    // The circuit tree depth is this.stateTreeDepth, so the number of siblings must be this.stateTreeDepth,
+    // The circuit tree depth is this.treeDepths.stateTreeDepth, so the number of siblings must be this.treeDepths.stateTreeDepth,
     // even if the tree depth is actually 3. The missing siblings can be set to 0, as they
     // won't be used to calculate the root in the circuit.
     const indices: bigint[] = [];
 
-    for (let i = 0; i < this.stateTreeDepth; i += 1) {
+    for (let i = 0; i < this.treeDepths.stateTreeDepth; i += 1) {
       // eslint-disable-next-line no-bitwise
       indices.push(BigInt((index >> i) & 1));
 
@@ -506,7 +507,7 @@ export class Poll implements IPoll {
 
     const elementsLength = pathIndices.length;
 
-    for (let i = 0; i < this.stateTreeDepth; i += 1) {
+    for (let i = 0; i < this.treeDepths.stateTreeDepth; i += 1) {
       if (i >= elementsLength) {
         pathElements[i] = [0n];
         pathIndices[i] = 0;
@@ -780,7 +781,7 @@ export class Poll implements IPoll {
     // we need to fill the array with 0s to match the length of the state leaves
     // eslint-disable-next-line @typescript-eslint/prefer-for-of
     for (let i = 0; i < currentStateLeavesPathElements.length; i += 1) {
-      while (currentStateLeavesPathElements[i].length < this.stateTreeDepth) {
+      while (currentStateLeavesPathElements[i].length < this.treeDepths.stateTreeDepth) {
         currentStateLeavesPathElements[i].push([0n]);
       }
     }
@@ -1322,6 +1323,7 @@ export class Poll implements IPoll {
       {
         intStateTreeDepth: Number(this.treeDepths.intStateTreeDepth),
         voteOptionTreeDepth: Number(this.treeDepths.voteOptionTreeDepth),
+        stateTreeDepth: Number(this.treeDepths.stateTreeDepth),
       },
       {
         tallyBatchSize: Number(this.batchSizes.tallyBatchSize.toString()),
@@ -1419,6 +1421,7 @@ export class Poll implements IPoll {
    */
   toJSON(): IJsonPoll {
     return {
+      stateTreeDepth: Number(this.treeDepths.stateTreeDepth),
       pollEndTimestamp: this.pollEndTimestamp.toString(),
       treeDepths: this.treeDepths,
       batchSizes: this.batchSizes,

--- a/packages/core/ts/__benchmarks__/utils/constants.ts
+++ b/packages/core/ts/__benchmarks__/utils/constants.ts
@@ -13,4 +13,5 @@ export const MAX_VALUES = {
 export const TREE_DEPTHS = {
   intStateTreeDepth: 2,
   voteOptionTreeDepth: 4,
+  stateTreeDepth: 10,
 };

--- a/packages/core/ts/__tests__/utils/constants.ts
+++ b/packages/core/ts/__tests__/utils/constants.ts
@@ -9,5 +9,6 @@ export const coordinatorKeypair = new Keypair();
 export const treeDepths = {
   intStateTreeDepth: 2,
   voteOptionTreeDepth: 4,
+  stateTreeDepth: 10,
 };
 export const maxVoteOptions = BigInt(VOTE_OPTION_TREE_ARITY ** treeDepths.voteOptionTreeDepth);

--- a/packages/core/ts/utils/constants.ts
+++ b/packages/core/ts/utils/constants.ts
@@ -1,4 +1,5 @@
 export const STATE_TREE_DEPTH = 10;
+export const POLL_STATE_TREE_DEPTH = 10;
 export const STATE_TREE_ARITY = 2;
 export const STATE_TREE_SUBDEPTH = 2;
 export const VOTE_OPTION_TREE_ARITY = 5;

--- a/packages/core/ts/utils/types.ts
+++ b/packages/core/ts/utils/types.ts
@@ -28,6 +28,7 @@ export type CircuitInputs = Record<string, string | bigint | bigint[] | bigint[]
 export interface TreeDepths {
   intStateTreeDepth: number;
   voteOptionTreeDepth: number;
+  stateTreeDepth: number;
 }
 
 /**
@@ -88,6 +89,7 @@ export interface IPoll {
  * This interface defines the JSON representation of a Poll
  */
 export interface IJsonPoll {
+  stateTreeDepth: number;
   pollEndTimestamp: string;
   treeDepths: TreeDepths;
   batchSizes: BatchSizes;

--- a/packages/sdk/ts/deploy/poll.ts
+++ b/packages/sdk/ts/deploy/poll.ts
@@ -27,6 +27,7 @@ export const deployPoll = async ({
   intStateTreeDepth,
   voteOptionTreeDepth,
   messageBatchSize,
+  stateTreeDepth,
   coordinatorPubKey,
   verifierContractAddress,
   vkRegistryContractAddress,
@@ -128,6 +129,7 @@ export const deployPoll = async ({
       treeDepths: {
         intStateTreeDepth,
         voteOptionTreeDepth,
+        stateTreeDepth,
       },
       messageBatchSize,
       coordinatorPubKey: coordinatorPubKey.asContractParam(),

--- a/packages/sdk/ts/deploy/types.ts
+++ b/packages/sdk/ts/deploy/types.ts
@@ -38,6 +38,11 @@ export interface IDeployPollArgs {
   messageBatchSize: number;
 
   /**
+   * The poll state tree depth
+   */
+  stateTreeDepth: number;
+
+  /**
    * The coordinator public key
    */
   coordinatorPubKey: PubKey;

--- a/packages/sdk/ts/verifyingKeys/setVerifyingKeys.ts
+++ b/packages/sdk/ts/verifyingKeys/setVerifyingKeys.ts
@@ -18,6 +18,7 @@ export const setVerifyingKeys = async ({
   processMessagesVk,
   tallyVotesVk,
   stateTreeDepth,
+  pollStateTreeDepth,
   intStateTreeDepth,
   voteOptionTreeDepth,
   messageBatchSize,
@@ -72,17 +73,18 @@ export const setVerifyingKeys = async ({
   }
 
   // set them onchain
-  const tx = await vkRegistryContract.setVerifyingKeysBatch(
+  const tx = await vkRegistryContract.setVerifyingKeysBatch({
     stateTreeDepth,
+    pollStateTreeDepth,
     intStateTreeDepth,
     voteOptionTreeDepth,
     messageBatchSize,
-    [mode],
-    pollJoiningVk.asContractParam() as IVerifyingKeyStruct,
-    pollJoinedVk.asContractParam() as IVerifyingKeyStruct,
-    [processMessagesVk.asContractParam() as IVerifyingKeyStruct],
-    [tallyVotesVk.asContractParam() as IVerifyingKeyStruct],
-  );
+    modes: [mode],
+    pollJoiningVk: pollJoiningVk.asContractParam() as IVerifyingKeyStruct,
+    pollJoinedVk: pollJoinedVk.asContractParam() as IVerifyingKeyStruct,
+    processVks: [processMessagesVk.asContractParam() as IVerifyingKeyStruct],
+    tallyVks: [tallyVotesVk.asContractParam() as IVerifyingKeyStruct],
+  });
 
   const receipt = await tx.wait();
 

--- a/packages/sdk/ts/verifyingKeys/types.ts
+++ b/packages/sdk/ts/verifyingKeys/types.ts
@@ -135,6 +135,11 @@ export interface ISetVerifyingKeysArgs {
   stateTreeDepth: number;
 
   /**
+   * The poll state tree depth
+   */
+  pollStateTreeDepth: number;
+
+  /**
    * The intermediate state tree depth (ballot tree)
    */
   intStateTreeDepth: number;

--- a/packages/testing/ts/__tests__/integration.test.ts
+++ b/packages/testing/ts/__tests__/integration.test.ts
@@ -48,6 +48,7 @@ import {
   pollDuration,
   maxMessages,
   maxVoteOptions,
+  POLL_STATE_TREE_DEPTH,
 } from "../constants";
 import { ITestSuite } from "../types";
 import { expectTally, genTestUserCommands, isArm, writeBackupFile, backupFolder } from "../utils";
@@ -91,6 +92,7 @@ describe("Integration tests", function test() {
 
     await setVerifyingKeys({
       stateTreeDepth: STATE_TREE_DEPTH,
+      pollStateTreeDepth: POLL_STATE_TREE_DEPTH,
       intStateTreeDepth: INT_STATE_TREE_DEPTH,
       voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
       messageBatchSize: MESSAGE_BATCH_SIZE,
@@ -151,6 +153,7 @@ describe("Integration tests", function test() {
       pollStartTimestamp: startDate,
       intStateTreeDepth: INT_STATE_TREE_DEPTH,
       messageBatchSize: MESSAGE_BATCH_SIZE,
+      stateTreeDepth: POLL_STATE_TREE_DEPTH,
       voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
       coordinatorPubKey: coordinatorKeypair.pubKey,
       maciAddress: contracts.maciContractAddress,
@@ -168,6 +171,7 @@ describe("Integration tests", function test() {
     const treeDepths: TreeDepths = {
       intStateTreeDepth: INT_STATE_TREE_DEPTH,
       voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
+      stateTreeDepth: POLL_STATE_TREE_DEPTH,
     };
 
     const messageBatchSize = MESSAGE_BATCH_SIZE;

--- a/packages/testing/ts/constants.ts
+++ b/packages/testing/ts/constants.ts
@@ -23,6 +23,7 @@ import type { Signer } from "ethers";
 import { readJSONFile } from "./utils";
 
 export const STATE_TREE_DEPTH = 10;
+export const POLL_STATE_TREE_DEPTH = 10;
 export const INT_STATE_TREE_DEPTH = 1;
 export const VOTE_OPTION_TREE_DEPTH = 2;
 export const MESSAGE_BATCH_SIZE = 20;
@@ -189,6 +190,7 @@ export const verifyingKeysArgs = async (
 
   return {
     stateTreeDepth: STATE_TREE_DEPTH,
+    pollStateTreeDepth: POLL_STATE_TREE_DEPTH,
     intStateTreeDepth: INT_STATE_TREE_DEPTH,
     voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
     messageBatchSize: MESSAGE_BATCH_SIZE,
@@ -219,6 +221,7 @@ export const deployPollArgs: Omit<
 > = {
   intStateTreeDepth: INT_STATE_TREE_DEPTH,
   messageBatchSize: MESSAGE_BATCH_SIZE,
+  stateTreeDepth: POLL_STATE_TREE_DEPTH,
   voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
   coordinatorPubKey: coordinatorKeypair.pubKey,
   initialVoiceCredits: DEFAULT_INITIAL_VOICE_CREDITS,

--- a/packages/testing/ts/testingClass.ts
+++ b/packages/testing/ts/testingClass.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_INITIAL_VOICE_CREDITS,
   DEFAULT_SG_DATA,
   DEFAULT_IVCP_DATA,
+  POLL_STATE_TREE_DEPTH,
 } from "./constants";
 import { User } from "./user";
 
@@ -138,6 +139,7 @@ export class TestingClass {
       intStateTreeDepth: INT_STATE_TREE_DEPTH,
       voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
       messageBatchSize: MESSAGE_BATCH_SIZE,
+      pollStateTreeDepth: POLL_STATE_TREE_DEPTH,
       pollJoiningVk: pollJoiningVk!,
       pollJoinedVk: pollJoinedVk!,
       processMessagesVk: processVk!,
@@ -187,6 +189,7 @@ export class TestingClass {
       pollEndTimestamp: startDate + 130,
       intStateTreeDepth: INT_STATE_TREE_DEPTH,
       messageBatchSize: MESSAGE_BATCH_SIZE,
+      stateTreeDepth: POLL_STATE_TREE_DEPTH,
       voteOptionTreeDepth: VOTE_OPTION_TREE_DEPTH,
       coordinatorPubKey: coordinatorKeypair.pubKey,
       mode: EMode.NON_QV,


### PR DESCRIPTION
# Description

- [x] Use poll state tree depth instead of maci state tree depth
- [x] Use maci state tree depth as a fallback
- [x] Update params for setting keys for vk registry
- [x] Update deploy scripts and compatibility fixes
- [x] Set verifying keys for poll if signature is not matched

## Additional Notes

Requires to compile circuits with `pollStateTreeDepth` params.

## Related issue(s)

Closes #2272

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
