### PR TITLE
fix(contracts): deploy poll with specified voice credit

### DIFF
--- a/packages/contracts/tasks/deploy/poll/03-poll.ts
+++ b/packages/contracts/tasks/deploy/poll/03-poll.ts
@@ -64,10 +64,11 @@ deployment.deployTask(EDeploySteps.Poll, "Deploy poll").then((task) =>
       deployment.getDeployConfigField<EContracts | null>(EContracts.Poll, "policy") || EContracts.FreeForAllPolicy;
     const fullPolicyName = FULL_POLICY_NAMES[policy as keyof typeof FULL_POLICY_NAMES] as unknown as EContracts;
     const policyContractAddress = storage.mustGetAddress(fullPolicyName, hre.network.name, `poll-${pollId}`);
-    const initialVoiceCreditProxyContractAddress = storage.mustGetAddress(
-      EContracts.ConstantInitialVoiceCreditProxy,
-      hre.network.name,
-    );
+
+    const initialVoiceCreditProxy =
+      deployment.getDeployConfigField<EContracts | null>(EContracts.Poll, "initialVoiceCreditProxy") ||
+      EContracts.ConstantInitialVoiceCreditProxy;
+    const initialVoiceCreditProxyContractAddress = storage.mustGetAddress(initialVoiceCreditProxy, hre.network.name);
 
     const voteOptions = deployment.getDeployConfigField<number>(EContracts.Poll, "voteOptions");
 

--- a/packages/contracts/tasks/helpers/types.ts
+++ b/packages/contracts/tasks/helpers/types.ts
@@ -579,7 +579,7 @@ export enum EPolicies {
   Semaphore = "@excubiae/contracts/contracts/extensions/semaphore/SemaphorePolicy.sol:SemaphorePolicy",
   MerkleProof = "@excubiae/contracts/contracts/extensions/merkle/MerkleProofPolicy.sol:MerkleProofPolicy",
   AnonAadhaar = "@excubiae/contracts/contracts/extensions/anonAadhaar/AnonAadhaarPolicy.sol:AnonAadhaarPolicy",
-  ERC20Votes = "@excubiae/contracts/contracts/extensions/erc20Votes/ERC20VotesPolicy.sol:ERC20VotesPolicy",
+  ERC20Votes = "@excubiae/contracts/contracts/extensions/erc20votes/ERC20VotesPolicy.sol:ERC20VotesPolicy",
   ERC20 = "@excubiae/contracts/contracts/extensions/erc20/ERC20Policy.sol:ERC20Policy",
 }
 


### PR DESCRIPTION
# Description

When running `pnpm deploy-poll:<NETWORK>` in the `packages/contracts` with a voice credit proxy different than `ConstantInitialVoiceCreditProxy`  I was getting an error saying that the contract was not saved. 

# Fixes

1. check if a specific initialVoiceCreditProxy is set in `deploy-config.json`. If there is none, use the `ConstantInitialVoiceCreditProxy`. Fetch that contract from the saved list (it should exist because it is deployed in the previous step `01-voiceCreditProxy.ts`

2. change **erc20Votes** by **erc20votes** in `@excubiae/contracts/contracts/extensions/erc20votes/` according to how it is spelled in the excubiae repository


## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
