### PR TITLE
feat(sdk): get results from tally contract

### DIFF
--- a/packages/sdk/ts/tally/index.ts
+++ b/packages/sdk/ts/tally/index.ts
@@ -6,4 +6,7 @@ export type {
   IGenerateTallyCommitmentsArgs,
   ITallyCommitments,
   ITallyVotesInputs,
+  IGetResultPerOptionArgs,
+  IGetResultsArgs,
 } from "./types";
+export { getResultPerOption, getResults } from "./results";

--- a/packages/sdk/ts/tally/results.ts
+++ b/packages/sdk/ts/tally/results.ts
@@ -1,0 +1,64 @@
+import {
+  MACI__factory as MACIFactory,
+  Tally__factory as TallyFactory,
+  Poll__factory as PollFactory,
+} from "@maci-protocol/contracts/typechain-types";
+
+import type { IGetResultPerOptionArgs, IGetResultsArgs } from "./types";
+
+/**
+ * Get result per option
+ * @param {IGetResultPerOptionsArgs} - The arguments to get result per option
+ * @returns The result per option
+ */
+export const getResultPerOption = async ({
+  maciAddress,
+  pollId,
+  index,
+  signer,
+}: IGetResultPerOptionArgs): Promise<bigint> => {
+  const maciContract = MACIFactory.connect(maciAddress, signer);
+
+  const pollContracts = await maciContract.getPoll(pollId);
+
+  const tallyContract = TallyFactory.connect(pollContracts.tally, signer);
+
+  const result = await tallyContract.tallyResults(index);
+
+  if (!result.flag) {
+    throw new Error("Tally result is not set");
+  }
+
+  return result.value;
+};
+
+/**
+ * Get all results from the Tally contract
+ * @param {IGetResultsArgs} - The arguments to get all the results
+ * @returns The results array (The final result of vote option n is in index n-1)
+ */
+export const getResults = async ({ maciAddress, pollId, signer }: IGetResultsArgs): Promise<bigint[]> => {
+  const maciContract = MACIFactory.connect(maciAddress, signer);
+
+  const pollContracts = await maciContract.getPoll(pollId);
+
+  const pollContract = PollFactory.connect(pollContracts.poll, signer);
+  const numberOfVoteOptions = await pollContract.voteOptions();
+
+  const tallyContract = TallyFactory.connect(pollContracts.tally, signer);
+
+  const results: bigint[] = [];
+
+  for (let i = 0; i < numberOfVoteOptions; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await tallyContract.tallyResults(i);
+
+    if (!result.flag) {
+      throw new Error(`Tally result for option ${i} is not set`);
+    }
+
+    results.push(result.value);
+  }
+
+  return results;
+};

--- a/packages/sdk/ts/tally/types.ts
+++ b/packages/sdk/ts/tally/types.ts
@@ -202,3 +202,33 @@ export interface ITallyVotesInputs {
   newPerVOSpentVoiceCreditsRootSalt: bigint;
   newSpentVoiceCreditSubtotalSalt: bigint;
 }
+
+/**
+ * Get results args
+ */
+export interface IGetResultsArgs {
+  /**
+   * The address of the MACI contract
+   */
+  maciAddress: string;
+
+  /**
+   * The ID of the poll
+   */
+  pollId: string;
+
+  /**
+   * The signer
+   */
+  signer: Signer;
+}
+
+/**
+ * Get result per option args
+ */
+export interface IGetResultPerOptionArgs extends IGetResultsArgs {
+  /**
+   * The index of the vote option
+   */
+  index: number;
+}


### PR DESCRIPTION
# Description

Add SDK functions to get tally results from the Tally contract

## Related issue(s)

fix #2413 
## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
