### PR TITLE
feat(sdk): allow to reuse inclusion proof for joinPoll

### DIFF
--- a/packages/sdk/ts/browser/index.ts
+++ b/packages/sdk/ts/browser/index.ts
@@ -6,7 +6,14 @@ export * from "../trees";
 export * from "../vote";
 export * from "../maciKeys";
 export { getSignedupUserData, signup, hasUserSignedUp } from "../user/signup";
-export { getJoinedUserData, hasUserJoinedPoll } from "../user/utils";
+export {
+  getJoinedUserData,
+  hasUserJoinedPoll,
+  generateMaciStateTree,
+  getPollJoiningCircuitEvents,
+  joiningCircuitInputs,
+  generateMaciStateTreeWithEndKey,
+} from "../user/utils";
 
 export * from "./joinPoll";
 

--- a/packages/sdk/ts/trees/index.ts
+++ b/packages/sdk/ts/trees/index.ts
@@ -1,2 +1,2 @@
-export { generateSignUpTree } from "./stateTree";
-export type { IGenerateSignUpTreeArgs, IGenerateSignUpTree } from "./types";
+export { generateSignUpTree, generateSignUpTreeWithEndKey } from "./stateTree";
+export type { IGenerateSignUpTreeArgs, IGenerateSignUpTree, IGenerateSignUpTreeWithEndKeyArgs } from "./types";

--- a/packages/sdk/ts/trees/stateTree.ts
+++ b/packages/sdk/ts/trees/stateTree.ts
@@ -4,9 +4,7 @@ import { hashLeanIMT, hashLeftRight, PAD_KEY_HASH } from "@maci-protocol/crypto"
 import { PublicKey } from "@maci-protocol/domainobjs";
 import { LeanIMT, LeanIMTHashFunction } from "@zk-kit/lean-imt";
 
-import assert from "assert";
-
-import type { IGenerateSignUpTreeArgs, IGenerateSignUpTree } from "./types";
+import type { IGenerateSignUpTreeArgs, IGenerateSignUpTree, IGenerateSignUpTreeWithEndKeyArgs } from "./types";
 
 import { sleep } from "../utils/utils";
 
@@ -44,7 +42,6 @@ export const generateSignUpTree = async ({
     // eslint-disable-next-line no-await-in-loop
     const signUpLogs = await maciContract.queryFilter(maciContract.filters.SignUp(), i, toBlock);
     signUpLogs.forEach((event) => {
-      assert(!!event);
       const publicKeyX = event.args._userPublicKeyX;
       const publicKeyY = event.args._userPublicKeyY;
 
@@ -53,6 +50,75 @@ export const generateSignUpTree = async ({
       publicKeys.push(publicKey);
       signUpTree.insert(hashLeftRight(publicKeyX, publicKeyY));
     });
+
+    if (sleepAmount) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(sleepAmount);
+    }
+  }
+
+  return {
+    signUpTree,
+    publicKeys,
+  };
+};
+
+/**
+ * Generate a State tree object from the events of a MACI smart contracts
+ * @param provider - the ethereum provider
+ * @param address - the address of the MACI contract
+ * @param fromBlock - the block number from which to start fetching events
+ * @param blocksPerRequest - the number of blocks to fetch in each request
+ * @param endBlock - the block number at which to stop fetching events
+ * @param sleepAmount - the amount of time to sleep between each request
+ * @param userPublicKey - the user public key where we end/stop the signUpTree replica.
+ *        If user public key is 4th then the returned signUpTree will have only 4 leaves
+ *        (does not matter if MACI' signUpTree has more).
+ * @returns State tree
+ */
+export const generateSignUpTreeWithEndKey = async ({
+  provider,
+  address,
+  fromBlock = 0,
+  blocksPerRequest = 50,
+  endBlock,
+  sleepAmount,
+  userPublicKey,
+}: IGenerateSignUpTreeWithEndKeyArgs): Promise<IGenerateSignUpTree> => {
+  const lastBlock = endBlock || (await provider.getBlockNumber());
+
+  const maciContract = MACIFactory.connect(address, provider);
+  const signUpTree = new LeanIMT(hashLeanIMT as LeanIMTHashFunction);
+  signUpTree.insert(PAD_KEY_HASH);
+  const publicKeys: PublicKey[] = [];
+
+  // Fetch event logs in batches (lastBlock inclusive)
+  for (let i = fromBlock; i <= lastBlock; i += blocksPerRequest + 1) {
+    // the last block batch will be either current iteration block + blockPerRequest
+    // or the end block if it is set
+    const toBlock = i + blocksPerRequest >= lastBlock ? lastBlock : i + blocksPerRequest;
+
+    // eslint-disable-next-line no-await-in-loop
+    const signUpLogs = await maciContract.queryFilter(maciContract.filters.SignUp(), i, toBlock);
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+    for (let j = 0; j < signUpLogs.length; j += 1) {
+      const event = signUpLogs[j];
+      const publicKeyX = event.args._userPublicKeyX;
+      const publicKeyY = event.args._userPublicKeyY;
+
+      const publicKey = new PublicKey([publicKeyX, publicKeyY]);
+
+      publicKeys.push(publicKey);
+      signUpTree.insert(hashLeftRight(publicKeyX, publicKeyY));
+
+      // early return cause we found the user
+      if (publicKey.equals(userPublicKey)) {
+        return {
+          signUpTree,
+          publicKeys,
+        };
+      }
+    }
 
     if (sleepAmount) {
       // eslint-disable-next-line no-await-in-loop

--- a/packages/sdk/ts/trees/types.ts
+++ b/packages/sdk/ts/trees/types.ts
@@ -38,6 +38,16 @@ export interface IGenerateSignUpTreeArgs {
 }
 
 /**
+ * An interface that represents arguments of generation sign up tree which stops fetching at a given public key
+ */
+export interface IGenerateSignUpTreeWithEndKeyArgs extends IGenerateSignUpTreeArgs {
+  /**
+   * The public key of the user
+   */
+  userPublicKey: PublicKey;
+}
+
+/**
  * An interface that represents sign up tree and state leaves
  */
 export interface IGenerateSignUpTree {

--- a/packages/sdk/ts/user/index.ts
+++ b/packages/sdk/ts/user/index.ts
@@ -1,6 +1,13 @@
 export { joinPoll } from "./joinPoll";
 export { getSignedupUserData, signup, hasUserSignedUp } from "./signup";
-export { getJoinedUserData, hasUserJoinedPoll } from "./utils";
+export {
+  getJoinedUserData,
+  hasUserJoinedPoll,
+  generateMaciStateTree as genMaciStateTree,
+  generateMaciStateTreeWithEndKey as genMaciStateTreeWithEndKey,
+  getPollJoiningCircuitEvents,
+  joiningCircuitInputs,
+} from "./utils";
 export type {
   IJoinedUserArgs,
   IIsRegisteredUser,
@@ -18,4 +25,6 @@ export type {
   IParseSignupEventsArgs,
   ISignupData,
   IHasUserSignedUpArgs,
+  IGenMaciStateTreeArgs,
+  IGenMaciStateTreeWithEndKeyArgs,
 } from "./types";

--- a/packages/sdk/ts/user/types.ts
+++ b/packages/sdk/ts/user/types.ts
@@ -1,3 +1,5 @@
+import { LeanIMTMerkleProof } from "@zk-kit/lean-imt";
+
 import type { MACI, Poll } from "@maci-protocol/contracts/typechain-types";
 import type { PrivateKey, PublicKey } from "@maci-protocol/domainobjs";
 import type { Signer } from "ethers";
@@ -355,6 +357,21 @@ export interface IJoinPollArgs {
 }
 
 /**
+ * Interface for the arguments to the joinPoll command for the browser
+ */
+export interface IJoinPollBrowserArgs extends IJoinPollArgs {
+  /**
+   * Whether to use of not the latest state index
+   */
+  useLatestStateIndex?: boolean;
+
+  /**
+   * The inclusion proof
+   */
+  inclusionProof?: LeanIMTMerkleProof;
+}
+
+/**
  * Interface for the return data to the joinPoll command
  */
 export interface IJoinPollData {
@@ -399,6 +416,46 @@ export interface IIsNullifierOnChainArgs {
    * The signer to use
    */
   signer: Signer;
+}
+
+/**
+ * Arguments for IGenMaciStateTreeArgs
+ */
+export interface IGenMaciStateTreeArgs {
+  /**
+   * The MACI contract
+   */
+  maciContract: MACI;
+
+  /**
+   * The signer
+   */
+  signer: Signer;
+
+  /**
+   * The start block
+   */
+  startBlock?: number;
+
+  /**
+   * The end block
+   */
+  endBlock?: number;
+
+  /**
+   * The blocks per batch
+   */
+  blocksPerBatch?: number;
+}
+
+/**
+ * Arguments for IGenMaciStateTreeWithEndKeyArgs
+ */
+export interface IGenMaciStateTreeWithEndKeyArgs extends IGenMaciStateTreeArgs {
+  /**
+   * The public key of the user
+   */
+  userPublicKey: PublicKey;
 }
 
 /**


### PR DESCRIPTION
# Description

Allow to join poll using by passing an already calculated inclusion proof

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
