### PR TITLE
fix(cli): adjust duplicate cli flag

### DIFF
--- a/packages/cli/ts/index.ts
+++ b/packages/cli/ts/index.ts
@@ -332,7 +332,7 @@ program
   .requiredOption("-p, --public-key <publicKey>", "the coordinator public key")
   .option("-m, --mode <mode>", "Voting mode (qv, non-qv, full)", (value) => MODE_NAME_TO_ENUM[value], EMode.QV)
   .option("-x, --maci-address <maciAddress>", "the MACI contract address")
-  .option("-m, --relayers <relayers>", "the relayer addresses", (value) => value.split(",").map((item) => item.trim()))
+  .option("--relayers <relayers>", "the relayer addresses", (value) => value.split(",").map((item) => item.trim()))
   .option("-q, --quiet <quiet>", "whether to print values to the console", (value) => value === "true", false)
   .option("-r, --rpc-provider <provider>", "the rpc provider URL")
   .option("-o, --vote-options <voteOptions>", "the number of vote options", parseInt)


### PR DESCRIPTION
# Description

Remove duplicate CLI flag

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
