### PR TITLE
fix: allow parent directories for prove output dir

### DIFF
--- a/apps/website/versioned_docs/version-v3.x/quick-start.md
+++ b/apps/website/versioned_docs/version-v3.x/quick-start.md
@@ -203,6 +203,10 @@ As a coordinator, first you need to merge signups and messages (votes). This opt
 pnpm merge:[network] --poll [poll-id]
 ```
 
+:::info
+`poll-id` starts at 0 and increments for each deployed poll
+:::
+
 Then you need to generate the proofs for the message processing, and tally calculations. This allows to publish the poll results on-chain and then everyone can verify the results:
 
 ```bash
@@ -214,8 +218,12 @@ pnpm run prove:[network] --poll [poll-id] \
     --blocks-per-batch [number-of-blocks]
 ```
 
-:::important
-You can reduce the time of the proving by including more blocks per batch, you can try with 500.
+:::info
+The `--coordinator-private-key` is the one you generated earlier with `pnpm run generateMaciKeyPair`.
+
+`--start-block` is the block number from which to start looking for events from. You can use the block that you deployed the contracts in.
+
+You can reduce the time of the proving by including more blocks per batch with `--blocks-per-batch`, you can try with 500.
 :::
 
 #### Submit On-chain
@@ -224,8 +232,8 @@ Now it's time to submit the poll results on-chain so that everyone can verify th
 
 ```bash
 pnpm submitOnChain:[network] --poll [poll-id] \
-    --output-dir proofs/ \
-    --tally-file proofs/tally.json
+    --output-dir ../results/proofs/ \
+    --tally-file ../results/tally.json
 ```
 
 ### Tally

--- a/packages/contracts/tasks/runner/prove.ts
+++ b/packages/contracts/tasks/runner/prove.ts
@@ -64,7 +64,7 @@ task("prove", "Command to generate proofs")
 
       if (!isOutputDirExists) {
         // Create the directory
-        await fs.promises.mkdir(outputDir);
+        await fs.promises.mkdir(outputDir, { recursive: true });
       }
 
       const maciPrivateKey = PrivateKey.deserialize(coordinatorPrivateKey);


### PR DESCRIPTION
# Description

* Allow parent directories when creating a prove output directory
* Small modifications to Getting Started guide to provide additional info on commands
* Use same directory structure in guide - some commands in the guide used different file paths for proof output directory 

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

The gettting started guide uses nested directories for outputting results. `mkdir` requires a -p flag in order to do this. You can do this by adding the `recursive` option:

```ts
// from this
await fs.promises.mkdir(outputDir);

// to this
await fs.promises.mkdir(outputDir, { recursive: true });
```

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
