### PR TITLE
feat(sdk): implement Subgraph fetcher for signup tree

### DIFF
--- a/apps/subgraph/config/network.json
+++ b/apps/subgraph/config/network.json
@@ -1,5 +1,5 @@
 {
   "network": "optimism-sepolia",
-  "maciContractAddress": "0xbE6e250bf8B5F689c65Cc79667589A9EBF6Fe8E3",
-  "maciContractStartBlock": 13160483
+  "maciContractAddress": "0x406CAe994Ea166B0010bEeCa6ec88D325Ec0EBE5",
+  "maciContractStartBlock": 27662188
 }

--- a/apps/subgraph/schemas/schema.v1.graphql
+++ b/apps/subgraph/schemas/schema.v1.graphql
@@ -1,4 +1,4 @@
-type MACI @entity(immutable: true) {
+type MACI @entity(immutable: false) {
   id: Bytes! # address
   stateTreeDepth: BigInt! # uint8
   updatedAt: BigInt!
@@ -27,7 +27,7 @@ type Account @entity(immutable: true) {
   owner: User!
 }
 
-type Poll @entity(immutable: true) {
+type Poll @entity(immutable: false) {
   id: Bytes! # poll address
   pollId: BigInt! # uint256
   startDate: BigInt! # uint256
@@ -63,7 +63,7 @@ type Vote @entity(immutable: true) {
   poll: Poll!
 }
 
-type ChainHash @entity(immutable: true) {
+type ChainHash @entity(immutable: false) {
   id: ID! # chain hash
   timestamp: BigInt!
 

--- a/packages/sdk/ts/browser/index.ts
+++ b/packages/sdk/ts/browser/index.ts
@@ -5,6 +5,7 @@ export * from "../tally";
 export * from "../trees";
 export * from "../vote";
 export * from "../maciKeys";
+export * from "../subgraph";
 export { getSignedupUserData, signup, hasUserSignedUp } from "../user/signup";
 export {
   getJoinedUserData,

--- a/packages/sdk/ts/index.ts
+++ b/packages/sdk/ts/index.ts
@@ -10,6 +10,7 @@ export * from "./utils";
 export * from "./user";
 export * from "./deploy";
 export * from "./maciKeys";
+export * from "./subgraph";
 export {
   EMode,
   EContracts,

--- a/packages/sdk/ts/subgraph/index.ts
+++ b/packages/sdk/ts/subgraph/index.ts
@@ -1,0 +1,2 @@
+export * from "./maciSubgraph";
+export type { GraphQLResponse } from "./types";

--- a/packages/sdk/ts/subgraph/maciSubgraph.ts
+++ b/packages/sdk/ts/subgraph/maciSubgraph.ts
@@ -1,0 +1,72 @@
+import { PublicKey } from "@maci-protocol/domainobjs";
+
+import type { GraphQLResponse } from "./types";
+
+/**
+ * A class that can be used to interact with MACI's subgraph
+ * @dev refer to apps/subgraph for subgraph deployment and configuration
+ */
+export class MaciSubgraph {
+  /**
+   * The URL of the subgraph
+   */
+  private url: string;
+
+  /**
+   * The query to get all MACIs public keys signed up
+   */
+  private userQuery = `
+        query {
+            users {
+                id
+            }
+        }
+    `;
+
+  /**
+   * Create a new instance of the MaciSubgraph class
+   *
+   * @param url - The URL of the subgraph
+   */
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  /**
+   * Get the public keys of all MACIs signed up
+   *
+   * @returns Array of public keys
+   */
+  async getKeys(): Promise<PublicKey[]> {
+    const res = await fetch(this.url, {
+      method: "POST",
+      body: JSON.stringify({
+        query: this.userQuery,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`GraphQL query failed: ${res.statusText}`);
+    }
+
+    const json = (await res.json()) as GraphQLResponse;
+
+    if (json.errors) {
+      throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
+    }
+
+    if (!json.data?.users) {
+      throw new Error("No users data in response");
+    }
+
+    return json.data.users.map((user) => {
+      // Split the id into x and y coordinates and convert to BigInt
+      const [x, y] = user.id.split(" ");
+      return new PublicKey([BigInt(x), BigInt(y)]);
+    });
+  }
+}

--- a/packages/sdk/ts/subgraph/types.ts
+++ b/packages/sdk/ts/subgraph/types.ts
@@ -1,0 +1,19 @@
+/**
+ * The response from the GraphQL query
+ */
+export interface GraphQLResponse {
+  /**
+   * The data from the query
+   */
+  data?: {
+    users: {
+      id: string;
+    }[];
+  };
+  /**
+   * The errors from the query
+   */
+  errors?: {
+    message: string;
+  }[];
+}

--- a/packages/sdk/ts/trees/index.ts
+++ b/packages/sdk/ts/trees/index.ts
@@ -1,2 +1,2 @@
-export { generateSignUpTree, generateSignUpTreeWithEndKey } from "./stateTree";
+export { generateSignUpTree, generateSignUpTreeWithEndKey, generateSignUpTreeFromKeys } from "./stateTree";
 export type { IGenerateSignUpTreeArgs, IGenerateSignUpTree, IGenerateSignUpTreeWithEndKeyArgs } from "./types";

--- a/packages/sdk/ts/trees/stateTree.ts
+++ b/packages/sdk/ts/trees/stateTree.ts
@@ -131,3 +131,16 @@ export const generateSignUpTreeWithEndKey = async ({
     publicKeys,
   };
 };
+
+/**
+ * Generate a sign up tree from the public keys
+ * @param publicKeys - the public keys to generate the sign up tree from
+ * @returns the sign up tree
+ */
+export const generateSignUpTreeFromKeys = (publicKeys: PublicKey[]): LeanIMT => {
+  const signUpTree = new LeanIMT(hashLeanIMT);
+  publicKeys.forEach((key) => {
+    signUpTree.insert(key.hash());
+  });
+  return signUpTree;
+};


### PR DESCRIPTION
# Description

Implement a MaciSubgraph class which allows to fetch all signed up public keys

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
