### PR TITLE
fix: ensure invalidVotes uses the correct nonce

### DIFF
--- a/apps/website/versioned_docs/version-v3.x/technical-references/zk-snark-circuits/setup.md
+++ b/apps/website/versioned_docs/version-v3.x/technical-references/zk-snark-circuits/setup.md
@@ -37,7 +37,7 @@ MACI's circuits are parameterized, and thus can be configured to support differe
 - **STATE_TREE_DEPTH** = how many users the system supports
 - **VOTE_OPTIONS_TREE_DEPTH** = how many vote options the system supports
 - **MESSAGE_BATCH_SIZE** = how many messages in a batch the circuit should process
-- **TALLY_PROCESSING_STATE_TREE_DEPTH** = how many ballots can be processed per batch when tallying the results (`5 ** TALLY_PROCESSING_STATE_TREE_DEPTH` ballots)
+- **TALLY_PROCESSING_STATE_TREE_DEPTH** = how many ballots can be processed per batch when tallying the results (`2 ** TALLY_PROCESSING_STATE_TREE_DEPTH` ballots)
 
 Please refer to the individual circuit documentation for more details on the inner working of each circuit and where parameters fit.
 

--- a/packages/sdk/ts/vote/invalidate.ts
+++ b/packages/sdk/ts/vote/invalidate.ts
@@ -34,7 +34,7 @@ export const invalidateVotes = async ({
   const message = generateVote({
     pollId,
     voteOptionIndex: 0n,
-    nonce: 0n,
+    nonce: 1n,
     privateKey: maciPrivateKey,
     stateIndex,
     // use a random key to invalidate the previous votes


### PR DESCRIPTION
# Description

Ensure we can invalidate votes by using the right nonce for the command to invalidate

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
