### PR TITLE
chore(contracts): reuse pollContracts for tally and mp addresses

### DIFF
--- a/packages/contracts/tasks/runner/prove.ts
+++ b/packages/contracts/tasks/runner/prove.ts
@@ -7,7 +7,7 @@ import { task, types } from "hardhat/config";
 import fs from "fs";
 
 import type { Proof } from "../../ts/types";
-import type { MACI, Poll, Tally } from "../../typechain-types";
+import type { MACI, Poll } from "../../typechain-types";
 
 import { logMagenta, info } from "../../ts/logger";
 import { ContractStorage } from "../helpers/ContractStorage";
@@ -121,12 +121,6 @@ task("prove", "Command to generate proofs")
         throw new Error(`Poll ${poll} not found`);
       }
 
-      const tallyContract = await deployment.getContract<Tally>({
-        name: EContracts.Tally,
-        key: `poll-${poll.toString()}`,
-      });
-      const tallyContractAddress = await tallyContract.getAddress();
-
       const modeKeys = {
         [EMode.QV]: "qv",
         [EMode.NON_QV]: "nonQv",
@@ -161,7 +155,7 @@ task("prove", "Command to generate proofs")
       const proofGenerator = new ProofGenerator({
         poll: foundPoll,
         maciContractAddress,
-        tallyContractAddress,
+        tallyContractAddress: pollContracts.tally,
         rapidsnark,
         tally: {
           zkey: voteTallyZkey,

--- a/packages/contracts/tasks/runner/submitOnChain.ts
+++ b/packages/contracts/tasks/runner/submitOnChain.ts
@@ -64,11 +64,11 @@ task("submitOnChain", "Command to prove the result of a poll on-chain")
       pollContract.stateMerged(),
       deployment.getContract<MessageProcessor>({
         name: EContracts.MessageProcessor,
-        key: `poll-${poll.toString()}`,
+        address: pollContracts.messageProcessor,
       }),
       deployment.getContract<Tally>({
         name: EContracts.Tally,
-        key: `poll-${poll.toString()}`,
+        address: pollContracts.tally,
       }),
     ]);
 


### PR DESCRIPTION
# Description

Do not rely on deployed-contracts.json for tally and mp addresses but use maci.polls() return value

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
