### PR TITLE
chore: expose sdk function invalidateVotes

### DIFF
--- a/packages/sdk/ts/vote/index.ts
+++ b/packages/sdk/ts/vote/index.ts
@@ -10,6 +10,7 @@ export type {
   ISubmitVoteBatchArgs,
 } from "./types";
 export { generateVote } from "./generate";
+export { invalidateVotes } from "./invalidate";
 export { publish, publishBatch } from "./publish";
 export { submitVote, submitVoteBatch } from "./submit";
 export { getCoordinatorPublicKey, validateSalt } from "./utils";


### PR DESCRIPTION
# Description

We want to [implement](https://github.com/privacy-scaling-explorations/maci-aragon-osx-gov-app/issues/26) a button to invalidate votes in the maci aragon demo. The `invalidateVotes` function is not exported from the sdk.

Added a follow up [issue](https://github.com/privacy-scaling-explorations/maci/issues/2517) to add tests for `invalidateVotes` as I can't see it used in any tests

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
