### PR TITLE
Fix typo in contract documentation

### DIFF
--- a/apps/website/versioned_docs/version-v0.x/contract.md
+++ b/apps/website/versioned_docs/version-v0.x/contract.md
@@ -84,7 +84,7 @@ uint256[] memory _finalSaltedResults,
 uint256[8] memory _proof
 ```
 
-This allows the coordinator to prove the correctness of their vote tally (in `_finalSaltedResults`). They do this in batches of state leaves. Each batch of state leaves is accumulated into an intermediate state root, and the Merkle root of all the intermediate state roots is the full state root. The proof shows that the result of adding the votes in the current batch to the culmulative results is computed correctly, but hides the results by salting and hashing them.
+This allows the coordinator to prove the correctness of their vote tally (in `_finalSaltedResults`). They do this in batches of state leaves. Each batch of state leaves is accumulated into an intermediate state root, and the Merkle root of all the intermediate state roots is the full state root. The proof shows that the result of adding the votes in the current batch to the cumulative results is computed correctly, but hides the results by salting and hashing them.
 
 `_finalSaltedResults` can be any value but for the final batch, it must be the correct quadratic vote tally.
 


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a minor typo in the contract documentation, replacing "culmulative" with the correct spelling "cumulative" for improved clarity and professionalism.

---