### PR TITLE
fix(sdk): sort users by creation date in subgraph query

### DIFF
--- a/packages/sdk/ts/subgraph/maciSubgraph.ts
+++ b/packages/sdk/ts/subgraph/maciSubgraph.ts
@@ -17,7 +17,7 @@ export class MaciSubgraph {
    */
   private userQuery = `
         query {
-            users {
+            users (orderBy: createdAt, orderDirection: asc) {
                 id
             }
         }


### PR DESCRIPTION
# Description

The `users` subgraph query previously did not guarantee the order of returned users, which could lead to inconsistencies.

### Changes

- Added `orderBy: createdAt` and `orderDirection: asc` to the users query that ensures users are returned in the order of their signup (ascending).

This ordering is necessary to correctly generate the signup tree when using `generateSignupTreeFromKeys`, which expects users in the exact order they signed up.

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
