### PR TITLE
feat(coordinator): update function in redis + adapt tests and utils

### DIFF
--- a/apps/coordinator/tests/e2e.redis.test.ts
+++ b/apps/coordinator/tests/e2e.redis.test.ts
@@ -1,3 +1,4 @@
+import { EMode } from "@maci-protocol/sdk";
 import { createClient, RedisClientType } from "@redis/client";
 
 import { ESupportedNetworks } from "../ts/common";
@@ -10,9 +11,10 @@ const REDIS__GET_ALL_PREFIX = "*-test";
 const scheduledPoll: IScheduledPoll = {
   maciAddress: "0xb83074Ac11fc569AC12F1b7D0C0a6809c3dc355b",
   pollId: "5",
-  mode: 1,
+  mode: EMode.NON_QV,
   chain: ESupportedNetworks.OPTIMISM_SEPOLIA,
   endDate: 1752534000,
+  deploymentBlockNumber: 1,
   merged: false,
   proofsGenerated: false,
 };
@@ -135,13 +137,20 @@ describe("RedisService", () => {
     expect(deleted).toBe(0);
   });
 
-  it("should return production key name when test is not specified", () => {
-    const key = getPollKeyFromObject(scheduledPoll, false);
-    expect(key).toBe(`${scheduledPoll.chain}-${scheduledPoll.maciAddress}-poll-${scheduledPoll.pollId}`);
-  });
-
-  it("should return test key name when test is specified", () => {
+  it("should update a value using set with same key", async () => {
     const key = getPollKeyFromObject(scheduledPoll, true);
-    expect(key).toBe(`${scheduledPoll.chain}-${scheduledPoll.maciAddress}-poll-${scheduledPoll.pollId}-test`);
+    const valuePoll = JSON.stringify(scheduledPoll);
+
+    await service.set(key, valuePoll);
+
+    const updatedPoll = { ...scheduledPoll, endDate: 1 };
+    const updatedPollValue = JSON.stringify(updatedPoll);
+
+    await service.set(key, updatedPollValue);
+
+    const stored = await service.get(key);
+    const parsed = JSON.parse(stored!) as IScheduledPoll;
+
+    expect(parsed.endDate).toBe(updatedPoll.endDate);
   });
 });

--- a/apps/coordinator/ts/redis/types.ts
+++ b/apps/coordinator/ts/redis/types.ts
@@ -2,9 +2,9 @@ import type { ESupportedNetworks } from "../common";
 import type { EMode } from "@maci-protocol/sdk";
 
 /**
- * Interface for scheduled polls stored in Redis
+ * Interface of the minimal properties to identify a scheduled poll
  */
-export interface IScheduledPoll {
+export interface IIdentityScheduledPoll {
   /**
    * Maci contract address
    */
@@ -16,17 +16,27 @@ export interface IScheduledPoll {
   pollId: string;
 
   /**
+   * Chain in which the poll is deployed
+   */
+  chain: ESupportedNetworks;
+}
+
+/**
+ * Interface for scheduled polls stored in Redis
+ */
+export interface IScheduledPoll extends IIdentityScheduledPoll {
+  /**
+   * Deployment block number
+   */
+  deploymentBlockNumber: number;
+
+  /**
    * Voting mode
    */
   mode: EMode;
 
   /**
-   * Chain in which the poll is deployed
-   */
-  chain: ESupportedNetworks;
-
-  /**
-   * End date
+   * End date in seconds
    */
   endDate: number;
 
@@ -44,22 +54,7 @@ export interface IScheduledPoll {
 /**
  * getPollKeyForRedis parameters
  */
-export interface IGetPollKeyForRedisParams {
-  /**
-   * Chain in which the poll is deployed
-   */
-  chain: ESupportedNetworks;
-
-  /**
-   * Maci contract address
-   */
-  maciAddress: string;
-
-  /**
-   * Poll id (unique identifier)
-   */
-  pollId: string;
-
+export interface IGetPollKeyForRedisParams extends IIdentityScheduledPoll {
   /**
    * Test environment flag (optional)
    */

--- a/apps/coordinator/ts/redis/utils.ts
+++ b/apps/coordinator/ts/redis/utils.ts
@@ -1,4 +1,4 @@
-import type { IGetPollKeyForRedisParams, IScheduledPoll } from "./types";
+import type { IGetPollKeyForRedisParams, IIdentityScheduledPoll } from "./types";
 
 /**
  * Generates a Redis key for a poll based on its attributes
@@ -9,8 +9,10 @@ import type { IGetPollKeyForRedisParams, IScheduledPoll } from "./types";
  * @param test - Optional flag to indicate if this is a test environment
  * @returns key for Redis
  */
-export const getPollKeyForRedis = ({ chain, maciAddress, pollId, test = false }: IGetPollKeyForRedisParams): string =>
-  `${chain}-${maciAddress}-poll-${pollId}${test ? `-test` : ""}`;
+export const getPollKeyForRedis = ({ chain, maciAddress, pollId, test = false }: IGetPollKeyForRedisParams): string => {
+  const isTest = test || process.env.NODE_ENV === "test";
+  return `${chain}-${maciAddress}-poll-${pollId}${isTest ? `-test` : ""}`;
+};
 
 /**
  * Generates a Redis key for a poll object
@@ -19,7 +21,7 @@ export const getPollKeyForRedis = ({ chain, maciAddress, pollId, test = false }:
  * @param test - Optional flag to indicate if this is a test environment
  * @returns key for Redis
  */
-export const getPollKeyFromObject = (scheduledPoll: IScheduledPoll, test?: boolean): string =>
+export const getPollKeyFromObject = (scheduledPoll: IIdentityScheduledPoll, test?: boolean): string =>
   getPollKeyForRedis({
     chain: scheduledPoll.chain,
     maciAddress: scheduledPoll.maciAddress,


### PR DESCRIPTION
# Description

1. update tests and examples were missing in the redis module. To end up with this particular implementation I had to consider a couple of things.
1.1. The `redis` package does not have an `update` function. It only has `set` and `delete`
1.2. I first tried to implement an `update` function that would use a redis transaction to execute `delete` and `set`. That way we would guarantee that all deleted values would get replaced by the new values. 
1.3. I realized that `set` can be used as an update function by passing the same key.
```javascript
this.service.set(key, value1); // set or create a new registry in Redis db
// ...
this.service.set(key, value2); // update current registry with new value

2. Created a `IIdentityScheduledPoll ` that contains the minimal properties required to identify a poll (maci address, poll id and chain). This would help out a lot in the scheduler module. `IScheduledPoll` added a couple of necessary properties as well (deploymentBlockNumber, mode)

3. The functions to compute the Redis key to retrieve data were updated to consider test environments using `process.env.NODE_ENV`. This helps out when running integration tests in computers that have some data in Redis.
```

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
