### PR TITLE
fix: add padding key to signup tree on initialization

### DIFF
--- a/packages/sdk/ts/trees/stateTree.ts
+++ b/packages/sdk/ts/trees/stateTree.ts
@@ -139,6 +139,7 @@ export const generateSignUpTreeWithEndKey = async ({
  */
 export const generateSignUpTreeFromKeys = (publicKeys: PublicKey[]): LeanIMT => {
   const signUpTree = new LeanIMT(hashLeanIMT);
+  signUpTree.insert(PAD_KEY_HASH);
   publicKeys.forEach((key) => {
     signUpTree.insert(key.hash());
   });


### PR DESCRIPTION
# Description

Ensure `generateSignupTreeFromKeys` correctly builds the signup tree by inserting the `PAD_KEY_HASH` before inserting hash of actual user public keys into the LeanIMT tree.

### Changes
Inserted the predefined `PAD_KEY_HASH` at the beginning of the LeanIMT tree in `generateSignupTreeFromKeys`.

### Why
There’s no on-chain event corresponding to the `padKey`, so it cannot be fetched via the subgraph.
Two approaches were considered:

1. Manually appending a `padKey` to the list of public keys returned by the subgraph through `getKeys` function.

2. Inserting a known `PAD_KEY_HASH` directly when constructing the tree from public keys.

This PR implements option 2, since the actual public key used to produce `PAD_KEY_HASH` isn’t known. And, only  `PAD_KEY_HASH` is used in sdk.

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
