### PR TITLE
fix(sdk): add padKey to array of retrieved MACI public keys

### DIFF
--- a/packages/sdk/ts/subgraph/maciSubgraph.ts
+++ b/packages/sdk/ts/subgraph/maciSubgraph.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from "@maci-protocol/domainobjs";
+import { PublicKey, padKey } from "@maci-protocol/domainobjs";
 
 import type { GraphQLResponse } from "./types";
 
@@ -35,7 +35,7 @@ export class MaciSubgraph {
   /**
    * Get the public keys of all MACIs signed up
    *
-   * @returns Array of public keys
+   * @returns Array of public keys including pad key
    */
   async getKeys(): Promise<PublicKey[]> {
     const res = await fetch(this.url, {
@@ -63,10 +63,13 @@ export class MaciSubgraph {
       throw new Error("No users data in response");
     }
 
-    return json.data.users.map((user) => {
+    const userKeys = json.data.users.map((user) => {
       // Split the id into x and y coordinates and convert to BigInt
       const [x, y] = user.id.split(" ");
       return new PublicKey([BigInt(x), BigInt(y)]);
     });
+
+    userKeys.unshift(padKey);
+    return userKeys;
   }
 }


### PR DESCRIPTION
# Description

Updated the `getKeys` function to include the known padKey as the first entry in the returned list of public keys to correctly generate signUpTree using `generateSignUpTreeFromKeys`

### Changes
Modified `getKeys` to prepend the known padKey to the list of public keys fetched from the subgraph.

### Why
The signup tree always starts with a `padKey`, but since there’s no on-chain event for its insertion, it isn’t included in subgraph results. This change ensures that downstream consumers like `generateSignupTreeFromKeys` receive a complete list, including the `padKey`, without having to handle it separately.


<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
