### PR TITLE
feat(contracts): improve prove tasks

### DIFF
--- a/packages/contracts/tasks/helpers/types.ts
+++ b/packages/contracts/tasks/helpers/types.ts
@@ -52,11 +52,6 @@ export interface IMergeParams {
    * The number of queue operations to perform
    */
   queueOps?: number;
-
-  /**
-   * Run prove command after merging
-   */
-  prove?: boolean;
 }
 
 /**
@@ -152,6 +147,11 @@ export interface IProveParams {
    * Backup files for ipfs messages (name format: ipfsHash1.json, ipfsHash2.json, ..., ipfsHashN.json)
    */
   ipfsMessageBackupFiles?: string;
+
+  /**
+   * Submit proofs on-chain
+   */
+  submitOnChain?: boolean;
 }
 
 /**

--- a/packages/contracts/tasks/runner/merge.ts
+++ b/packages/contracts/tasks/runner/merge.ts
@@ -14,8 +14,7 @@ import { EContracts, type IMergeParams } from "../helpers/types";
  */
 task("merge", "Merge signups")
   .addParam("poll", "The poll id", undefined, types.string)
-  .addOptionalParam("prove", "Run prove command after merging", false, types.boolean)
-  .setAction(async ({ poll, prove }: IMergeParams, hre) => {
+  .setAction(async ({ poll }: IMergeParams, hre) => {
     const deployment = Deployment.getInstance({ hre });
 
     deployment.setHre(hre);
@@ -51,9 +50,4 @@ task("merge", "Merge signups")
 
     logMagenta({ text: info(`End balance: ${Number(endBalance / 10n ** 12n) / 1e6}`) });
     logMagenta({ text: info(`Merge expenses: ${Number((startBalance - endBalance) / 10n ** 12n) / 1e6}`) });
-
-    if (prove) {
-      logMagenta({ text: info(`Prove poll ${poll} results`) });
-      await hre.run("prove");
-    }
   });

--- a/packages/contracts/tasks/runner/prove.ts
+++ b/packages/contracts/tasks/runner/prove.ts
@@ -42,6 +42,7 @@ task("prove", "Command to generate proofs")
     undefined,
     types.string,
   )
+  .addFlag("submitOnChain", "Submit proofs on-chain")
   .setAction(
     async (
       {
@@ -58,6 +59,7 @@ task("prove", "Command to generate proofs")
         endBlock,
         transactionHash,
         ipfsMessageBackupFiles,
+        submitOnChain,
       }: IProveParams,
       hre,
     ) => {
@@ -192,5 +194,13 @@ task("prove", "Command to generate proofs")
           "Please make sure that you do not delete the proofs from the proof directory until they are all submitted on-chain.\nRegenerating proofs will result in overwriting the existing proofs and commitments which will be different due to the use of random salts.",
         ),
       });
+      if (submitOnChain) {
+        logMagenta({ text: info(`Submitting proofs on-chain`) });
+        await hre.run("submitOnChain", {
+          poll,
+          outputDir,
+          tallyFile,
+        });
+      }
     },
   );

--- a/packages/contracts/ts/index.ts
+++ b/packages/contracts/ts/index.ts
@@ -15,6 +15,7 @@ export {
   deploySignupTokenPolicy,
   deployConstantInitialVoiceCreditProxyFactory,
   deployConstantInitialVoiceCreditProxy,
+  deployERC20VotesInitialVoiceCreditProxyFactory,
   deployERC20VotesInitialVoiceCreditProxy,
   deployFreeForAllSignUpPolicy,
   deployGitcoinPassportPolicy,


### PR DESCRIPTION

# Description
- removes `prove` parameter from merge task as its functionality was not executable without extra params.
- adds `submit-on-chain` flag to prove task to do both the tasks together easily if needed.
- exports missing `deployERC20VotesInitialVoiceCreditProxyFactory`.


## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
