### PR TITLE
feat(sdk): export EMode + user types

### DIFF
--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -3,7 +3,7 @@ PRIVATE_KEY=
 INITIAL_INDEX=0
 # api key for eth mainnet etherscan
 ETH_ETHERSCAN_API_KEY=
-# RPC url to talk to optimism mainnet
+# RPC url to talk to testnet sepolia
 SEPOLIA_RPC_URL=
 # RPC url to talk to optimism
 OP_RPC_URL=

--- a/packages/sdk/ts/browser/index.ts
+++ b/packages/sdk/ts/browser/index.ts
@@ -6,6 +6,7 @@ export * from "../trees";
 export * from "../vote";
 export * from "../maciKeys";
 export * from "../subgraph";
+export * from "../user/types";
 export { getSignedupUserData, signup, hasUserSignedUp } from "../user/signup";
 export {
   getJoinedUserData,
@@ -19,6 +20,7 @@ export {
 export * from "./joinPoll";
 
 export type {
+  EMode,
   FullProveResult,
   IDeployParams,
   IMergeParams,

--- a/packages/sdk/ts/user/types.ts
+++ b/packages/sdk/ts/user/types.ts
@@ -1,4 +1,4 @@
-import { LeanIMTMerkleProof } from "@zk-kit/lean-imt";
+import { type LeanIMTMerkleProof } from "@zk-kit/lean-imt";
 
 import type { MACI, Poll } from "@maci-protocol/contracts/typechain-types";
 import type { PrivateKey, PublicKey } from "@maci-protocol/domainobjs";


### PR DESCRIPTION
# Description

1. Export `EMode` to be used in external apps
2. Export user types to be used in external apps
3. Small fix in the .env.example comment

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
