### PR TITLE
chore: add webhook notification for scheduled jobs

### DIFF
--- a/.github/workflows/nightly-ceremony.yml
+++ b/.github/workflows/nightly-ceremony.yml
@@ -57,3 +57,10 @@ jobs:
       - name: Run e2e tests
         working-directory: packages/circuits
         run: pnpm test:ceremonyParams
+
+      - name: Notify on failure
+        if: ${{ always() && (failure() || cancelled()) }}
+        run: |
+          curl -X POST -H 'Content-Type: application/json' \
+          -d '{"text": ":x: GitHub Actions job *${{ github.workflow }}* failed in *${{ github.repository }}* on branch *${{ github.ref }}*. [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
+          ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/nightly-coordinator-e2e.yml
+++ b/.github/workflows/nightly-coordinator-e2e.yml
@@ -90,3 +90,10 @@ jobs:
         working-directory: apps/coordinator
         run: |
           pnpm run test:e2e
+
+      - name: Notify on failure
+        if: ${{ always() && (failure() || cancelled()) }}
+        run: |
+          curl -X POST -H 'Content-Type: application/json' \
+          -d '{"text": ":x: GitHub Actions job *${{ github.workflow }}* failed in *${{ github.repository }}* on branch *${{ github.ref }}*. [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
+          ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -99,3 +99,10 @@ jobs:
       - name: Stop Hardhat
         if: always()
         run: kill $(lsof -t -i:8545)
+
+      - name: Notify on failure
+        if: ${{ always() && (failure() || cancelled()) }}
+        run: |
+          curl -X POST -H 'Content-Type: application/json' \
+          -d '{"text": ":x: GitHub Actions job *${{ github.workflow }}* failed in *${{ github.repository }}* on branch *${{ github.ref }}*. [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
+          ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,3 +115,10 @@ jobs:
       - name: Stop Hardhat
         if: always()
         run: kill $(lsof -t -i:8545)
+
+      - name: Notify on failure
+        if: ${{ always() && (failure() || cancelled()) }}
+        run: |
+          curl -X POST -H 'Content-Type: application/json' \
+          -d '{"text": ":x: GitHub Actions job *${{ github.workflow }}* failed in *${{ github.repository }}* on branch *${{ github.ref }}*. [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
+          ${{ secrets.WEBHOOK_URL }}

--- a/apps/website/versioned_docs/version-v3.x/contributing/contributing.md
+++ b/apps/website/versioned_docs/version-v3.x/contributing/contributing.md
@@ -60,12 +60,18 @@ Pull requests are great if you want to add a feature or fix a bug. Here's a quic
 8. Commit your changes. Please make sure your forked `main` branch is synced as well feature/fix branch and there are no "temp" commits (like wip, fix typo/lint/types and etc). We recommend to squash the feature/fix branch commits before creating PR. You can use this command for it:
 
 ```bash
+git checkout main
+git pull
+git checkout your-branch
+git rebase main
 git reset $(git merge-base main $(git rev-parse --abbrev-ref HEAD))
 ```
 
-9. Push to your fork and submit a pull request on our `main` branch. Please provide us with some explanation of why you made the changes you made. For new features make sure to explain a standard use case to us.
+9. Before creating a pull request make sure your work is ready. Do not create WIP pull requests and do not skip pre-commit hooks.
 
-10. Link any issues that the PR is addressing as described in our processes documentation.
+10. Push to your fork and submit a pull request on our `main` branch. Please provide us with some explanation of why you made the changes you made. For new features make sure to explain a standard use case to us. Do not remove our PR template and follow all the steps defined in it.
+
+11. Link any issues that the PR is addressing as described in our processes documentation.
 
 ## CI (Github Actions) Tests
 


### PR DESCRIPTION
# Description

Add webhook notification for scheduled jobs and add some improvements for contribution guide

## Additional Notes

Blocked by https://github.com/privacy-scaling-explorations/maci/pull/2727

## Related issue(s)

N/A

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I ran and verified that all tests pass according to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
